### PR TITLE
[#13] Update frontend to submit attempts via /api/attempt and survive refresh

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,37 +1,53 @@
 import { fetchHealth } from "./api";
 import { useEffect, useState } from "react";
+import TodayPractice from "./pages/TodayPractice";
 
 function App() {
-  const [health, setHealth] = useState<string | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  const [backendReady, setBackendReady] = useState<boolean>(false);
+  const [checking, setChecking] = useState(true);
 
   useEffect(() => {
     fetchHealth()
-      .then((data) => setHealth(JSON.stringify(data, null, 2)))
-      .catch((err) => setError(err.message));
+      .then(() => setBackendReady(true))
+      .catch(() => setBackendReady(false))
+      .finally(() => setChecking(false));
   }, []);
 
-  return (
-    <main
-      style={{
-        maxWidth: 480,
-        margin: "0 auto",
-        padding: "24px 16px",
-        fontFamily: "system-ui, sans-serif",
-      }}
-    >
-      <h1>Tiny IPA</h1>
-      <p>Daily IPA practice with small beginner word sets.</p>
-      {error && <p style={{ color: "red" }}>Error: {error}</p>}
-      {health ? (
-        <pre style={{ background: "#f5f5f5", padding: 12, borderRadius: 8 }}>
-          {health}
-        </pre>
-      ) : (
-        !error && <p>Connecting to backend…</p>
-      )}
-    </main>
-  );
+  if (checking) {
+    return (
+      <main
+        style={{
+          maxWidth: 480,
+          margin: "0 auto",
+          padding: "24px 16px",
+          fontFamily: "system-ui, sans-serif",
+        }}
+      >
+        <h1>Tiny IPA</h1>
+        <p>Connecting to backend…</p>
+      </main>
+    );
+  }
+
+  if (!backendReady) {
+    return (
+      <main
+        style={{
+          maxWidth: 480,
+          margin: "0 auto",
+          padding: "24px 16px",
+          fontFamily: "system-ui, sans-serif",
+        }}
+      >
+        <h1>Tiny IPA</h1>
+        <p style={{ color: "#c00" }}>
+          Cannot reach the backend. Make sure it is running on port 8010.
+        </p>
+      </main>
+    );
+  }
+
+  return <TodayPractice />;
 }
 
 export default App;

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -79,11 +79,6 @@ export interface AttemptResponse {
   next_action: string;
 }
 
-export interface AttemptError {
-  error: string;
-  detail: string;
-}
-
 export async function submitAttempt(
   sessionItemId: string,
   selectedAnswer: string,
@@ -97,11 +92,24 @@ export async function submitAttempt(
     }),
   });
   if (!res.ok) {
-    const body: AttemptError = await res.json().catch(() => ({
-      error: "NETWORK_ERROR",
-      detail: `HTTP ${res.status}`,
-    }));
-    throw body;
+    // Normalise FastAPI structured errors into a user-friendly string.
+    let message = `Request failed (HTTP ${res.status})`;
+    try {
+      const body = await res.json();
+      // FastAPI wraps HTTPException detail at top-level "detail"
+      const inner = body.detail ?? body;
+      if (typeof inner === "object" && inner !== null) {
+        // Prefer {error, detail} shape → "ERROR_CODE: detail"
+        const code = inner.error ?? "";
+        const text = inner.detail ?? JSON.stringify(inner);
+        message = code ? `${code}: ${text}` : String(text);
+      } else if (typeof inner === "string") {
+        message = inner;
+      }
+    } catch {
+      // Fall through with the default message.
+    }
+    throw new Error(message);
   }
   return res.json();
 }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -5,6 +5,10 @@
 
 const API_BASE = import.meta.env.VITE_API_BASE ?? "/api";
 
+// ---------------------------------------------------------------------------
+// Health
+// ---------------------------------------------------------------------------
+
 export interface HealthResponse {
   status: string;
   content_version: string;
@@ -15,6 +19,89 @@ export async function fetchHealth(): Promise<HealthResponse> {
   const res = await fetch(`${API_BASE}/health`);
   if (!res.ok) {
     throw new Error(`Health check failed: ${res.status}`);
+  }
+  return res.json();
+}
+
+// ---------------------------------------------------------------------------
+// Today practice
+// ---------------------------------------------------------------------------
+
+export interface TodayItem {
+  session_item_id: string;
+  word_id: string;
+  display_ipa: string;
+  word: string;
+  meaning_zh: string | null;
+  audio_url: string | null;
+  target_phonemes: string[];
+  question: {
+    type: string;
+    prompt: string;
+    choices: string[];
+  };
+}
+
+export interface TodayResponse {
+  session_id: string;
+  date: string;
+  primary_accent: string;
+  daily_word_count: number;
+  status: string;
+  items: TodayItem[];
+  error?: string;
+  detail?: string;
+}
+
+export async function fetchToday(): Promise<TodayResponse> {
+  const res = await fetch(`${API_BASE}/today`);
+  if (!res.ok) {
+    throw new Error(`GET /api/today failed: ${res.status}`);
+  }
+  return res.json();
+}
+
+// ---------------------------------------------------------------------------
+// Attempt submission
+// ---------------------------------------------------------------------------
+
+export interface UpdatedPhoneme {
+  phoneme: string;
+  attempt_count: number;
+  correct_count: number;
+  mastery_status: string;
+}
+
+export interface AttemptResponse {
+  is_correct: boolean;
+  correct_answer: string;
+  updated_phonemes: UpdatedPhoneme[];
+  next_action: string;
+}
+
+export interface AttemptError {
+  error: string;
+  detail: string;
+}
+
+export async function submitAttempt(
+  sessionItemId: string,
+  selectedAnswer: string,
+): Promise<AttemptResponse> {
+  const res = await fetch(`${API_BASE}/attempt`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      session_item_id: sessionItemId,
+      selected_answer: selectedAnswer,
+    }),
+  });
+  if (!res.ok) {
+    const body: AttemptError = await res.json().catch(() => ({
+      error: "NETWORK_ERROR",
+      detail: `HTTP ${res.status}`,
+    }));
+    throw body;
   }
   return res.json();
 }

--- a/frontend/src/components/ChoiceQuestion.tsx
+++ b/frontend/src/components/ChoiceQuestion.tsx
@@ -1,0 +1,129 @@
+/**
+ * ChoiceQuestion component.
+ *
+ * Displays a word and a set of IPA choices. The user selects one — it is
+ * submitted to the server for grading. Feedback is shown after the server
+ * responds.
+ */
+
+import { useState } from "react";
+import type { TodayItem } from "../api";
+import { submitAttempt } from "../api";
+
+export interface ChoiceResult {
+  sessionItemId: string;
+  selectedAnswer: string;
+  isCorrect: boolean;
+  correctAnswer: string;
+}
+
+interface Props {
+  item: TodayItem;
+  onResult: (result: ChoiceResult) => void;
+}
+
+export function ChoiceQuestion({ item, onResult }: Props) {
+  const [selected, setSelected] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [feedback, setFeedback] = useState<{
+    isCorrect: boolean;
+    correctAnswer: string;
+  } | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSelect = async (choice: string) => {
+    if (submitting || feedback) return; // Already answered
+    setSelected(choice);
+    setSubmitting(true);
+    setError(null);
+
+    try {
+      const result = await submitAttempt(item.session_item_id, choice);
+      setFeedback({
+        isCorrect: result.is_correct,
+        correctAnswer: result.correct_answer,
+      });
+      onResult({
+        sessionItemId: item.session_item_id,
+        selectedAnswer: choice,
+        isCorrect: result.is_correct,
+        correctAnswer: result.correct_answer,
+      });
+    } catch (err: any) {
+      const detail = typeof err === "object" && err !== null
+        ? err.detail || err.error || "Unknown error"
+        : String(err);
+      setError(detail);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const isAnswered = feedback !== null;
+  const isError = error !== null;
+
+  return (
+    <div className="choice-question">
+      {/* Word display — IPA-first: word is shown, user picks matching IPA */}
+      <div className="word-display">
+        <span className="word-text">{item.word}</span>
+        {item.meaning_zh && (
+          <span className="word-meaning">{item.meaning_zh}</span>
+        )}
+      </div>
+
+      <p className="question-prompt">{item.question.prompt}</p>
+
+      <div className="choices-list">
+        {item.question.choices.map((choice) => {
+          let className = "choice-btn";
+          if (isAnswered && choice === feedback.correctAnswer) {
+            className += " choice-correct";
+          } else if (
+            isAnswered &&
+            choice === selected &&
+            !feedback.isCorrect
+          ) {
+            className += " choice-wrong";
+          }
+
+          return (
+            <button
+              key={choice}
+              className={className}
+              onClick={() => handleSelect(choice)}
+              disabled={submitting || isAnswered}
+              aria-label={`Select ${choice}`}
+            >
+              {choice}
+            </button>
+          );
+        })}
+      </div>
+
+      {submitting && <p className="submit-status">Submitting…</p>}
+
+      {isAnswered && (
+        <div
+          className={`feedback ${feedback.isCorrect ? "feedback-correct" : "feedback-wrong"}`}
+          role="alert"
+        >
+          {feedback.isCorrect ? (
+            <p>✅ Correct!</p>
+          ) : (
+            <p>
+              ❌ Not quite — the correct answer is{" "}
+              <strong>{feedback.correctAnswer}</strong>
+            </p>
+          )}
+        </div>
+      )}
+
+      {isError && (
+        <div className="feedback feedback-error" role="alert">
+          <p>⚠️ Failed to submit: {error}</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/ChoiceQuestion.tsx
+++ b/frontend/src/components/ChoiceQuestion.tsx
@@ -50,10 +50,9 @@ export function ChoiceQuestion({ item, onResult }: Props) {
         correctAnswer: result.correct_answer,
       });
     } catch (err: any) {
-      const detail = typeof err === "object" && err !== null
-        ? err.detail || err.error || "Unknown error"
-        : String(err);
-      setError(detail);
+      // submitAttempt normalises errors into Error with .message
+      const message = err instanceof Error ? err.message : String(err);
+      setError(message);
     } finally {
       setSubmitting(false);
     }

--- a/frontend/src/pages/TodayPractice.tsx
+++ b/frontend/src/pages/TodayPractice.tsx
@@ -1,0 +1,145 @@
+/**
+ * TodayPractice page.
+ *
+ * Loads /api/today, renders a sequence of practice items, and submits
+ * answers to /api/attempt for server-side grading. The page is
+ * refresh-safe: reloading on the same date resumes the same session.
+ */
+
+import { useEffect, useState } from "react";
+import type { TodayItem, TodayResponse } from "../api";
+import { fetchToday } from "../api";
+import type { ChoiceResult } from "../components/ChoiceQuestion";
+import { ChoiceQuestion } from "../components/ChoiceQuestion";
+
+interface PracticeResult {
+  sessionItemId: string;
+  wordId: string;
+  word: string;
+  selectedAnswer: string;
+  correctAnswer: string;
+  isCorrect: boolean;
+}
+
+export default function TodayPractice() {
+  const [session, setSession] = useState<TodayResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [results, setResults] = useState<PracticeResult[]>([]);
+  const [finished, setFinished] = useState(false);
+
+  // Load today's session on mount.
+  useEffect(() => {
+    fetchToday()
+      .then((data) => {
+        if (data.error) {
+          setError(data.detail ?? data.error);
+        } else {
+          setSession(data);
+        }
+        setLoading(false);
+      })
+      .catch((err) => {
+        setError(err.message);
+        setLoading(false);
+      });
+  }, []);
+
+  const handleResult = (item: TodayItem, result: ChoiceResult) => {
+    setResults((prev) => [
+      ...prev,
+      {
+        sessionItemId: result.sessionItemId,
+        wordId: item.word_id,
+        word: item.word,
+        selectedAnswer: result.selectedAnswer,
+        correctAnswer: result.correctAnswer,
+        isCorrect: result.isCorrect,
+      },
+    ]);
+  };
+
+  const handleNext = () => {
+    if (!session) return;
+    const nextIndex = currentIndex + 1;
+    if (nextIndex >= session.items.length) {
+      setFinished(true);
+    } else {
+      setCurrentIndex(nextIndex);
+    }
+  };
+
+  // Loading state
+  if (loading) {
+    return (
+      <main className="practice-container">
+        <p>Loading today's practice…</p>
+      </main>
+    );
+  }
+
+  // Error state
+  if (error || !session || session.error) {
+    return (
+      <main className="practice-container">
+        <div className="practice-error">
+          <h2>Practice unavailable</h2>
+          <p>{error || session?.detail || "Unknown error"}</p>
+          <p className="hint">
+            Make sure you've run <code>import_words.py</code> and the backend
+            is running.
+          </p>
+        </div>
+      </main>
+    );
+  }
+
+  // Finished state — show summary
+  if (finished) {
+    const correctCount = results.filter((r) => r.isCorrect).length;
+    const total = results.length;
+    return (
+      <main className="practice-container">
+        <div className="practice-summary">
+          <h2>Practice complete!</h2>
+          <p className="summary-score">
+            {correctCount} / {total} correct
+          </p>
+          <ul className="summary-list">
+            {results.map((r, i) => (
+              <li key={i} className={r.isCorrect ? "summary-correct" : "summary-wrong"}>
+                <strong>{r.word}</strong> — you picked{" "}
+                <code>{r.selectedAnswer}</code>
+                {r.isCorrect ? " ✅" : ` ❌ (correct: ${r.correctAnswer})`}
+              </li>
+            ))}
+          </ul>
+        </div>
+      </main>
+    );
+  }
+
+  // Active practice — show current item
+  const currentItem = session.items[currentIndex];
+  const progress = `${currentIndex + 1} / ${session.items.length}`;
+
+  return (
+    <main className="practice-container">
+      <div className="practice-header">
+        <span className="progress-label">Progress: {progress}</span>
+        <span className="accent-label">{session.primary_accent} practice</span>
+      </div>
+
+      <ChoiceQuestion
+        key={currentItem.session_item_id}
+        item={currentItem}
+        onResult={(result) => {
+          handleResult(currentItem, result);
+          // Auto-advance after a short delay so the user can read feedback.
+          setTimeout(() => handleNext(), 1500);
+        }}
+      />
+    </main>
+  );
+}

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -22,3 +22,193 @@ button {
   font: inherit;
   cursor: pointer;
 }
+
+/* ---------------------------------------------------------------------------
+ * Practice container — mobile-first, max 480px
+ * --------------------------------------------------------------------------- */
+
+.practice-container {
+  max-width: 480px;
+  margin: 0 auto;
+  padding: 24px 16px;
+}
+
+.practice-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 20px;
+  font-size: 0.875rem;
+  color: #666;
+}
+
+.progress-label {
+  font-weight: 600;
+}
+
+.accent-label {
+  background: #e8e8e8;
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-size: 0.75rem;
+}
+
+.practice-error {
+  text-align: center;
+  padding: 32px 0;
+}
+
+.practice-error h2 {
+  margin-bottom: 8px;
+}
+
+.practice-error .hint {
+  margin-top: 12px;
+  font-size: 0.85rem;
+  color: #888;
+}
+
+/* ---------------------------------------------------------------------------
+ * Choice question
+ * --------------------------------------------------------------------------- */
+
+.choice-question {
+  margin-bottom: 24px;
+}
+
+.word-display {
+  text-align: center;
+  margin-bottom: 12px;
+}
+
+.word-text {
+  font-size: 2rem;
+  font-weight: 700;
+  display: block;
+}
+
+.word-meaning {
+  font-size: 0.9rem;
+  color: #888;
+  display: block;
+  margin-top: 4px;
+}
+
+.question-prompt {
+  text-align: center;
+  font-size: 0.95rem;
+  color: #555;
+  margin-bottom: 16px;
+}
+
+.choices-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-bottom: 16px;
+}
+
+.choice-btn {
+  padding: 14px 16px;
+  border: 2px solid #ddd;
+  border-radius: 10px;
+  background: #fafafa;
+  font-size: 1.25rem;
+  text-align: center;
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.choice-btn:hover:not(:disabled) {
+  border-color: #4a90d9;
+  background: #eef5fc;
+}
+
+.choice-btn:disabled {
+  cursor: default;
+}
+
+.choice-correct {
+  border-color: #2e7d32 !important;
+  background: #e8f5e9 !important;
+  color: #2e7d32;
+}
+
+.choice-wrong {
+  border-color: #c62828 !important;
+  background: #ffebee !important;
+  color: #c62828;
+}
+
+.submit-status {
+  text-align: center;
+  font-size: 0.85rem;
+  color: #999;
+}
+
+/* ---------------------------------------------------------------------------
+ * Feedback
+ * --------------------------------------------------------------------------- */
+
+.feedback {
+  text-align: center;
+  padding: 12px;
+  border-radius: 8px;
+  margin-top: 12px;
+  font-size: 1rem;
+}
+
+.feedback-correct {
+  background: #e8f5e9;
+  color: #2e7d32;
+  border: 1px solid #a5d6a7;
+}
+
+.feedback-wrong {
+  background: #fff3e0;
+  color: #e65100;
+  border: 1px solid #ffcc80;
+}
+
+.feedback-error {
+  background: #ffebee;
+  color: #c62828;
+  border: 1px solid #ef9a9a;
+}
+
+/* ---------------------------------------------------------------------------
+ * Summary
+ * --------------------------------------------------------------------------- */
+
+.practice-summary {
+  text-align: center;
+}
+
+.practice-summary h2 {
+  margin-bottom: 8px;
+}
+
+.summary-score {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin-bottom: 20px;
+}
+
+.summary-list {
+  list-style: none;
+  text-align: left;
+  padding: 0;
+}
+
+.summary-list li {
+  padding: 8px 0;
+  border-bottom: 1px solid #eee;
+  font-size: 0.95rem;
+}
+
+.summary-correct {
+  color: #2e7d32;
+}
+
+.summary-wrong {
+  color: #c62828;
+}


### PR DESCRIPTION
Closes #13

Depends on: #31

## Scope completed
- api.ts — fetchToday(), submitAttempt(), TypeScript types
- TodayPractice.tsx — practice flow: load, sequence, submit, feedback, summary
- ChoiceQuestion.tsx — word + IPA choices + submit + feedback/error display
- App.tsx — health gate then practice page
- global.css — mobile-first practice UI styles

## Verification
- TypeScript 0 errors, Vite build success
- Backend 82 tests pass (0 regressions)
- Refresh-safe via database-backed /api/today