### PR TITLE
Document issue-level review handoff comments

### DIFF
--- a/docs/08-multi-agent-epic-workflow.md
+++ b/docs/08-multi-agent-epic-workflow.md
@@ -95,6 +95,15 @@ Base:   main
 
 Milestone-sized PRs are not the default. They are allowed only when the child issues are tightly coupled, the PR body maps every child issue to completed scope, and review remains tractable.
 
+Stacked PRs are allowed when dependencies are real, but merging a stacked PR merges it into its base branch, not necessarily into `main`. Before closing issues or an Epic, verify that every required commit is reachable from `origin/main`. If stacked PRs were reviewed against non-main bases, use one of these release paths:
+
+```text
+Option A: retarget each PR to main after its lower dependency lands, then merge in order
+Option B: open a final integration PR from the top stack branch to main
+```
+
+Do not treat a stacked PR as complete merely because GitHub shows it as merged; check the merge destination.
+
 ## Project Status Flow
 
 Use the Kanban status as shared state:

--- a/docs/08-multi-agent-epic-workflow.md
+++ b/docs/08-multi-agent-epic-workflow.md
@@ -200,6 +200,47 @@ When changing handoff ownership, always add a short comment that states what cha
 
 When marking an Epic's child issues ready, leave a comment on the Epic that points Implementers to the child issues, but do not label the Epic `needs:implementer`.
 
+### Review Handoff Contract
+
+When the Architect sends a task back from review, the handoff must be visible from the child issue itself.
+
+Required actions:
+
+```text
+1. Post detailed code/API feedback on the PR.
+2. Post a short handoff comment on the linked child issue.
+3. Replace needs:architect with needs:implementer on the child issue.
+4. Leave the Project status as In Review unless the task is explicitly reopened.
+```
+
+The issue comment must include:
+
+```markdown
+## Implementer handoff: changes requested
+
+This issue was moved back to `needs:implementer` after Architect review.
+
+Fix branch: `agent/<issue-number>-...`
+PR: #...
+Detailed review: <PR comment URL>
+
+Next action:
+- Checkout the fix branch.
+- Apply the requested fix from the PR review comment.
+- Add or adjust regression tests for the blocker.
+- Push the same branch and move this issue back to `needs:architect` when ready for re-review.
+```
+
+Do not rely on PR comments alone for a role handoff. Implementers discover work from issue labels first, so the issue must contain a durable pointer to the PR feedback.
+
+Implementer re-review pickup command:
+
+```bash
+gh issue list -R farmerhunter/tiny-ipa --state open --label needs:implementer
+gh issue view <issue-number> -R farmerhunter/tiny-ipa --comments
+gh pr view <pr-number> -R farmerhunter/tiny-ipa --comments
+```
+
 ## Comment Routing
 
 Route durable coordination through GitHub:

--- a/docs/08-multi-agent-epic-workflow.md
+++ b/docs/08-multi-agent-epic-workflow.md
@@ -202,15 +202,16 @@ When marking an Epic's child issues ready, leave a comment on the Epic that poin
 
 ### Review Handoff Contract
 
-When the Architect sends a task back from review, the handoff must be visible from the child issue itself.
+When the Architect sends a task back from review, the handoff must be visible from both the child issue and the linked PR. Agents may scan either surface first, so single-channel feedback is not reliable.
 
 Required actions:
 
 ```text
 1. Post detailed code/API feedback on the PR.
 2. Post a short handoff comment on the linked child issue.
-3. Replace needs:architect with needs:implementer on the child issue.
-4. Leave the Project status as In Review unless the task is explicitly reopened.
+3. If the reason for the handoff is not already the latest PR comment, post a short PR follow-up comment too.
+4. Replace needs:architect with needs:implementer on the child issue.
+5. Leave the Project status as In Review unless the task is explicitly reopened.
 ```
 
 The issue comment must include:
@@ -232,6 +233,8 @@ Next action:
 ```
 
 Do not rely on PR comments alone for a role handoff. Implementers discover work from issue labels first, so the issue must contain a durable pointer to the PR feedback.
+
+Do not rely on issue comments alone for a PR-specific or stacked-branch handoff. Implementers often inspect PR conversations when fixing an open PR, so the PR must also contain a short pointer to the latest action.
 
 Implementer re-review pickup command:
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -46,7 +46,7 @@ gh issue view <issue-number> -R farmerhunter/tiny-ipa --comments
 gh pr view <pr-number> -R farmerhunter/tiny-ipa --comments
 ```
 
-Architect must not rely on PR comments alone when moving an issue back to `needs:implementer`. The issue comment should point to the PR review, name the fix branch, and summarize the blocker.
+Architect must not rely on only one comment surface when moving an issue back to `needs:implementer`. The issue comment should point to the PR review, name the fix branch, and summarize the blocker. The PR conversation should also include the latest handoff or a pointer to it, especially for stacked-branch refresh requests.
 
 ## Issue-driven execution
 
@@ -133,6 +133,7 @@ If Architect requests changes on a PR, the handoff is complete only after:
 
 - the PR has detailed review feedback
 - the child issue has a short `Implementer handoff` comment linking to that PR feedback
+- the PR also has the latest handoff or a short pointer to the issue handoff
 - the child issue is labeled `needs:implementer`
 
 Implementer fixes should be pushed to the existing issue branch, not a new branch, unless the Architect explicitly asks for a replacement branch.

--- a/docs/development.md
+++ b/docs/development.md
@@ -39,6 +39,15 @@ When handing work to another role, update the label and add a short issue or PR 
 
 Do not put `needs:implementer` on an Epic. Implementers pick up child issues, not Epic containers. If an Epic-level concern requires execution, create a child task such as integration QA, cross-issue gap fixing, or final manual QA evidence.
 
+When an issue returns from Architect review, read both the issue handoff comment and the linked PR comment:
+
+```bash
+gh issue view <issue-number> -R farmerhunter/tiny-ipa --comments
+gh pr view <pr-number> -R farmerhunter/tiny-ipa --comments
+```
+
+Architect must not rely on PR comments alone when moving an issue back to `needs:implementer`. The issue comment should point to the PR review, name the fix branch, and summarize the blocker.
+
 ## Issue-driven execution
 
 Each meaningful code change links to a child issue. Child issues are the source of truth for local scope, constraints, and acceptance criteria. Epic issues are the source of truth for cross-issue QA, readiness, and workflow closure.
@@ -117,6 +126,16 @@ blocked           -> latest comment explains the blocker
 ```
 
 Allowed Epic handoff labels are `needs:architect`, `needs:user`, and `blocked`. `needs:implementer`, `needs:ci`, and `needs:merge` belong on child issues or PRs.
+
+### Review handoff
+
+If Architect requests changes on a PR, the handoff is complete only after:
+
+- the PR has detailed review feedback
+- the child issue has a short `Implementer handoff` comment linking to that PR feedback
+- the child issue is labeled `needs:implementer`
+
+Implementer fixes should be pushed to the existing issue branch, not a new branch, unless the Architect explicitly asks for a replacement branch.
 
 ## Local development
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -96,6 +96,7 @@ Residual risks:
 - PRs that pass CI checks may be auto-merged for normal scoped changes.
 - Default PR granularity is one child issue per PR.
 - Cross-issue findings belong on the parent Epic unless one child issue clearly owns them.
+- For stacked PRs, merging a PR only merges into that PR's base branch. Before closing issues or Epics, verify the final commits are reachable from `origin/main`. Use a final integration PR to `main` or retarget PRs in order.
 - **Do not auto-merge** if:
   - CI is failing
   - The change touches the database schema without a migration path


### PR DESCRIPTION
## Summary\n- Require issue-level handoff comments when Architect sends reviewed work back to Implementer\n- Add pickup commands for reading issue and PR comments\n- Clarify that PR comments alone are not enough for cross-agent routing\n\n## Verification\n- Markdown/documentation-only change\n- Confirmed #10-#13 now have issue-level handoff comments