### PR TITLE
[#10] Add SQLite data layer and content import pipeline

### DIFF
--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -1,0 +1,49 @@
+"""Database connection helper.
+
+Uses stdlib sqlite3. No ORM — models are plain dataclasses and repositories
+write their own queries. Connection details come from environment variables
+with sensible local-development defaults.
+
+The module-level `get_connection` is the primary entry point. Callers should
+use it as a context manager or close the returned connection explicitly.
+"""
+
+import os
+import sqlite3
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Generator, Optional
+
+DEFAULT_DB_PATH = os.getenv(
+    "TINY_IPA_DB_PATH",
+    str(Path(__file__).resolve().parent.parent / "tiny_ipa.sqlite"),
+)
+
+
+def get_connection(db_path: Optional[str] = None) -> sqlite3.Connection:
+    """Return a sqlite3.Connection with WAL mode, foreign keys, and Row factory.
+
+    Args:
+        db_path: Path to the SQLite database file. Falls back to
+                 ``TINY_IPA_DB_PATH`` env var or ``backend/tiny_ipa.sqlite``.
+    """
+    path = db_path or DEFAULT_DB_PATH
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA foreign_keys=ON")
+    return conn
+
+
+@contextmanager
+def get_db(db_path: Optional[str] = None) -> Generator[sqlite3.Connection, None, None]:
+    """Context-managed database connection (auto-commit / close)."""
+    conn = get_connection(db_path)
+    try:
+        yield conn
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,0 +1,120 @@
+"""Domain models for the Tiny IPA runtime data layer.
+
+Plain dataclasses that mirror the SQLite tables defined in the DDL schema.
+They are used as return types from repositories — not as ORM entities.
+Callers construct them from ``sqlite3.Row`` dicts or raw kwargs.
+"""
+
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+
+# ---------------------------------------------------------------------------
+# Words
+# ---------------------------------------------------------------------------
+
+@dataclass
+class Word:
+    """A single word entry in the runtime database."""
+
+    id: str
+    word: str
+    level: str
+    ipa_us: str
+    phoneme_tags_us: List[str]
+    content_status: str
+    ipa_uk: Optional[str] = None
+    phoneme_tags_uk: Optional[List[str]] = None
+    meaning_zh: Optional[str] = None
+    audio_us: Optional[str] = None
+    audio_uk: Optional[str] = None
+    difficulty_tags: Optional[List[str]] = None
+    minimal_pair_group: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# Phonemes
+# ---------------------------------------------------------------------------
+
+@dataclass
+class Phoneme:
+    """A phoneme entry imported from ``content/phonemes.json``."""
+
+    id: str
+    symbol: str
+    accent_scope: str  # "US" | "UK" | "both"
+    category: str
+    priority: int
+    example_word: Optional[str] = None
+    description_zh: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# Settings
+# ---------------------------------------------------------------------------
+
+@dataclass
+class Settings:
+    """Per-user settings row. MVP has only user_id="default"."""
+
+    user_id: str = "default"
+    primary_accent: str = "US"
+    daily_word_count: int = 10
+    show_translation: bool = True
+    show_accent_compare: bool = False
+    practice_mode: str = "ipa_first"
+    review_strength: str = "normal"
+    updated_at: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Daily sessions (defined for M2 completeness; tested in later issues)
+# ---------------------------------------------------------------------------
+
+@dataclass
+class DailySession:
+    id: str
+    user_id: str
+    session_date: str
+    primary_accent: str
+    status: str
+    created_at: str
+    completed_at: Optional[str] = None
+
+
+@dataclass
+class SessionItem:
+    id: str
+    session_id: str
+    word_id: str
+    order_index: int
+    target_phonemes: List[str]
+    question_type: str
+    status: str
+
+
+@dataclass
+class Attempt:
+    id: str
+    user_id: str
+    session_item_id: str
+    word_id: str
+    primary_accent: str
+    question_type: str
+    correct_answer: str
+    is_correct: bool
+    created_at: str
+    target_phoneme: Optional[str] = None
+    selected_answer: Optional[str] = None
+
+
+@dataclass
+class PhonemeStat:
+    user_id: str
+    primary_accent: str
+    phoneme_id: str
+    attempt_count: int
+    correct_count: int
+    mastery_status: str
+    last_attempt_at: Optional[str] = None
+    last_wrong_at: Optional[str] = None

--- a/backend/app/services/db_schema.py
+++ b/backend/app/services/db_schema.py
@@ -1,0 +1,146 @@
+"""Database schema initialization for Tiny IPA.
+
+Defines all M2 tables up front (words, phonemes, settings, daily_sessions,
+session_items, attempts, phoneme_stats) but callers only need to call
+``init_db(conn)`` to create the full schema. The function is idempotent:
+it uses ``IF NOT EXISTS`` on every table.
+"""
+
+import sqlite3
+from typing import List
+
+
+TABLES_DDL: List[str] = [
+    # ------------------------------------------------------------------
+    # words
+    # ------------------------------------------------------------------
+    """
+    CREATE TABLE IF NOT EXISTS words (
+        id                TEXT PRIMARY KEY,
+        word              TEXT    NOT NULL,
+        level             TEXT    NOT NULL,
+        ipa_us            TEXT    NOT NULL,
+        ipa_uk            TEXT,
+        phoneme_tags_us   TEXT    NOT NULL,   -- JSON array
+        phoneme_tags_uk   TEXT,                -- JSON array
+        meaning_zh        TEXT,
+        audio_us          TEXT,
+        audio_uk          TEXT,
+        difficulty_tags   TEXT,                -- JSON array
+        minimal_pair_group TEXT,
+        content_status    TEXT    NOT NULL
+    )
+    """,
+    # ------------------------------------------------------------------
+    # phonemes
+    # ------------------------------------------------------------------
+    """
+    CREATE TABLE IF NOT EXISTS phonemes (
+        id            TEXT PRIMARY KEY,
+        symbol        TEXT    NOT NULL,
+        accent_scope  TEXT    NOT NULL,   -- "US" | "UK" | "both"
+        category      TEXT    NOT NULL,   -- "vowel" | "diphthong" | "consonant" | ...
+        priority      INTEGER NOT NULL,
+        example_word  TEXT,
+        description_zh TEXT
+    )
+    """,
+    # ------------------------------------------------------------------
+    # settings
+    # ------------------------------------------------------------------
+    """
+    CREATE TABLE IF NOT EXISTS settings (
+        user_id              TEXT PRIMARY KEY,
+        primary_accent       TEXT    NOT NULL,
+        daily_word_count     INTEGER NOT NULL,
+        show_translation     INTEGER NOT NULL,   -- boolean 0/1
+        show_accent_compare  INTEGER NOT NULL,   -- boolean 0/1
+        practice_mode        TEXT    NOT NULL,
+        review_strength      TEXT    NOT NULL,
+        updated_at           TEXT    NOT NULL
+    )
+    """,
+    # ------------------------------------------------------------------
+    # daily_sessions
+    # ------------------------------------------------------------------
+    """
+    CREATE TABLE IF NOT EXISTS daily_sessions (
+        id              TEXT PRIMARY KEY,
+        user_id         TEXT    NOT NULL,
+        session_date    TEXT    NOT NULL,
+        primary_accent  TEXT    NOT NULL,
+        status          TEXT    NOT NULL,
+        created_at      TEXT    NOT NULL,
+        completed_at    TEXT
+    )
+    """,
+    # ------------------------------------------------------------------
+    # session_items
+    # ------------------------------------------------------------------
+    """
+    CREATE TABLE IF NOT EXISTS session_items (
+        id               TEXT PRIMARY KEY,
+        session_id       TEXT    NOT NULL,
+        word_id          TEXT    NOT NULL,
+        order_index      INTEGER NOT NULL,
+        target_phonemes  TEXT    NOT NULL,   -- JSON array
+        question_type    TEXT    NOT NULL,
+        status           TEXT    NOT NULL,
+        FOREIGN KEY (session_id) REFERENCES daily_sessions(id),
+        FOREIGN KEY (word_id)     REFERENCES words(id)
+    )
+    """,
+    # ------------------------------------------------------------------
+    # attempts
+    # ------------------------------------------------------------------
+    """
+    CREATE TABLE IF NOT EXISTS attempts (
+        id               TEXT PRIMARY KEY,
+        user_id          TEXT NOT NULL,
+        session_item_id  TEXT NOT NULL,
+        word_id          TEXT NOT NULL,
+        primary_accent   TEXT NOT NULL,
+        question_type    TEXT NOT NULL,
+        target_phoneme   TEXT,
+        selected_answer  TEXT,
+        correct_answer   TEXT NOT NULL,
+        is_correct       INTEGER NOT NULL,   -- boolean 0/1
+        created_at       TEXT NOT NULL,
+        FOREIGN KEY (session_item_id) REFERENCES session_items(id),
+        FOREIGN KEY (word_id)          REFERENCES words(id)
+    )
+    """,
+    # ------------------------------------------------------------------
+    # phoneme_stats
+    # ------------------------------------------------------------------
+    """
+    CREATE TABLE IF NOT EXISTS phoneme_stats (
+        user_id         TEXT    NOT NULL,
+        primary_accent  TEXT    NOT NULL,
+        phoneme_id      TEXT    NOT NULL,
+        attempt_count   INTEGER NOT NULL,
+        correct_count   INTEGER NOT NULL,
+        last_attempt_at TEXT,
+        last_wrong_at   TEXT,
+        mastery_status  TEXT    NOT NULL,
+        PRIMARY KEY (user_id, primary_accent, phoneme_id)
+    )
+    """,
+]
+
+
+def init_db(conn: sqlite3.Connection) -> None:
+    """Execute all DDL statements to create tables if they do not exist.
+
+    Idempotent — safe to call on an already-initialised database.
+    """
+    for ddl in TABLES_DDL:
+        conn.execute(ddl)
+
+
+def table_names(conn: sqlite3.Connection) -> List[str]:
+    """Return a sorted list of user-defined table names in the database."""
+    rows = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'"
+    ).fetchall()
+    return sorted(r["name"] for r in rows)

--- a/backend/app/services/db_store.py
+++ b/backend/app/services/db_store.py
@@ -1,0 +1,236 @@
+"""Repository helpers for words, phonemes, and settings tables.
+
+Plain sqlite3 queries — no ORM. JSON-serialised list fields are handled
+at this layer so callers work with Python lists, not raw strings.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from typing import List, Optional
+
+from app.models import Phoneme, Settings, Word
+
+
+# ============================================================================
+# Serialisation helpers
+# ============================================================================
+
+_LIST_FIELDS_WORDS = {
+    "phoneme_tags_us",
+    "phoneme_tags_uk",
+    "difficulty_tags",
+}
+
+_NULLABLE_LIST_FIELDS_WORDS = {
+    "phoneme_tags_uk",
+    "difficulty_tags",
+}
+
+
+def _to_json(value: Optional[List[str]]) -> Optional[str]:
+    """Encode a Python list as a JSON string."""
+    if value is None:
+        return None
+    return json.dumps(value, ensure_ascii=False)
+
+
+def _parse_list(raw: Optional[str]) -> Optional[List[str]]:
+    """Decode a JSON string into a Python list, or return None."""
+    if raw is None:
+        return None
+    try:
+        parsed = json.loads(raw)
+        if isinstance(parsed, list):
+            return parsed
+        return None
+    except (json.JSONDecodeError, TypeError):
+        return None
+
+
+def _word_from_row(row: sqlite3.Row) -> Word:
+    """Build a Word dataclass from a sqlite3.Row."""
+    return Word(
+        id=row["id"],
+        word=row["word"],
+        level=row["level"],
+        ipa_us=row["ipa_us"],
+        ipa_uk=row["ipa_uk"],
+        phoneme_tags_us=_parse_list(row["phoneme_tags_us"]) or [],
+        phoneme_tags_uk=_parse_list(row["phoneme_tags_uk"]),
+        meaning_zh=row["meaning_zh"],
+        audio_us=row["audio_us"],
+        audio_uk=row["audio_uk"],
+        difficulty_tags=_parse_list(row["difficulty_tags"]),
+        minimal_pair_group=row["minimal_pair_group"],
+        content_status=row["content_status"],
+    )
+
+
+def _phoneme_from_row(row: sqlite3.Row) -> Phoneme:
+    return Phoneme(
+        id=row["id"],
+        symbol=row["symbol"],
+        accent_scope=row["accent_scope"],
+        category=row["category"],
+        priority=row["priority"],
+        example_word=row["example_word"],
+        description_zh=row["description_zh"],
+    )
+
+
+def _settings_from_row(row: sqlite3.Row) -> Settings:
+    return Settings(
+        user_id=row["user_id"],
+        primary_accent=row["primary_accent"],
+        daily_word_count=row["daily_word_count"],
+        show_translation=bool(row["show_translation"]),
+        show_accent_compare=bool(row["show_accent_compare"]),
+        practice_mode=row["practice_mode"],
+        review_strength=row["review_strength"],
+        updated_at=row["updated_at"],
+    )
+
+
+# ============================================================================
+# Words
+# ============================================================================
+
+
+def upsert_word(conn: sqlite3.Connection, word_data: dict) -> str:
+    """Insert or replace a single word row. Returns the word id.
+
+    ``word_data`` is the raw source dict; this function handles JSON
+    encoding of list fields internally.
+    """
+    # Start with empty defaults for every bind parameter so sqlite3
+    # never raises "You did not supply a value for binding N".
+    values: dict = {
+        "word_id": None,
+        "word": None,
+        "level": None,
+        "ipa_us": None,
+        "ipa_uk": None,
+        "phoneme_tags_us": None,
+        "phoneme_tags_uk": None,
+        "meaning_zh": None,
+        "audio_us": None,
+        "audio_uk": None,
+        "difficulty_tags": None,
+        "minimal_pair_group": None,
+        "content_status": None,
+    }
+    # Overlay caller data, mapping "id" → "word_id" for convenience.
+    for k, v in word_data.items():
+        if k == "id":
+            values["word_id"] = v
+        elif k in values:
+            values[k] = v
+    # JSON-encode list fields.
+    for field in _LIST_FIELDS_WORDS:
+        if values.get(field) is not None:
+            values[field] = _to_json(values[field])
+
+    conn.execute(
+        """
+        INSERT OR REPLACE INTO words (
+            id, word, level, ipa_us, ipa_uk,
+            phoneme_tags_us, phoneme_tags_uk,
+            meaning_zh, audio_us, audio_uk,
+            difficulty_tags, minimal_pair_group, content_status
+        ) VALUES (
+            :word_id, :word, :level, :ipa_us, :ipa_uk,
+            :phoneme_tags_us, :phoneme_tags_uk,
+            :meaning_zh, :audio_us, :audio_uk,
+            :difficulty_tags, :minimal_pair_group, :content_status
+        )
+        """,
+        values,
+    )
+    return values.get("word_id") or ""
+
+
+def count_words(conn: sqlite3.Connection) -> int:
+    row = conn.execute("SELECT COUNT(*) AS cnt FROM words").fetchone()
+    return row["cnt"]
+
+
+def get_word_by_id(conn: sqlite3.Connection, word_id: str) -> Optional[Word]:
+    row = conn.execute("SELECT * FROM words WHERE id = ?", (word_id,)).fetchone()
+    if row is None:
+        return None
+    return _word_from_row(row)
+
+
+# ============================================================================
+# Phonemes
+# ============================================================================
+
+
+def upsert_phoneme(conn: sqlite3.Connection, phoneme_data: dict) -> str:
+    """Insert or replace a single phoneme row. Returns the phoneme id."""
+    conn.execute(
+        """
+        INSERT OR REPLACE INTO phonemes (
+            id, symbol, accent_scope, category, priority, example_word, description_zh
+        ) VALUES (
+            :id, :symbol, :accent_scope, :category, :priority, :example_word, :description_zh
+        )
+        """,
+        phoneme_data,
+    )
+    return phoneme_data["id"]
+
+
+def count_phonemes(conn: sqlite3.Connection) -> int:
+    row = conn.execute("SELECT COUNT(*) AS cnt FROM phonemes").fetchone()
+    return row["cnt"]
+
+
+def get_phoneme_by_id(conn: sqlite3.Connection, phoneme_id: str) -> Optional[Phoneme]:
+    row = conn.execute("SELECT * FROM phonemes WHERE id = ?", (phoneme_id,)).fetchone()
+    if row is None:
+        return None
+    return _phoneme_from_row(row)
+
+
+# ============================================================================
+# Settings
+# ============================================================================
+
+
+def upsert_settings(conn: sqlite3.Connection, settings: Settings) -> None:
+    """Create or replace the settings row for a given user_id."""
+    conn.execute(
+        """
+        INSERT OR REPLACE INTO settings (
+            user_id, primary_accent, daily_word_count,
+            show_translation, show_accent_compare,
+            practice_mode, review_strength, updated_at
+        ) VALUES (
+            :user_id, :primary_accent, :daily_word_count,
+            :show_translation, :show_accent_compare,
+            :practice_mode, :review_strength, :updated_at
+        )
+        """,
+        {
+            "user_id": settings.user_id,
+            "primary_accent": settings.primary_accent,
+            "daily_word_count": settings.daily_word_count,
+            "show_translation": int(settings.show_translation),
+            "show_accent_compare": int(settings.show_accent_compare),
+            "practice_mode": settings.practice_mode,
+            "review_strength": settings.review_strength,
+            "updated_at": settings.updated_at,
+        },
+    )
+
+
+def get_settings(conn: sqlite3.Connection, user_id: str = "default") -> Optional[Settings]:
+    row = conn.execute(
+        "SELECT * FROM settings WHERE user_id = ?", (user_id,)
+    ).fetchone()
+    if row is None:
+        return None
+    return _settings_from_row(row)

--- a/backend/scripts/import_words.py
+++ b/backend/scripts/import_words.py
@@ -138,9 +138,15 @@ def import_words(
         known_phonemes = load_phoneme_set(phonemes_path)
         words = load_words(source_path)
         val_report = validate_words(words, known_phonemes)
-        report["validation_errors"] = len(val_report["errors"])
+        # Unknown US phoneme tags are hard errors — reject the import.
+        if val_report["unknown_phoneme_tags_us"]:
+            for tag_entry in val_report["unknown_phoneme_tags_us"]:
+                report["errors"].append(tag_entry)
+        # Append other validation errors.
         if val_report["errors"]:
             report["errors"].extend(val_report["errors"])
+        report["validation_errors"] = len(report["errors"])
+        if report["errors"]:
             return report
         report["validation_passed"] = True
     else:

--- a/backend/scripts/import_words.py
+++ b/backend/scripts/import_words.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""Import words and phoneme inventory into the SQLite runtime database.
+
+Usage:
+    cd backend && source .venv/bin/activate
+    python scripts/import_words.py --source ../content/generated/candidate_words.json
+
+The script validates source content, initialises the database schema if
+needed, upserts words and phonemes, creates default settings, and prints
+an import report.
+
+Dependencies: reuse validation helpers from ``validate_content.py``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Optional, Set
+
+# Ensure the backend package is importable when running this script directly.
+_HERE = Path(__file__).resolve().parent
+_BACKEND = _HERE.parent
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+# Reuse validation helpers from the validate_content script.
+_SCRIPTS = _HERE
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+from validate_content import (  # noqa: E402
+    load_phoneme_set,
+    load_words,
+    validate_words,
+)
+
+from app.db import get_db  # noqa: E402
+from app.models import Settings  # noqa: E402
+from app.services.db_schema import init_db, table_names  # noqa: E402
+from app.services.db_store import (  # noqa: E402
+    count_phonemes,
+    count_words,
+    upsert_phoneme,
+    upsert_settings,
+    upsert_word,
+)
+
+# ---------------------------------------------------------------------------
+# Default paths (relative to repo root)
+# ---------------------------------------------------------------------------
+
+_SCRIPT_DIR = Path(__file__).resolve().parent
+_REPO_ROOT = _SCRIPT_DIR.parent.parent
+
+DEFAULT_SOURCE = os.getenv(
+    "TINY_IPA_CONTENT_SOURCE",
+    str(_REPO_ROOT / "content" / "generated" / "candidate_words.json"),
+)
+DEFAULT_PHONEMES = str(_REPO_ROOT / "content" / "phonemes.json")
+
+# ---------------------------------------------------------------------------
+# Phoneme inventory import
+# ---------------------------------------------------------------------------
+
+
+def build_phoneme_rows(phonemes_path: Path) -> List[dict]:
+    """Parse ``content/phonemes.json`` into a flat list of db-row dicts."""
+    with open(phonemes_path, "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+
+    rows: List[dict] = []
+    # Determine accent_scope heuristically: currently the inventory is
+    # shared between US and UK.
+    for category in ("vowels", "consonants"):
+        for entry in data.get(category, []):
+            rows.append(
+                {
+                    "id": entry["symbol"],
+                    "symbol": entry["symbol"],
+                    "accent_scope": "both",
+                    "category": entry.get("category", category),
+                    "priority": entry.get("priority", 2),
+                    "example_word": entry.get("example_word"),
+                    "description_zh": entry.get("description_zh"),
+                }
+            )
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Import pipeline
+# ---------------------------------------------------------------------------
+
+
+def import_words(
+    source_path: Path,
+    phonemes_path: Path,
+    db_path: str,
+    *,
+    skip_validation: bool = False,
+) -> dict:
+    """Run the full import pipeline and return a report dict.
+
+    Args:
+        source_path: Path to the words JSON file.
+        phonemes_path: Path to ``content/phonemes.json``.
+        db_path: SQLite database path (``sqlite:///`` prefix stripped if
+                 present, for CLI ergonomics).
+        skip_validation: If True, skip content validation (not recommended
+                         for production; useful for trusted fixtures).
+
+    Returns:
+        A report dict with keys: inserted, updated, skipped, errors,
+        phonemes_inserted, validation_passed, tables_created.
+    """
+    # Normalise optional sqlite:/// prefix
+    if db_path.startswith("sqlite:///"):
+        db_path = db_path[len("sqlite:///"):]
+
+    report: dict = {
+        "inserted": 0,
+        "updated": 0,
+        "skipped": 0,
+        "errors": [],
+        "phonemes_inserted": 0,
+        "validation_passed": False,
+        "validation_errors": 0,
+        "tables_created": [],
+    }
+
+    # ---- validation --------------------------------------------------------
+    if not skip_validation:
+        known_phonemes = load_phoneme_set(phonemes_path)
+        words = load_words(source_path)
+        val_report = validate_words(words, known_phonemes)
+        report["validation_errors"] = len(val_report["errors"])
+        if val_report["errors"]:
+            report["errors"].extend(val_report["errors"])
+            return report
+        report["validation_passed"] = True
+    else:
+        # Still need the word list for import
+        words = load_words(source_path)
+
+    # ---- database initialisation -------------------------------------------
+    with get_db(db_path) as conn:
+        existing_tables = set(table_names(conn))
+        init_db(conn)
+        new_tables = sorted(set(table_names(conn)) - existing_tables)
+        report["tables_created"] = new_tables
+
+        # ---- word import ---------------------------------------------------
+        for w in words:
+            word_id = w.get("word_id") or w.get("id", "")
+            if not word_id:
+                report["skipped"] += 1
+                report["errors"].append("entry without word_id — skipped")
+                continue
+            try:
+                upsert_word(conn, w)
+                # For the report we count every write as "inserted" since
+                # we can't cheaply distinguish insert from update with
+                # INSERT OR REPLACE without a prior SELECT.
+                report["inserted"] += 1
+            except Exception as exc:
+                report["skipped"] += 1
+                report["errors"].append(f"{word_id}: db error — {exc}")
+
+        total_words = count_words(conn)
+        report["total_words_in_db"] = total_words
+
+        # ---- phoneme import ------------------------------------------------
+        phoneme_rows = build_phoneme_rows(phonemes_path)
+        for pr in phoneme_rows:
+            try:
+                upsert_phoneme(conn, pr)
+                report["phonemes_inserted"] += 1
+            except Exception as exc:
+                report["errors"].append(f"{pr['id']}: phoneme db error — {exc}")
+
+        # ---- default settings ----------------------------------------------
+        default_settings = Settings(
+            user_id="default",
+            primary_accent="US",
+            daily_word_count=10,
+            show_translation=True,
+            show_accent_compare=False,
+            practice_mode="ipa_first",
+            review_strength="normal",
+            updated_at=datetime.now(timezone.utc).isoformat(),
+        )
+        upsert_settings(conn, default_settings)
+
+    return report
+
+
+def print_report(report: dict) -> None:
+    """Print a human-readable import report to stdout."""
+    print("=" * 60)
+    print("Tiny IPA Import Report")
+    print("=" * 60)
+    print(f"Validation: {'PASS' if report['validation_passed'] else 'SKIPPED'}"
+          f" ({report['validation_errors']} errors)")
+    print(f"Tables created:  {', '.join(report['tables_created']) if report['tables_created'] else '(none — already existed)'}")
+    print(f"Words inserted:  {report['inserted']}")
+    print(f"Words skipped:   {report['skipped']}")
+    print(f"Total words:     {report.get('total_words_in_db', '?')}")
+    print(f"Phonemes added:  {report['phonemes_inserted']}")
+    print(f"Import errors:   {len(report['errors'])}")
+    if report["errors"]:
+        print()
+        print("--- Errors (first 20) ---")
+        for err in report["errors"][:20]:
+            print(f"  {err}")
+        if len(report["errors"]) > 20:
+            print(f"  ... and {len(report['errors']) - 20} more")
+    print("=" * 60)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Import words and phonemes into the Tiny IPA SQLite database."
+    )
+    parser.add_argument(
+        "--source",
+        default=DEFAULT_SOURCE,
+        help="Path to source words JSON file (default: content/generated/candidate_words.json).",
+    )
+    parser.add_argument(
+        "--phonemes",
+        default=DEFAULT_PHONEMES,
+        help="Path to phonemes.json (default: content/phonemes.json).",
+    )
+    parser.add_argument(
+        "--db-url",
+        default="sqlite:///./tiny_ipa_dev.sqlite",
+        help="SQLite database path or sqlite:/// URI (default: sqlite:///./tiny_ipa_dev.sqlite).",
+    )
+    parser.add_argument(
+        "--skip-validation",
+        action="store_true",
+        help="Skip content validation (use only with trusted fixtures).",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output the report as JSON instead of human-readable text.",
+    )
+    args = parser.parse_args()
+
+    source_path = Path(args.source)
+    if not source_path.exists():
+        print(f"Error: source file not found: {source_path}", file=sys.stderr)
+        sys.exit(1)
+
+    phonemes_path = Path(args.phonemes)
+    if not phonemes_path.exists():
+        print(f"Error: phonemes file not found: {phonemes_path}", file=sys.stderr)
+        sys.exit(1)
+
+    report = import_words(
+        source_path=source_path,
+        phonemes_path=phonemes_path,
+        db_path=args.db_url,
+        skip_validation=args.skip_validation,
+    )
+
+    if args.json:
+        print(json.dumps(report, indent=2, default=str))
+    else:
+        print_report(report)
+
+    if report["errors"]:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/test_import_words.py
+++ b/backend/tests/test_import_words.py
@@ -293,6 +293,22 @@ class TestImportWords:
         conn2.close()
         assert len(tables_after) >= 7
 
+    def test_unknown_phoneme_tags_us_blocks_import(self, temp_db, tmp_path):
+        """Words with phoneme tags not in the inventory must fail the import."""
+        bad_file = tmp_path / "bad_phoneme.json"
+        bad_file.write_text(json.dumps([{
+            "word_id": "ship",
+            "word": "ship",
+            "level": "beginner",
+            "ipa_us": "/ʃɪp/",
+            "phoneme_tags_us": ["/ʃ/", "/ɪ/", "/ɸ/"],  # /ɸ/ is not in phonemes.json
+            "content_status": "core_selected",
+        }]))
+        report = import_words(bad_file, PHONEMES_PATH, temp_db)
+        assert report["validation_passed"] is False
+        assert report["validation_errors"] > 0
+        assert any("unknown phoneme tag" in e.lower() for e in report["errors"])
+
     def test_skip_validation_flag(self, temp_db, tmp_path):
         """With --skip-validation, content errors are bypassed."""
         bad_file = tmp_path / "unvalidated.json"

--- a/backend/tests/test_import_words.py
+++ b/backend/tests/test_import_words.py
@@ -1,0 +1,349 @@
+"""Tests for import_words.py and the supporting db / schema / store modules."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure scripts are importable.
+_SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+from import_words import build_phoneme_rows, import_words  # noqa: E402
+
+from app.db import get_connection, get_db  # noqa: E402
+from app.models import Settings  # noqa: E402
+from app.services.db_schema import init_db, table_names  # noqa: E402
+from app.services.db_store import (  # noqa: E402
+    count_phonemes,
+    count_words,
+    get_phoneme_by_id,
+    get_settings,
+    get_word_by_id,
+    upsert_settings,
+    upsert_word,
+)
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures"
+CONTENT_SAMPLE = FIXTURES / "content_sample.json"
+PHONEMES_PATH = Path(__file__).resolve().parent.parent.parent / "content" / "phonemes.json"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(name="temp_db")
+def temp_db_fixture(tmp_path: Path):
+    """Create a fresh SQLite database in a temporary directory."""
+    db_path = str(tmp_path / "test.sqlite")
+    return db_path
+
+
+# ---------------------------------------------------------------------------
+# db_schema
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaInitialisation:
+    """Tests for ``app.services.db_schema``."""
+
+    def test_init_creates_expected_tables(self, temp_db):
+        conn = get_connection(temp_db)
+        init_db(conn)
+        names = table_names(conn)
+        conn.close()
+        for expected in [
+            "attempts",
+            "daily_sessions",
+            "phoneme_stats",
+            "phonemes",
+            "session_items",
+            "settings",
+            "words",
+        ]:
+            assert expected in names, f"Table '{expected}' missing from {names}"
+
+    def test_init_is_idempotent(self, temp_db):
+        conn = get_connection(temp_db)
+        init_db(conn)
+        before = table_names(conn)
+        init_db(conn)  # second call
+        after = table_names(conn)
+        conn.close()
+        assert before == after
+
+
+# ---------------------------------------------------------------------------
+# db_store — words
+# ---------------------------------------------------------------------------
+
+
+class TestWordStore:
+    """Tests for word CRUD in ``app.services.db_store``."""
+
+    @pytest.fixture(autouse=True)
+    def _init(self, temp_db):
+        """Each test gets its own initialised database."""
+        conn = get_connection(temp_db)
+        init_db(conn)
+        self.conn = conn
+        self.db_path = temp_db
+        yield
+        conn.close()
+
+    def test_upsert_and_retrieve_word(self):
+        data = {
+            "word_id": "ship",
+            "word": "ship",
+            "level": "beginner",
+            "ipa_us": "/ʃɪp/",
+            "ipa_uk": "/ʃɪp/",
+            "phoneme_tags_us": ["/ʃ/", "/ɪ/", "/p/"],
+            "phoneme_tags_uk": ["/ʃ/", "/ɪ/", "/p/"],
+            "meaning_zh": "船",
+            "difficulty_tags": ["sh", "short_i"],
+            "minimal_pair_group": "ship_sheep",
+            "content_status": "core_selected",
+        }
+        wid = upsert_word(self.conn, data)
+        assert wid == "ship"
+
+        w = get_word_by_id(self.conn, "ship")
+        assert w is not None
+        assert w.word == "ship"
+        assert w.ipa_us == "/ʃɪp/"
+        assert w.ipa_uk == "/ʃɪp/"
+        assert w.phoneme_tags_us == ["/ʃ/", "/ɪ/", "/p/"]
+        assert w.phoneme_tags_uk == ["/ʃ/", "/ɪ/", "/p/"]
+        assert w.meaning_zh == "船"
+        assert w.difficulty_tags == ["sh", "short_i"]
+        assert w.minimal_pair_group == "ship_sheep"
+        assert w.content_status == "core_selected"
+
+    def test_upsert_is_idempotent(self):
+        data = {
+            "word_id": "cat",
+            "word": "cat",
+            "level": "beginner",
+            "ipa_us": "/kæt/",
+            "phoneme_tags_us": ["/k/", "/æ/", "/t/"],
+            "content_status": "core_selected",
+        }
+        upsert_word(self.conn, data)
+        assert count_words(self.conn) == 1
+        upsert_word(self.conn, data)
+        assert count_words(self.conn) == 1  # no duplicate
+
+    def test_upsert_preserves_accent_fields(self):
+        """ipa_uk and phoneme_tags_uk must survive a round-trip."""
+        data = {
+            "word_id": "ship",
+            "word": "ship",
+            "level": "beginner",
+            "ipa_us": "/ʃɪp/",
+            "ipa_uk": "/ʃɪp/",
+            "phoneme_tags_us": ["/ʃ/", "/ɪ/", "/p/"],
+            "phoneme_tags_uk": ["/ʃ/", "/ɪ/", "/p/"],
+            "content_status": "core_selected",
+        }
+        upsert_word(self.conn, data)
+        w = get_word_by_id(self.conn, "ship")
+        assert w.ipa_uk == "/ʃɪp/"
+        assert w.phoneme_tags_uk == ["/ʃ/", "/ɪ/", "/p/"]
+
+    def test_null_uk_fields(self):
+        """Words with no UK data store NULLs and return None/empty."""
+        data = {
+            "word_id": "cat",
+            "word": "cat",
+            "level": "beginner",
+            "ipa_us": "/kæt/",
+            "phoneme_tags_us": ["/k/", "/æ/", "/t/"],
+            "content_status": "auto_selected",
+        }
+        upsert_word(self.conn, data)
+        w = get_word_by_id(self.conn, "cat")
+        assert w.ipa_uk is None
+        assert w.phoneme_tags_uk is None
+        assert w.audio_uk is None
+
+    def test_get_missing_word(self):
+        assert get_word_by_id(self.conn, "nonexistent") is None
+
+
+# ---------------------------------------------------------------------------
+# db_store — settings
+# ---------------------------------------------------------------------------
+
+
+class TestSettingsStore:
+    @pytest.fixture(autouse=True)
+    def _init(self, temp_db):
+        conn = get_connection(temp_db)
+        init_db(conn)
+        self.conn = conn
+        yield
+        conn.close()
+
+    def test_default_settings_roundtrip(self):
+        s = Settings(
+            user_id="default",
+            primary_accent="US",
+            daily_word_count=10,
+            show_translation=True,
+            show_accent_compare=False,
+            practice_mode="ipa_first",
+            review_strength="normal",
+            updated_at="2026-06-06T00:00:00Z",
+        )
+        upsert_settings(self.conn, s)
+        got = get_settings(self.conn, "default")
+        assert got is not None
+        assert got.primary_accent == "US"
+        assert got.daily_word_count == 10
+        assert got.show_translation is True
+        assert got.show_accent_compare is False
+        assert got.practice_mode == "ipa_first"
+        assert got.review_strength == "normal"
+
+    def test_get_missing_settings(self):
+        assert get_settings(self.conn, "no_such_user") is None
+
+
+# ---------------------------------------------------------------------------
+# import_words script
+# ---------------------------------------------------------------------------
+
+
+class TestImportWords:
+    """Integration tests for the import pipeline."""
+
+    def test_import_fixture_success(self, temp_db):
+        """Import the 3-word fixture and verify counts + contents."""
+        report = import_words(
+            source_path=CONTENT_SAMPLE,
+            phonemes_path=PHONEMES_PATH,
+            db_path=temp_db,
+        )
+        assert report["validation_passed"] is True
+        assert report["inserted"] == 3
+        assert report["skipped"] == 0
+        assert len(report["errors"]) == 0
+        assert report["phonemes_inserted"] == 41
+        assert report.get("total_words_in_db") == 3
+
+    def test_import_idempotent(self, temp_db):
+        """Re-running import with the same data does not duplicate rows."""
+        report1 = import_words(CONTENT_SAMPLE, PHONEMES_PATH, temp_db)
+        report2 = import_words(CONTENT_SAMPLE, PHONEMES_PATH, temp_db)
+        assert report2["inserted"] == report1["inserted"]
+        assert report2.get("total_words_in_db") == 3
+
+    def test_import_creates_default_settings(self, temp_db):
+        """After import, the default settings row must exist."""
+        import_words(CONTENT_SAMPLE, PHONEMES_PATH, temp_db)
+        conn = get_connection(temp_db)
+        settings = get_settings(conn, "default")
+        conn.close()
+        assert settings is not None
+        assert settings.user_id == "default"
+        assert settings.primary_accent == "US"
+        assert settings.daily_word_count == 10
+
+    def test_import_preserves_accent_fields(self, temp_db):
+        """After import, ship.ipa_uk and phoneme_tags_uk are stored."""
+        import_words(CONTENT_SAMPLE, PHONEMES_PATH, temp_db)
+        conn = get_connection(temp_db)
+        w = get_word_by_id(conn, "ship")
+        conn.close()
+        assert w is not None
+        assert w.ipa_uk == "/ʃɪp/"
+        assert w.phoneme_tags_uk == ["/ʃ/", "/ɪ/", "/p/"]
+
+    def test_invalid_content_reports_errors(self, temp_db, tmp_path):
+        """Words with missing required fields produce validation errors."""
+        bad_file = tmp_path / "bad.json"
+        bad_file.write_text(json.dumps([{"word": "no_id"}]))
+        report = import_words(bad_file, PHONEMES_PATH, temp_db)
+        assert report["validation_passed"] is False
+        assert report["validation_errors"] > 0
+
+    def test_import_creates_tables(self, temp_db):
+        """First import creates the full schema."""
+        # Use a fresh db and verify tables don't exist beforehand.
+        conn1 = get_connection(temp_db)
+        tables_before = table_names(conn1)
+        conn1.close()
+        assert len(tables_before) == 0
+
+        import_words(CONTENT_SAMPLE, PHONEMES_PATH, temp_db)
+
+        conn2 = get_connection(temp_db)
+        tables_after = table_names(conn2)
+        conn2.close()
+        assert len(tables_after) >= 7
+
+    def test_skip_validation_flag(self, temp_db, tmp_path):
+        """With --skip-validation, content errors are bypassed."""
+        bad_file = tmp_path / "unvalidated.json"
+        bad_file.write_text(json.dumps([{
+            "word_id": "x",
+            "word": "x",
+            "level": "beginner",
+            "ipa_us": "/ɛks/",
+            "phoneme_tags_us": ["/ɪ/"],
+            "content_status": "core_selected",
+        }]))
+        report = import_words(
+            bad_file, PHONEMES_PATH, temp_db, skip_validation=True
+        )
+        assert report["inserted"] == 1
+        assert len(report["errors"]) == 0
+
+    def test_phoneme_rows_are_imported(self, temp_db):
+        """Imported phonemes can be read back."""
+        import_words(CONTENT_SAMPLE, PHONEMES_PATH, temp_db)
+        conn = get_connection(temp_db)
+        p = get_phoneme_by_id(conn, "/ʃ/")
+        conn.close()
+        assert p is not None
+        assert p.symbol == "/ʃ/"
+        assert p.category in ("consonant", "fricative")
+
+    def test_sqlite_prefix_is_handled(self, temp_db):
+        """The sqlite:/// prefix in db_path is stripped automatically."""
+        db_uri = f"sqlite:///{temp_db}"
+        import_words(CONTENT_SAMPLE, PHONEMES_PATH, db_uri)
+        conn = get_connection(temp_db)
+        assert count_words(conn) == 3
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Phoneme inventory
+# ---------------------------------------------------------------------------
+
+
+class TestPhonemeRows:
+    def test_builds_rows_from_phonemes_json(self):
+        rows = build_phoneme_rows(PHONEMES_PATH)
+        assert len(rows) == 41  # 17 vowels + 24 consonants
+        symbols = {r["symbol"] for r in rows}
+        assert "/ʃ/" in symbols
+        assert "/ɪ/" in symbols
+        assert "/iː/" in symbols
+        # Every row must have required fields
+        for r in rows:
+            assert r["id"]
+            assert r["symbol"]
+            assert r["accent_scope"] in ("US", "UK", "both")


### PR DESCRIPTION
Closes #10

## Scope completed
- `backend/app/db.py` — stdlib sqlite3 connection helper with WAL + foreign keys
- `backend/app/models.py` — plain dataclasses for all M2 tables
- `backend/app/services/db_schema.py` — idempotent DDL (7 tables)
- `backend/app/services/db_store.py` — repository helpers for words, phonemes, settings with JSON encode/decode for list fields
- `backend/scripts/import_words.py` — import pipeline: validates content, inits schema, upserts words/phonemes, creates default settings, prints report
- `backend/tests/test_import_words.py` — 19 tests covering schema, CRUD, import pipeline, idempotency, accent preservation, validation errors

## Verification
- All 55 tests pass (0 failures, 0 regressions)
- End-to-end import: 3792 words, 41 phonemes, 0 errors
- Idempotent re-import: same counts, no duplicates

## Manual QA
```bash
cd backend && source .venv/bin/activate
python scripts/import_words.py --source ../content/generated/candidate_words.json
# Validation: PASS, 3792 words, 41 phonemes, 0 errors
```

## Residual risks
- `content/seed_words.json` does not exist yet; import was verified with `content/generated/candidate_words.json` and the test fixture
- No Alembic/migration machinery (by design for M2)
- SQLite WAL files (`.sqlite-shm`, `.sqlite-wal`) are already gitignored