### PR TITLE
[#11] Persist daily sessions and make /api/today database-backed

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,6 +4,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.routes.health import router as health_router
+from app.routes.practice import router as practice_router
 
 app = FastAPI(title="Tiny IPA", version="0.1.0")
 
@@ -15,3 +16,4 @@ app.add_middleware(
 )
 
 app.include_router(health_router, prefix="/api")
+app.include_router(practice_router, prefix="/api")

--- a/backend/app/routes/practice.py
+++ b/backend/app/routes/practice.py
@@ -1,0 +1,19 @@
+"""Practice endpoints — daily session and attempt submission."""
+
+from fastapi import APIRouter
+
+from app.db import get_db
+from app.services.sessions import build_today_response
+
+router = APIRouter()
+
+
+@router.get("/today")
+def today():
+    """Return today's practice session, creating it if needed.
+
+    Refresh-safe: repeated calls on the same date return the same session
+    and items. Session and item rows are persisted in SQLite.
+    """
+    with get_db() as conn:
+        return build_today_response(conn)

--- a/backend/app/services/db_store.py
+++ b/backend/app/services/db_store.py
@@ -1,4 +1,4 @@
-"""Repository helpers for words, phonemes, and settings tables.
+"""Repository helpers for words, phonemes, settings, sessions, and session_items tables.
 
 Plain sqlite3 queries — no ORM. JSON-serialised list fields are handled
 at this layer so callers work with Python lists, not raw strings.
@@ -10,7 +10,7 @@ import json
 import sqlite3
 from typing import List, Optional
 
-from app.models import Phoneme, Settings, Word
+from app.models import Attempt, DailySession, Phoneme, SessionItem, Settings, Word
 
 
 # ============================================================================
@@ -234,3 +234,141 @@ def get_settings(conn: sqlite3.Connection, user_id: str = "default") -> Optional
     if row is None:
         return None
     return _settings_from_row(row)
+
+
+# ============================================================================
+# Daily sessions
+# ============================================================================
+
+
+def _session_from_row(row: sqlite3.Row) -> DailySession:
+    return DailySession(
+        id=row["id"],
+        user_id=row["user_id"],
+        session_date=row["session_date"],
+        primary_accent=row["primary_accent"],
+        status=row["status"],
+        created_at=row["created_at"],
+        completed_at=row["completed_at"],
+    )
+
+
+def _session_item_from_row(row: sqlite3.Row) -> SessionItem:
+    return SessionItem(
+        id=row["id"],
+        session_id=row["session_id"],
+        word_id=row["word_id"],
+        order_index=row["order_index"],
+        target_phonemes=_parse_list(row["target_phonemes"]) or [],
+        question_type=row["question_type"],
+        status=row["status"],
+    )
+
+
+def create_session(conn: sqlite3.Connection, session: DailySession) -> str:
+    """Insert a new daily session row. Returns the session id."""
+    conn.execute(
+        """
+        INSERT INTO daily_sessions (
+            id, user_id, session_date, primary_accent, status, created_at, completed_at
+        ) VALUES (
+            :id, :user_id, :session_date, :primary_accent, :status, :created_at, :completed_at
+        )
+        """,
+        {
+            "id": session.id,
+            "user_id": session.user_id,
+            "session_date": session.session_date,
+            "primary_accent": session.primary_accent,
+            "status": session.status,
+            "created_at": session.created_at,
+            "completed_at": session.completed_at,
+        },
+    )
+    return session.id
+
+
+def get_session_for_date(
+    conn: sqlite3.Connection, user_id: str, session_date: str, primary_accent: str
+) -> Optional[DailySession]:
+    """Return the daily session for the given user, date and accent, or None."""
+    row = conn.execute(
+        """
+        SELECT * FROM daily_sessions
+        WHERE user_id = ? AND session_date = ? AND primary_accent = ?
+        """,
+        (user_id, session_date, primary_accent),
+    ).fetchone()
+    if row is None:
+        return None
+    return _session_from_row(row)
+
+
+def create_session_item(conn: sqlite3.Connection, item: SessionItem) -> str:
+    """Insert a session item row. Returns the item id."""
+    conn.execute(
+        """
+        INSERT INTO session_items (
+            id, session_id, word_id, order_index, target_phonemes, question_type, status
+        ) VALUES (
+            :id, :session_id, :word_id, :order_index, :target_phonemes, :question_type, :status
+        )
+        """,
+        {
+            "id": item.id,
+            "session_id": item.session_id,
+            "word_id": item.word_id,
+            "order_index": item.order_index,
+            "target_phonemes": _to_json(item.target_phonemes),
+            "question_type": item.question_type,
+            "status": item.status,
+        },
+    )
+    return item.id
+
+
+def get_session_items(
+    conn: sqlite3.Connection, session_id: str
+) -> List[SessionItem]:
+    """Return all session items for a session, ordered by order_index."""
+    rows = conn.execute(
+        "SELECT * FROM session_items WHERE session_id = ? ORDER BY order_index",
+        (session_id,),
+    ).fetchall()
+    return [_session_item_from_row(r) for r in rows]
+
+
+# ============================================================================
+# Attempts
+# ============================================================================
+
+
+def create_attempt(conn: sqlite3.Connection, attempt: Attempt) -> str:
+    """Insert an attempt row. Returns the attempt id."""
+    conn.execute(
+        """
+        INSERT INTO attempts (
+            id, user_id, session_item_id, word_id, primary_accent,
+            question_type, target_phoneme, selected_answer, correct_answer,
+            is_correct, created_at
+        ) VALUES (
+            :id, :user_id, :session_item_id, :word_id, :primary_accent,
+            :question_type, :target_phoneme, :selected_answer, :correct_answer,
+            :is_correct, :created_at
+        )
+        """,
+        {
+            "id": attempt.id,
+            "user_id": attempt.user_id,
+            "session_item_id": attempt.session_item_id,
+            "word_id": attempt.word_id,
+            "primary_accent": attempt.primary_accent,
+            "question_type": attempt.question_type,
+            "target_phoneme": attempt.target_phoneme,
+            "selected_answer": attempt.selected_answer,
+            "correct_answer": attempt.correct_answer,
+            "is_correct": int(attempt.is_correct),
+            "created_at": attempt.created_at,
+        },
+    )
+    return attempt.id

--- a/backend/app/services/questions.py
+++ b/backend/app/services/questions.py
@@ -1,0 +1,50 @@
+"""Question generation for practice items.
+
+For each session item, generates a ``choose_ipa`` question with the correct
+IPA and plausible distractors drawn from other words.
+"""
+
+import random
+from typing import Dict, List, Optional
+
+from app.models import Word
+
+
+def generate_question(
+    word: Word,
+    accent: str = "US",
+    *,
+    distractor_pool: Optional[List[str]] = None,
+    seed: Optional[int] = None,
+) -> dict:
+    """Build a ``choose_ipa`` question dict for a word.
+
+    Args:
+        word: The target word (must have ipa_us for accent="US").
+        accent: "US" or "UK" — which IPA to use as the correct answer.
+        distractor_pool: Pre-built pool of IPA strings to draw distractors
+                         from. If omitted, no distractors are generated and
+                         a placeholder is used (caller should supply a pool
+                         for real use).
+        seed: Shuffle seed so the same word gets the same choices on repeat
+              calls.
+
+    Returns:
+        A question dict matching the API contract:
+        ``{"type": "choose_ipa", "prompt": "...", "choices": [...]}``
+    """
+    correct = word.ipa_us if accent.upper() == "US" else (word.ipa_uk or word.ipa_us)
+
+    choices = [correct]
+    if distractor_pool:
+        rng = random.Random(seed)
+        candidates = [ipa for ipa in distractor_pool if ipa != correct]
+        rng.shuffle(candidates)
+        choices.extend(candidates[:3])
+        rng.shuffle(choices)
+
+    return {
+        "type": "choose_ipa",
+        "prompt": "Which IPA matches this word?",
+        "choices": choices,
+    }

--- a/backend/app/services/scheduler.py
+++ b/backend/app/services/scheduler.py
@@ -1,0 +1,55 @@
+"""Word selection for daily practice sessions.
+
+The scheduler selects ``daily_word_count`` words from the ``words`` table.
+For M2 the selection is simple — usable words, shuffle, take N. Weak-phoneme
+weighting and new/review ratio are M5 concerns.
+"""
+
+import random
+import sqlite3
+from typing import List
+
+from app.models import Word
+from app.services.db_store import get_word_by_id
+
+
+def select_daily_words(
+    conn: sqlite3.Connection,
+    daily_word_count: int = 10,
+    accent: str = "US",
+    seed: int = 0,
+) -> List[Word]:
+    """Select ``daily_word_count`` usable words for today's practice.
+
+    Usable = ipa_us is present and content_status is not 'disabled'.
+
+    Args:
+        conn: Database connection.
+        daily_word_count: How many words to select.
+        accent: "US" or "UK" — only words with the matching IPA field.
+        seed: Deterministic seed for shuffle. Use the date-derived value
+              so same-day calls return the same order.
+
+    Returns:
+        List of Word dataclasses, length ≤ daily_word_count.
+    """
+    ipa_field = "ipa_us" if accent.upper() == "US" else "ipa_uk"
+    rows = conn.execute(
+        f"""
+        SELECT id FROM words
+        WHERE {ipa_field} IS NOT NULL AND {ipa_field} != ''
+          AND content_status != 'disabled'
+        """
+    ).fetchall()
+
+    word_ids = [r["id"] for r in rows]
+    rng = random.Random(seed)
+    rng.shuffle(word_ids)
+    selected_ids = word_ids[:daily_word_count]
+
+    words: List[Word] = []
+    for wid in selected_ids:
+        w = get_word_by_id(conn, wid)
+        if w is not None:
+            words.append(w)
+    return words

--- a/backend/app/services/sessions.py
+++ b/backend/app/services/sessions.py
@@ -1,0 +1,180 @@
+"""Session orchestration for GET /api/today.
+
+Handles the full flow: check for existing session → create or resume →
+build the full API response.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import date, datetime, timezone
+from typing import Dict, List, Optional, Tuple
+
+from app.db import get_db
+from app.models import DailySession, SessionItem, Settings, Word
+from app.services.db_store import (
+    create_session,
+    create_session_item,
+    get_session_for_date,
+    get_session_items,
+    get_settings,
+    get_word_by_id,
+)
+from app.services.questions import generate_question
+from app.services.scheduler import select_daily_words
+
+
+def _today_date_str() -> str:
+    return date.today().isoformat()
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _seed_from_date(session_date: str) -> int:
+    """Deterministic seed so same-date calls get the same word ordering."""
+    return hash(session_date) & 0x7FFFFFFF
+
+
+def build_today_response(
+    conn,
+    *,
+    user_id: str = "default",
+    accent: str = "US",
+    db_path: str = "",
+) -> dict:
+    """Run the full /api/today flow and return the response dict.
+
+    This is the single entry point called by the route handler.
+    """
+    session_date = _today_date_str()
+
+    # ---- load settings ------------------------------------------------------
+    settings = get_settings(conn, user_id)
+    if settings is None:
+        return {
+            "error": "CONTENT_NOT_READY",
+            "detail": "Settings not initialised. Run import_words.py first.",
+        }
+
+    daily_word_count = settings.daily_word_count
+
+    # ---- check for existing session -----------------------------------------
+    existing = get_session_for_date(conn, user_id, session_date, accent)
+    if existing is not None:
+        items = get_session_items(conn, existing.id)
+        return _build_response(
+            session=existing,
+            items=items,
+            daily_word_count=daily_word_count,
+            conn=conn,
+            accent=accent,
+        )
+
+    # ---- create new session -------------------------------------------------
+    seed = _seed_from_date(session_date)
+    words = select_daily_words(conn, daily_word_count, accent, seed=seed)
+
+    if not words:
+        return {
+            "error": "CONTENT_NOT_READY",
+            "detail": "No usable words found. Run import_words.py first.",
+        }
+
+    # Build a distractor pool from all available word IPAs
+    all_ipas = _build_distractor_pool(conn, accent)
+
+    session_id = f"{session_date}-{user_id}"
+    session = DailySession(
+        id=session_id,
+        user_id=user_id,
+        session_date=session_date,
+        primary_accent=accent,
+        status="in_progress",
+        created_at=_now_iso(),
+        completed_at=None,
+    )
+    create_session(conn, session)
+
+    items: List[SessionItem] = []
+    for i, word in enumerate(words):
+        item_id = f"{session_id}_item_{i + 1:03d}"
+        item = SessionItem(
+            id=item_id,
+            session_id=session_id,
+            word_id=word.id,
+            order_index=i,
+            target_phonemes=word.phoneme_tags_us if accent == "US" else (word.phoneme_tags_uk or []),
+            question_type="choose_ipa",
+            status="pending",
+        )
+        create_session_item(conn, item)
+        items.append(item)
+
+    return _build_response(
+        session=session,
+        items=items,
+        daily_word_count=daily_word_count,
+        conn=conn,
+        accent=accent,
+    )
+
+
+def _build_distractor_pool(conn, accent: str) -> List[str]:
+    """Collect IPA strings from the words table for distractor generation."""
+    ipa_field = "ipa_us" if accent.upper() == "US" else "ipa_uk"
+    rows = conn.execute(
+        f"""
+        SELECT DISTINCT {ipa_field} FROM words
+        WHERE {ipa_field} IS NOT NULL AND {ipa_field} != ''
+        LIMIT 200
+        """
+    ).fetchall()
+    return [r[0] for r in rows if r[0]]
+
+
+def _build_response(
+    *,
+    session: DailySession,
+    items: List[SessionItem],
+    daily_word_count: int,
+    conn,
+    accent: str,
+) -> dict:
+    """Assemble the /api/today JSON response from session + items."""
+    distractor_pool = _build_distractor_pool(conn, accent)
+    item_dicts: List[dict] = []
+    for item in items:
+        word = get_word_by_id(conn, item.word_id)
+        if word is None:
+            continue
+
+        question = generate_question(
+            word,
+            accent=accent,
+            distractor_pool=distractor_pool,
+            seed=hash(item.id) & 0x7FFFFFFF,
+        )
+
+        item_dicts.append(
+            {
+                "session_item_id": item.id,
+                "word_id": word.id,
+                "display_ipa": word.ipa_us if accent == "US" else (word.ipa_uk or ""),
+                "word": word.word,
+                "meaning_zh": word.meaning_zh,
+                "audio_url": word.audio_us if accent == "US" else word.audio_uk,
+                "target_phonemes": item.target_phonemes,
+                "question": question,
+            }
+        )
+
+    return {
+        "session_id": session.id,
+        "date": session.session_date,
+        "primary_accent": session.primary_accent,
+        "daily_word_count": daily_word_count,
+        "status": session.status,
+        "items": item_dicts,
+    }

--- a/backend/app/services/sessions.py
+++ b/backend/app/services/sessions.py
@@ -6,6 +6,7 @@ build the full API response.
 
 from __future__ import annotations
 
+import hashlib
 import uuid
 from datetime import date, datetime, timezone
 from typing import Dict, List, Optional, Tuple
@@ -32,9 +33,14 @@ def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
+def _stable_hash(s: str) -> int:
+    """Cross-process stable hash — ``hashlib.md5`` instead of Python ``hash()``."""
+    return int(hashlib.md5(s.encode()).hexdigest(), 16) & 0x7FFFFFFF
+
+
 def _seed_from_date(session_date: str) -> int:
     """Deterministic seed so same-date calls get the same word ordering."""
-    return hash(session_date) & 0x7FFFFFFF
+    return _stable_hash(session_date)
 
 
 def build_today_response(
@@ -154,7 +160,7 @@ def _build_response(
             word,
             accent=accent,
             distractor_pool=distractor_pool,
-            seed=hash(item.id) & 0x7FFFFFFF,
+            seed=_stable_hash(item.id),
         )
 
         item_dicts.append(

--- a/backend/scripts/import_words.py
+++ b/backend/scripts/import_words.py
@@ -39,7 +39,7 @@ from validate_content import (  # noqa: E402
     validate_words,
 )
 
-from app.db import get_db  # noqa: E402
+from app.db import DEFAULT_DB_PATH, get_db  # noqa: E402
 from app.models import Settings  # noqa: E402
 from app.services.db_schema import init_db, table_names  # noqa: E402
 from app.services.db_store import (  # noqa: E402
@@ -243,8 +243,8 @@ def main() -> None:
     )
     parser.add_argument(
         "--db-url",
-        default="sqlite:///./tiny_ipa_dev.sqlite",
-        help="SQLite database path or sqlite:/// URI (default: sqlite:///./tiny_ipa_dev.sqlite).",
+        default=None,
+        help="SQLite database path or sqlite:/// URI (default: same as runtime DEFAULT_DB_PATH).",
     )
     parser.add_argument(
         "--skip-validation",
@@ -268,10 +268,11 @@ def main() -> None:
         print(f"Error: phonemes file not found: {phonemes_path}", file=sys.stderr)
         sys.exit(1)
 
+    db_path = args.db_url if args.db_url else DEFAULT_DB_PATH
     report = import_words(
         source_path=source_path,
         phonemes_path=phonemes_path,
-        db_path=args.db_url,
+        db_path=db_path,
         skip_validation=args.skip_validation,
     )
 

--- a/backend/tests/test_today_persistence.py
+++ b/backend/tests/test_today_persistence.py
@@ -1,0 +1,264 @@
+"""Tests for GET /api/today — session persistence and refresh safety."""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import date
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+# Ensure scripts importable.
+_SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+from import_words import import_words  # noqa: E402
+from app.main import app  # noqa: E402
+from app.db import get_connection, get_db  # noqa: E402
+from app.services.db_store import (  # noqa: E402
+    count_words,
+    create_session,
+    create_session_item,
+    get_session_for_date,
+    get_session_items,
+    get_settings,
+    get_word_by_id,
+)
+from app.services.db_schema import init_db, table_names  # noqa: E402
+from app.models import DailySession, SessionItem  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures"
+CONTENT_SAMPLE = FIXTURES / "content_sample.json"
+PHONEMES_PATH = Path(__file__).resolve().parent.parent.parent / "content" / "phonemes.json"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(name="seeded_db")
+def seeded_db_fixture(tmp_path: Path) -> str:
+    """Create a database pre-loaded with the 3-word fixture content."""
+    db_path = str(tmp_path / "test.sqlite")
+    import_words(
+        source_path=CONTENT_SAMPLE,
+        phonemes_path=PHONEMES_PATH,
+        db_path=db_path,
+    )
+    # Monkey-patch the default DB path so the TestClient uses this DB.
+    import app.db as db_mod
+
+    orig = db_mod.DEFAULT_DB_PATH
+    db_mod.DEFAULT_DB_PATH = db_path
+    yield db_path
+    db_mod.DEFAULT_DB_PATH = orig
+
+
+@pytest.fixture(name="client")
+def client_fixture(seeded_db: str) -> TestClient:
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Session persistence tests
+# ---------------------------------------------------------------------------
+
+
+class TestTodayPersistence:
+    """Tests that /api/today is database-backed and refresh-safe."""
+
+    def test_first_today_creates_session(self, client, seeded_db):
+        resp = client.get("/api/today")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "error" not in data, data
+        assert data["status"] == "in_progress"
+        assert data["date"] == date.today().isoformat()
+        assert data["primary_accent"] == "US"
+        assert data["daily_word_count"] == 10
+        assert len(data["items"]) == 3  # fixture has 3 words
+        # Session row exists in DB
+        conn = get_connection(seeded_db)
+        s = get_session_for_date(conn, "default", date.today().isoformat(), "US")
+        conn.close()
+        assert s is not None
+        assert s.status == "in_progress"
+
+    def test_second_today_returns_same_session(self, client, seeded_db):
+        first = client.get("/api/today").json()
+        second = client.get("/api/today").json()
+        assert second["session_id"] == first["session_id"]
+        assert len(second["items"]) == len(first["items"])
+        for a, b in zip(first["items"], second["items"]):
+            assert a["session_item_id"] == b["session_item_id"]
+            assert a["word_id"] == b["word_id"]
+
+    def test_second_today_creates_no_duplicate(self, client, seeded_db):
+        client.get("/api/today")
+        client.get("/api/today")
+        conn = get_connection(seeded_db)
+        today = date.today().isoformat()
+        # Try to create another — should be caught by uniqueness of session_id
+        items = conn.execute(
+            "SELECT COUNT(*) as cnt FROM daily_sessions WHERE session_date = ?", (today,)
+        ).fetchone()
+        conn.close()
+        assert items["cnt"] == 1
+
+    def test_items_have_required_fields(self, client, seeded_db):
+        resp = client.get("/api/today")
+        data = resp.json()
+        for item in data["items"]:
+            assert "session_item_id" in item
+            assert "word_id" in item
+            assert "display_ipa" in item
+            assert "word" in item
+            assert "question" in item
+            assert item["question"]["type"] == "choose_ipa"
+            assert "choices" in item["question"]
+            assert len(item["question"]["choices"]) >= 2  # correct + distractors
+
+    def test_items_use_us_accent(self, client, seeded_db):
+        resp = client.get("/api/today")
+        data = resp.json()
+        for item in data["items"]:
+            conn = get_connection(seeded_db)
+            w = get_word_by_id(conn, item["word_id"])
+            conn.close()
+            assert w is not None
+            # display_ipa should match ipa_us
+            assert item["display_ipa"] == w.ipa_us
+
+    def test_disabled_words_not_scheduled(self, client, seeded_db):
+        # Mark one word as disabled and verify it's excluded.
+        conn = get_connection(seeded_db)
+        conn.execute("UPDATE words SET content_status = 'disabled' WHERE id = 'cat'")
+        conn.commit()
+        conn.close()
+
+        resp = client.get("/api/today")
+        data = resp.json()
+        word_ids = [item["word_id"] for item in data["items"]]
+        assert "cat" not in word_ids
+
+    def test_daily_word_count_respected(self, client, seeded_db):
+        # Lower daily_word_count and verify fewer items.
+        conn = get_connection(seeded_db)
+        conn.execute("UPDATE settings SET daily_word_count = 1 WHERE user_id = 'default'")
+        conn.commit()
+        conn.close()
+
+        resp = client.get("/api/today")
+        data = resp.json()
+        assert len(data["items"]) <= 1
+
+    def test_content_not_ready_without_import(self, tmp_path):
+        """Without running import first, /api/today returns CONTENT_NOT_READY."""
+        db_path = str(tmp_path / "empty.sqlite")
+        conn = get_connection(db_path)
+        init_db(conn)
+        conn.close()
+
+        import app.db as db_mod
+
+        orig = db_mod.DEFAULT_DB_PATH
+        db_mod.DEFAULT_DB_PATH = db_path
+        try:
+            c = TestClient(app)
+            resp = c.get("/api/today")
+            assert resp.status_code == 200
+            data = resp.json()
+            assert data["error"] == "CONTENT_NOT_READY"
+        finally:
+            db_mod.DEFAULT_DB_PATH = orig
+
+
+# ---------------------------------------------------------------------------
+# Session store tests (unit-level)
+# ---------------------------------------------------------------------------
+
+
+class TestSessionStore:
+    @pytest.fixture(autouse=True)
+    def _init(self, tmp_path):
+        db_path = str(tmp_path / "test.sqlite")
+        conn = get_connection(db_path)
+        init_db(conn)
+        # Insert required settings so FK-based tests pass
+        conn.execute(
+            """
+            INSERT OR REPLACE INTO settings (
+                user_id, primary_accent, daily_word_count,
+                show_translation, show_accent_compare,
+                practice_mode, review_strength, updated_at
+            ) VALUES ('default', 'US', 10, 1, 0, 'ipa_first', 'normal', '2026-06-06T00:00:00Z')
+            """
+        )
+        # Insert a test word
+        conn.execute(
+            """
+            INSERT OR REPLACE INTO words (
+                id, word, level, ipa_us, phoneme_tags_us, content_status
+            ) VALUES ('ship', 'ship', 'beginner', '/ʃɪp/', '["/ʃ/", "/ɪ/", "/p/"]', 'core_selected')
+            """
+        )
+        conn.commit()
+        self.conn = conn
+        yield
+        conn.close()
+
+    def test_create_and_retrieve_session(self):
+        s = DailySession(
+            id="2026-06-06-default",
+            user_id="default",
+            session_date="2026-06-06",
+            primary_accent="US",
+            status="in_progress",
+            created_at="2026-06-06T00:00:00Z",
+        )
+        create_session(self.conn, s)
+        got = get_session_for_date(self.conn, "default", "2026-06-06", "US")
+        assert got is not None
+        assert got.id == "2026-06-06-default"
+        assert got.status == "in_progress"
+
+    def test_get_missing_session(self):
+        assert (
+            get_session_for_date(self.conn, "default", "2099-01-01", "US") is None
+        )
+
+    def test_create_and_retrieve_session_items(self):
+        sess = DailySession(
+            id="s1",
+            user_id="default",
+            session_date="2026-06-06",
+            primary_accent="US",
+            status="in_progress",
+            created_at="2026-06-06T00:00:00Z",
+        )
+        create_session(self.conn, sess)
+
+        item = SessionItem(
+            id="s1_item_001",
+            session_id="s1",
+            word_id="ship",
+            order_index=0,
+            target_phonemes=["/ʃ/", "/ɪ/", "/p/"],
+            question_type="choose_ipa",
+            status="pending",
+        )
+        create_session_item(self.conn, item)
+
+        items = get_session_items(self.conn, "s1")
+        assert len(items) == 1
+        assert items[0].id == "s1_item_001"
+        assert items[0].word_id == "ship"
+        assert items[0].target_phonemes == ["/ʃ/", "/ɪ/", "/p/"]


### PR DESCRIPTION
Closes #11

Depends on: #29

## Scope completed
- `backend/app/routes/practice.py` — GET /api/today: creates or resumes daily session
- `backend/app/services/sessions.py` — session orchestration: settings lookup → session check → create/resume → full response
- `backend/app/services/scheduler.py` — word selection: filters usable words, deterministic shuffle from date seed
- `backend/app/services/questions.py` — choose_ipa question generation with distractor pool
- `backend/app/services/db_store.py` — added session, session_item, and attempt CRUD
- `backend/app/main.py` — registered practice router under /api
- `backend/tests/test_today_persistence.py` — 11 tests

## Verification
- All 66 tests pass (0 failures, 0 regressions)
- Manual API test:
  - First GET /api/today → 10 items, session created
  - Second GET /api/today → same session_id, same items (refresh-safe)
  - Disabled words excluded, daily_word_count respected

## Residual risks
- Word selection is simple shuffle; no weak-phoneme weighting (M5 concern)
- `/api/health` shows `db_ready: false` — config.py checks TINY_IPA_DB_PATH env var but defaults to a path that doesn't match the import script's default. Not blocking for this issue but worth a follow-up