### PR TITLE
[#12] Implement POST /api/attempt with server-side grading and phoneme stats

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,6 +5,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from app.routes.health import router as health_router
 from app.routes.practice import router as practice_router
+from app.routes.attempts import router as attempts_router
 
 app = FastAPI(title="Tiny IPA", version="0.1.0")
 
@@ -17,3 +18,4 @@ app.add_middleware(
 
 app.include_router(health_router, prefix="/api")
 app.include_router(practice_router, prefix="/api")
+app.include_router(attempts_router, prefix="/api")

--- a/backend/app/routes/attempts.py
+++ b/backend/app/routes/attempts.py
@@ -1,0 +1,132 @@
+"""Attempt submission endpoint — POST /api/attempt."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, HTTPException, Request
+
+from app.db import get_db
+from app.models import Attempt
+from app.services.db_store import (
+    create_attempt,
+    get_session_by_id,
+    get_session_items,
+    get_word_by_id,
+)
+from app.services.grading import determine_correct_answer, grade_attempt
+from app.services.progress import update_phoneme_stats
+
+router = APIRouter()
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+@router.post("/attempt")
+async def attempt(request: Request):
+    """Submit a practice attempt for grading.
+
+    Expects JSON body::
+
+        {"session_item_id": "...", "selected_answer": "..."}
+
+    The correct answer is determined server-side. Client must not
+    submit ``correct_answer`` — it is ignored if present.
+    """
+    body = await request.json()
+    session_item_id = body.get("session_item_id", "")
+    selected_answer = body.get("selected_answer", "")
+
+    if not session_item_id:
+        raise HTTPException(
+            status_code=400, detail={"error": "INVALID_ATTEMPT", "detail": "Missing session_item_id"}
+        )
+
+    with get_db() as conn:
+        # Resolve session from the session_item_id prefix.
+        # Items have ids like "2026-06-06-default_item_001".
+        # The session_id is the prefix before the last "_item_".
+        parts = session_item_id.rsplit("_item_", 1)
+        if len(parts) != 2:
+            raise HTTPException(
+                status_code=404,
+                detail={"error": "ITEM_NOT_FOUND", "detail": f"Invalid item id: {session_item_id}"},
+            )
+
+        # Find the matching session item across all sessions. Since the
+        # item id is globally unique (session prefix embedded), we look
+        # it up directly via the session it belongs to.
+        session_id = parts[0]
+        items = get_session_items(conn, session_id)
+        item = next((it for it in items if it.id == session_item_id), None)
+        if item is None:
+            raise HTTPException(
+                status_code=404,
+                detail={"error": "ITEM_NOT_FOUND", "detail": session_item_id},
+            )
+
+        # Check session status.
+        session = get_session_by_id(conn, session_id)
+
+        if session is None:
+            raise HTTPException(
+                status_code=404,
+                detail={"error": "SESSION_NOT_FOUND", "detail": session_id},
+            )
+        if session.status == "completed":
+            raise HTTPException(
+                status_code=400,
+                detail={"error": "SESSION_ALREADY_COMPLETED", "detail": session_id},
+            )
+
+        # Get the word for grading.
+        word = get_word_by_id(conn, item.word_id)
+        if word is None:
+            raise HTTPException(
+                status_code=400,
+                detail={"error": "CONTENT_NOT_READY", "detail": f"Word not found: {item.word_id}"},
+            )
+
+        # Server-side grading.
+        correct_answer = determine_correct_answer(item, word, session.primary_accent)
+        is_correct = grade_attempt(selected_answer, correct_answer)
+
+        # Persist attempt.
+        timestamp = _now_iso()
+        attempt_row = Attempt(
+            id=str(uuid.uuid4()),
+            user_id="default",
+            session_item_id=session_item_id,
+            word_id=item.word_id,
+            primary_accent=session.primary_accent,
+            question_type=item.question_type,
+            correct_answer=correct_answer,
+            is_correct=is_correct,
+            created_at=timestamp,
+            selected_answer=selected_answer,
+            target_phoneme=item.target_phonemes[0] if item.target_phonemes else None,
+        )
+        create_attempt(conn, attempt_row)
+
+        # Update phoneme stats.
+        updated_phonemes = update_phoneme_stats(
+            conn,
+            user_id="default",
+            primary_accent=session.primary_accent,
+            target_phonemes=item.target_phonemes,
+            is_correct=is_correct,
+            timestamp=timestamp,
+        )
+
+        # Determine next_action.
+        next_action = "next_item"
+
+        return {
+            "is_correct": is_correct,
+            "correct_answer": correct_answer,
+            "updated_phonemes": updated_phonemes,
+            "next_action": next_action,
+        }

--- a/backend/app/services/db_store.py
+++ b/backend/app/services/db_store.py
@@ -327,6 +327,16 @@ def create_session_item(conn: sqlite3.Connection, item: SessionItem) -> str:
     return item.id
 
 
+def get_session_by_id(conn: sqlite3.Connection, session_id: str) -> Optional[DailySession]:
+    """Return a daily session by its primary key, or None."""
+    row = conn.execute(
+        "SELECT * FROM daily_sessions WHERE id = ?", (session_id,)
+    ).fetchone()
+    if row is None:
+        return None
+    return _session_from_row(row)
+
+
 def get_session_items(
     conn: sqlite3.Connection, session_id: str
 ) -> List[SessionItem]:

--- a/backend/app/services/grading.py
+++ b/backend/app/services/grading.py
@@ -1,0 +1,40 @@
+"""Server-side grading for practice attempts.
+
+Compares the user's selected answer against the correct IPA for the
+session item's word and accent. The correct answer is determined from
+the database, not trusted from the client request.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Optional
+
+from app.models import SessionItem, Word
+
+
+def determine_correct_answer(item: SessionItem, word: Word, accent: str = "US") -> str:
+    """Return the correct IPA string for a session item.
+
+    Args:
+        item: The session item being answered.
+        word: The corresponding word row.
+        accent: "US" or "UK".
+
+    Returns:
+        The IPA string the user should match, e.g. "/ʃɪp/".
+    """
+    if accent.upper() == "UK" and word.ipa_uk:
+        return word.ipa_uk
+    return word.ipa_us
+
+
+def grade_attempt(selected_answer: str, correct_answer: str) -> bool:
+    """Compare the selected answer with the correct answer.
+
+    Leading/trailing whitespace is stripped. The comparison is
+    exact — no fuzzy matching for M2.
+    """
+    if not selected_answer or not correct_answer:
+        return False
+    return selected_answer.strip() == correct_answer.strip()

--- a/backend/app/services/progress.py
+++ b/backend/app/services/progress.py
@@ -1,0 +1,168 @@
+"""Phoneme-level statistics and mastery computation.
+
+Every attempt submission updates ``phoneme_stats`` for each target
+phoneme on the session item. Mastery status is derived from attempt
+count and accuracy with documented precedence rules.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Dict, List, Optional, Tuple
+
+# ---------------------------------------------------------------------------
+# Mastery status
+# ---------------------------------------------------------------------------
+
+# Precedence: "weak" beats "learning" when accuracy < 0.70.
+#              "mastered" beats "learning"/"weak" when threshold met.
+#              "new" is the base state.
+
+def _compute_mastery(attempt_count: int, correct_count: int) -> str:
+    """Map attempt count and accuracy to a mastery status string.
+
+    Rules (in evaluation order — first match wins):
+    1. ``attempt_count < 3`` → ``"new"``
+    2. ``attempt_count >= 5 AND accuracy >= 0.85`` → ``"mastered"``
+    3. ``attempt_count >= 3 AND accuracy < 0.70`` → ``"weak"``
+    4. ``attempt_count >= 3 AND accuracy < 0.85`` → ``"learning"``
+    5. ``attempt_count >= 3 AND accuracy >= 0.85`` → ``"learning"``
+       (ready for mastery after 5+)
+    """
+    if attempt_count == 0:
+        return "new"
+    accuracy = correct_count / attempt_count
+    if attempt_count >= 5 and accuracy >= 0.85:
+        return "mastered"
+    if attempt_count >= 3:
+        if accuracy < 0.70:
+            return "weak"
+        return "learning"
+    return "new"
+
+
+# ---------------------------------------------------------------------------
+# Stats helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_or_create_stat(
+    conn: sqlite3.Connection,
+    user_id: str,
+    primary_accent: str,
+    phoneme_id: str,
+) -> dict:
+    """Return the current phoneme_stats row for (user, accent, phoneme) or a
+    default dict suitable for first-time insert."""
+    row = conn.execute(
+        """
+        SELECT attempt_count, correct_count, mastery_status
+        FROM phoneme_stats
+        WHERE user_id = ? AND primary_accent = ? AND phoneme_id = ?
+        """,
+        (user_id, primary_accent, phoneme_id),
+    ).fetchone()
+    if row is None:
+        return {"attempt_count": 0, "correct_count": 0, "mastery_status": "new"}
+    return {
+        "attempt_count": row["attempt_count"],
+        "correct_count": row["correct_count"],
+        "mastery_status": row["mastery_status"],
+    }
+
+
+def _upsert_phoneme_stat(
+    conn: sqlite3.Connection,
+    user_id: str,
+    primary_accent: str,
+    phoneme_id: str,
+    attempt_count: int,
+    correct_count: int,
+    mastery_status: str,
+    last_attempt_at: str,
+    last_wrong_at: Optional[str],
+) -> None:
+    conn.execute(
+        """
+        INSERT OR REPLACE INTO phoneme_stats (
+            user_id, primary_accent, phoneme_id,
+            attempt_count, correct_count,
+            last_attempt_at, last_wrong_at, mastery_status
+        ) VALUES (
+            :user_id, :primary_accent, :phoneme_id,
+            :attempt_count, :correct_count,
+            :last_attempt_at, :last_wrong_at, :mastery_status
+        )
+        """,
+        {
+            "user_id": user_id,
+            "primary_accent": primary_accent,
+            "phoneme_id": phoneme_id,
+            "attempt_count": attempt_count,
+            "correct_count": correct_count,
+            "last_attempt_at": last_attempt_at,
+            "last_wrong_at": last_wrong_at,
+            "mastery_status": mastery_status,
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def update_phoneme_stats(
+    conn: sqlite3.Connection,
+    *,
+    user_id: str,
+    primary_accent: str,
+    target_phonemes: List[str],
+    is_correct: bool,
+    timestamp: str,
+) -> List[dict]:
+    """Update phoneme_stats for each target phoneme after an attempt.
+
+    Args:
+        conn: Database connection.
+        user_id: e.g. "default".
+        primary_accent: "US" or "UK".
+        target_phonemes: Phoneme symbols from the session item.
+        is_correct: Whether the user answered correctly.
+        timestamp: ISO-8601 timestamp for this attempt.
+
+    Returns:
+        A list of ``updated_phonemes`` dicts matching the API contract,
+        one per target phoneme.
+    """
+    updated: List[dict] = []
+    for phoneme_id in target_phonemes:
+        stat = _get_or_create_stat(conn, user_id, primary_accent, phoneme_id)
+        new_count = stat["attempt_count"] + 1
+        new_correct = stat["correct_count"] + (1 if is_correct else 0)
+        mastery = _compute_mastery(new_count, new_correct)
+        wrong_at = None if is_correct else timestamp
+        if not is_correct:
+            wrong_at = timestamp
+
+        _upsert_phoneme_stat(
+            conn,
+            user_id,
+            primary_accent,
+            phoneme_id,
+            attempt_count=new_count,
+            correct_count=new_correct,
+            mastery_status=mastery,
+            last_attempt_at=timestamp,
+            last_wrong_at=wrong_at,
+        )
+
+        updated.append(
+            {
+                "phoneme": phoneme_id,
+                "attempt_count": new_count,
+                "correct_count": new_correct,
+                "mastery_status": mastery,
+            }
+        )
+    return updated

--- a/backend/app/services/progress.py
+++ b/backend/app/services/progress.py
@@ -56,18 +56,24 @@ def _get_or_create_stat(
     default dict suitable for first-time insert."""
     row = conn.execute(
         """
-        SELECT attempt_count, correct_count, mastery_status
+        SELECT attempt_count, correct_count, mastery_status, last_wrong_at
         FROM phoneme_stats
         WHERE user_id = ? AND primary_accent = ? AND phoneme_id = ?
         """,
         (user_id, primary_accent, phoneme_id),
     ).fetchone()
     if row is None:
-        return {"attempt_count": 0, "correct_count": 0, "mastery_status": "new"}
+        return {
+            "attempt_count": 0,
+            "correct_count": 0,
+            "mastery_status": "new",
+            "last_wrong_at": None,
+        }
     return {
         "attempt_count": row["attempt_count"],
         "correct_count": row["correct_count"],
         "mastery_status": row["mastery_status"],
+        "last_wrong_at": row["last_wrong_at"],
     }
 
 
@@ -141,8 +147,10 @@ def update_phoneme_stats(
         new_count = stat["attempt_count"] + 1
         new_correct = stat["correct_count"] + (1 if is_correct else 0)
         mastery = _compute_mastery(new_count, new_correct)
-        wrong_at = None if is_correct else timestamp
-        if not is_correct:
+        # Preserve existing last_wrong_at on correct attempts.
+        if is_correct:
+            wrong_at = stat.get("last_wrong_at")
+        else:
             wrong_at = timestamp
 
         _upsert_phoneme_stat(

--- a/backend/tests/test_attempts.py
+++ b/backend/tests/test_attempts.py
@@ -1,0 +1,280 @@
+"""Tests for POST /api/attempt — grading, persistence, and phoneme stats."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+_SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+from import_words import import_words  # noqa: E402
+from app.main import app  # noqa: E402
+from app.db import get_connection  # noqa: E402
+from app.services.db_store import (  # noqa: E402
+    create_attempt,
+    count_phonemes,
+    get_session_items,
+    get_word_by_id,
+)
+from app.services.progress import _compute_mastery, update_phoneme_stats  # noqa: E402
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures"
+CONTENT_SAMPLE = FIXTURES / "content_sample.json"
+PHONEMES_PATH = Path(__file__).resolve().parent.parent.parent / "content" / "phonemes.json"
+
+
+@pytest.fixture(name="seeded_db")
+def seeded_db_fixture(tmp_path: Path) -> str:
+    """Database pre-loaded with the 3-word fixture + imported phonemes."""
+    db_path = str(tmp_path / "test.sqlite")
+    import_words(
+        source_path=CONTENT_SAMPLE,
+        phonemes_path=PHONEMES_PATH,
+        db_path=db_path,
+    )
+    import app.db as db_mod
+
+    orig = db_mod.DEFAULT_DB_PATH
+    db_mod.DEFAULT_DB_PATH = db_path
+    yield db_path
+    db_mod.DEFAULT_DB_PATH = orig
+
+
+@pytest.fixture(name="client")
+def client_fixture(seeded_db: str) -> TestClient:
+    return TestClient(app)
+
+
+def _get_first_item(client: TestClient) -> dict:
+    """Get today's session and return the first item."""
+    today = client.get("/api/today").json()
+    assert "error" not in today, today
+    items = today["items"]
+    assert len(items) > 0
+    return items[0]
+
+
+# ---------------------------------------------------------------------------
+# Mastery status
+# ---------------------------------------------------------------------------
+
+
+class TestMasteryStatus:
+    def test_new(self):
+        assert _compute_mastery(0, 0) == "new"
+        assert _compute_mastery(1, 0) == "new"
+        assert _compute_mastery(2, 2) == "new"
+
+    def test_weak(self):
+        # >= 3 attempts AND accuracy < 0.70
+        assert _compute_mastery(3, 0) == "weak"  # 0%
+        assert _compute_mastery(3, 1) == "weak"  # 33%
+        assert _compute_mastery(3, 2) == "weak"  # 66%
+        assert _compute_mastery(10, 5) == "weak"  # 50%
+
+    def test_learning(self):
+        # >= 3 attempts AND 0.70 <= accuracy < 0.85
+        assert _compute_mastery(3, 2) == "weak"  # 66% -> still weak
+        assert _compute_mastery(5, 4) == "learning"  # 80%
+        assert _compute_mastery(3, 3) == "learning"  # 100% but only 3 attempts
+        assert _compute_mastery(4, 3) == "learning"  # 75%
+
+    def test_mastered(self):
+        # >= 5 attempts AND accuracy >= 0.85
+        assert _compute_mastery(5, 5) == "mastered"  # 100%
+        assert _compute_mastery(6, 5) == "learning"  # 83% < 85%
+        assert _compute_mastery(10, 9) == "mastered"  # 90%
+
+
+class TestAttemptRoute:
+    """Integration tests for POST /api/attempt."""
+
+    def test_correct_answer_creates_attempt(self, client, seeded_db):
+        item = _get_first_item(client)
+        correct = item["display_ipa"]
+
+        resp = client.post("/api/attempt", json={
+            "session_item_id": item["session_item_id"],
+            "selected_answer": correct,
+        })
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["is_correct"] is True
+        assert data["correct_answer"] == correct
+        assert len(data["updated_phonemes"]) > 0
+        assert data["next_action"] == "next_item"
+
+    def test_wrong_answer_creates_attempt(self, client, seeded_db):
+        item = _get_first_item(client)
+        resp = client.post("/api/attempt", json={
+            "session_item_id": item["session_item_id"],
+            "selected_answer": "/wrong/",
+        })
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["is_correct"] is False
+        assert data["correct_answer"] == item["display_ipa"]
+
+    def test_attempt_persisted(self, client, seeded_db):
+        item = _get_first_item(client)
+        client.post("/api/attempt", json={
+            "session_item_id": item["session_item_id"],
+            "selected_answer": item["display_ipa"],
+        })
+        # Verify in DB
+        conn = get_connection(seeded_db)
+        rows = conn.execute(
+            "SELECT * FROM attempts WHERE session_item_id = ?",
+            (item["session_item_id"],),
+        ).fetchall()
+        conn.close()
+        assert len(rows) == 1
+        assert rows[0]["is_correct"] == 1
+
+    def test_missing_item_returns_error(self, client):
+        resp = client.post("/api/attempt", json={
+            "session_item_id": "nonexistent_item_999",
+            "selected_answer": "/ʃɪp/",
+        })
+        assert resp.status_code == 404
+        data = resp.json()
+        assert data["detail"]["error"] == "ITEM_NOT_FOUND"
+
+    def test_missing_session_item_id(self, client):
+        resp = client.post("/api/attempt", json={
+            "selected_answer": "/ʃɪp/",
+        })
+        assert resp.status_code == 400
+        data = resp.json()
+        assert data["detail"]["error"] == "INVALID_ATTEMPT"
+
+    def test_phoneme_stats_updated(self, client, seeded_db):
+        item = _get_first_item(client)
+        client.post("/api/attempt", json={
+            "session_item_id": item["session_item_id"],
+            "selected_answer": item["display_ipa"],
+        })
+        resp_data = client.post("/api/attempt", json={
+            "session_item_id": item["session_item_id"],
+            "selected_answer": "/wrong/",
+        }).json()
+
+        # Should show attempt_count=2, correct_count=1 for each phoneme
+        for ps in resp_data["updated_phonemes"]:
+            assert ps["attempt_count"] == 2
+            assert ps["correct_count"] == 1
+
+    def test_stats_are_accent_partitioned(self, client, seeded_db):
+        """Stats written with primary_accent='US' are persisted."""
+        item = _get_first_item(client)
+        client.post("/api/attempt", json={
+            "session_item_id": item["session_item_id"],
+            "selected_answer": item["display_ipa"],
+        })
+        conn = get_connection(seeded_db)
+        rows = conn.execute(
+            "SELECT * FROM phoneme_stats WHERE primary_accent = 'US'"
+        ).fetchall()
+        conn.close()
+        assert len(rows) > 0
+        for r in rows:
+            assert r["primary_accent"] == "US"
+
+    def test_client_correct_answer_ignored(self, client, seeded_db):
+        """Client sending correct_answer in body is ignored."""
+        item = _get_first_item(client)
+        resp = client.post("/api/attempt", json={
+            "session_item_id": item["session_item_id"],
+            "selected_answer": "/bogus/",
+            "correct_answer": "/client_fake/",
+        })
+        assert resp.status_code == 200
+        data = resp.json()
+        # Server should have graded against the real answer, not /client_fake/
+        assert data["is_correct"] is False
+        assert data["correct_answer"] == item["display_ipa"]
+
+    def test_empty_selected_answer(self, client):
+        item = _get_first_item(client)
+        resp = client.post("/api/attempt", json={
+            "session_item_id": item["session_item_id"],
+            "selected_answer": "",
+        })
+        assert resp.status_code == 200
+        assert resp.json()["is_correct"] is False
+
+
+# ---------------------------------------------------------------------------
+# Progress service (unit tests)
+# ---------------------------------------------------------------------------
+
+
+class TestProgressService:
+    @pytest.fixture(autouse=True)
+    def _init(self, tmp_path):
+        db_path = str(tmp_path / "test.sqlite")
+        conn = get_connection(db_path)
+        from app.services.db_schema import init_db
+        init_db(conn)
+        # Seed phoneme_stats with pre-existing data
+        conn.execute(
+            """
+            INSERT OR REPLACE INTO phoneme_stats
+                (user_id, primary_accent, phoneme_id, attempt_count, correct_count,
+                 mastery_status, last_attempt_at)
+            VALUES
+                ('default', 'US', '/ʃ/', 2, 1, 'new', '2026-06-05T00:00:00Z')
+            """
+        )
+        conn.commit()
+        self.conn = conn
+        self.db_path = db_path
+        yield
+        conn.close()
+
+    def test_update_existing_stat(self):
+        updated = update_phoneme_stats(
+            self.conn,
+            user_id="default",
+            primary_accent="US",
+            target_phonemes=["/ʃ/"],
+            is_correct=True,
+            timestamp="2026-06-06T00:00:00Z",
+        )
+        assert len(updated) == 1
+        assert updated[0]["phoneme"] == "/ʃ/"
+        assert updated[0]["attempt_count"] == 3
+        assert updated[0]["correct_count"] == 2
+        # 3 attempts, 2/3 = 67% < 70% → weak
+        assert updated[0]["mastery_status"] == "weak"
+
+    def test_update_new_stat(self):
+        updated = update_phoneme_stats(
+            self.conn,
+            user_id="default",
+            primary_accent="US",
+            target_phonemes=["/ɪ/"],
+            is_correct=False,
+            timestamp="2026-06-06T00:00:00Z",
+        )
+        assert updated[0]["attempt_count"] == 1
+        assert updated[0]["correct_count"] == 0
+        assert updated[0]["mastery_status"] == "new"
+
+    def test_multiple_phonemes(self):
+        updated = update_phoneme_stats(
+            self.conn,
+            user_id="default",
+            primary_accent="US",
+            target_phonemes=["/ʃ/", "/ɪ/", "/p/"],
+            is_correct=True,
+            timestamp="2026-06-06T00:00:00Z",
+        )
+        assert len(updated) == 3
+        symbols = {ps["phoneme"] for ps in updated}
+        assert symbols == {"/ʃ/", "/ɪ/", "/p/"}

--- a/backend/tests/test_attempts.py
+++ b/backend/tests/test_attempts.py
@@ -185,6 +185,29 @@ class TestAttemptRoute:
         for r in rows:
             assert r["primary_accent"] == "US"
 
+    def test_last_wrong_at_preserved_after_correct(self, client, seeded_db):
+        """After wrong→correct, last_wrong_at should persist, not be cleared."""
+        item = _get_first_item(client)
+        # Submit wrong answer first
+        client.post("/api/attempt", json={
+            "session_item_id": item["session_item_id"],
+            "selected_answer": "/wrong/",
+        })
+        # Submit correct answer
+        client.post("/api/attempt", json={
+            "session_item_id": item["session_item_id"],
+            "selected_answer": item["display_ipa"],
+        })
+        conn = get_connection(seeded_db)
+        rows = conn.execute(
+            "SELECT phoneme_id, last_wrong_at FROM phoneme_stats WHERE primary_accent = 'US'"
+        ).fetchall()
+        conn.close()
+        for r in rows:
+            assert r["last_wrong_at"] is not None, (
+                f"last_wrong_at was cleared for phoneme {r['phoneme_id']} after correct attempt"
+            )
+
     def test_client_correct_answer_ignored(self, client, seeded_db):
         """Client sending correct_answer in body is ignored."""
         item = _get_first_item(client)


### PR DESCRIPTION
Closes #12

Depends on: #30

## Scope completed
- routes/attempts.py — POST /api/attempt
- services/grading.py — server-side correct answer lookup + grading
- services/progress.py — phoneme_stats CRUD + mastery status
- test_attempts.py — 16 tests

## Verification
- All 82 tests pass