### PR TITLE
Add anecdote on multi-agent scheduling

### DIFF
--- a/docs/00-design-index.md
+++ b/docs/00-design-index.md
@@ -38,6 +38,11 @@
 8. [Multi-Agent Epic Workflow](08-multi-agent-epic-workflow.md)
    定义 Architect / Implementer 双 agent 协作、Epic/issue/branch/PR 粒度、评论路由和 merge 规则。
 
+## 工程随笔
+
+1. [Vibe Coding 中的老登式多 Agent 调度经历](anecdote_Reinventing_agent_scheduler.md)
+   记录 Tiny IPA 开发中从双 agent 传话协作、GitHub Project Kanban、Milestone 到 Epic 的流程演化，以及它如何自然长成一个小型 agent 调度系统。
+
 ## 当前建议路线
 
 Tiny IPA 的推荐主线是：

--- a/docs/anecdote_Reinventing_agent_scheduler.md
+++ b/docs/anecdote_Reinventing_agent_scheduler.md
@@ -50,20 +50,26 @@ Codex 负责规划和 review，DeepSeek 负责执行。我负责在两个窗口�
 
 只要共享状态还在我的剪贴板里，我就会变成人肉消息队列。谁该开工、谁该 review、哪个 issue 已经 ready、哪个 PR 需要补测试，这些信息都不应该靠我记着。
 
-到这一步，问题已经不是 prompt engineering，而是 workflow engineering。
+到这一步，明显不是我不会用 prompt engineering，而是需要 workflow engineering 了。
 
-所谓自动化，也不是让两个 agent 神秘地互相聊天，而是把“下一步该谁做什么”变成一个可查询、可更新、可审计的系统状态。
 
-## 三、从 Issue 到 Milestone，再到 Epic
+## 三、重新拾回全套技术流程概念体系
 
-我们很自然地把工作流放到了 GitHub Project 上。
+利用一个文档传递项目规划的方式显然不够用了。
 
-原因也简单：既然 agent 都能用 `gh`，既然 issue / PR / comment / label 都是可读可写的，那 GitHub 就是最便宜、最稳、最不用自己造后台的协作数据库。
+我们很自然地把工作流放到了 GitHub Project 上。第一版很朴素：issue 记录 task，milestone 组织阶段，PR 承载代码交付。这已经足够让 DeepSeek 按 issue 执行，让 Codex 按 issue review。
 
-第一版很朴素：issue 记录 task，milestone 组织阶段，PR 承载代码交付。这已经足够让 DeepSeek 按 issue 执行，让 Codex 按 issue review。
+但 milestone 很快显出局限。于是又引入了Epic。。咦，怎么这么熟悉的感觉呢？想当年曾经为了说服队友们接受Epic这类层级架构磨破了嘴皮。。
 
-但 milestone 很快显出局限。
+且慢，还得引入明确的职责指定和流转规则。。这不也是当年每天都反复提醒的内容吗？
 
+好在现在agent都特听话，不但立即执行而且给足情绪价值。
+
+## 四、技术细节：目前揉出来的流程
+
+这一段讲具体流程，不感兴趣可以跳过。
+
+### 为什么milestone不够用
 Milestone 是时间切片，天然带有线性暗示：M0 完了再 M1，M1 完了再 M2。它适合表达路线图，却不适合表达多 agent 并行协作中的能力边界、依赖关系和集成验收。
 
 更具体地说，milestone 有三个问题：
@@ -80,11 +86,7 @@ Epic 对应一个能力阶段，下面挂 child issues。Child issue 是执行�
 
 这样 milestone 就退回到路线图和历史阶段，Epic 成为真正的协作单位。
 
-这个变化的价值不在“名字更时髦”，而在它打破了线性阶段感，让多 agent 协作可以围绕能力图而不是时间队列展开。
-
-## 四、技术夹层：我们最后揉出来的流程
-
-这一段讲具体流程，不感兴趣可以跳过。
+### 目前的流程
 
 现在 tiny-ipa 的多 agent 协作大概长这样：
 
@@ -133,11 +135,7 @@ needs:merge       -> 可以 merge
 blocked           -> 被阻塞，读最新 comment
 ```
 
-一个重要修正是：Epic 本身不是 implementer 的工作项。
-
-也就是说，不能因为 M2 的子任务 ready 了，就给 Epic #22 标 `needs:implementer`。Implementer 不应该“领取 Epic”，它应该领取 Epic 下面的 child issue。
-
-如果 Epic-level 的事情需要人执行，比如：
+Epic 本身不是 implementer 的工作项。如果 Epic-level 的事情需要人执行，比如：
 
 ```text
 Run integration QA and close Epic readiness gaps
@@ -145,13 +143,8 @@ Fix cross-issue session / attempt integration gaps
 Add final manual QA evidence for Epic closure
 ```
 
-那就新建一个 child issue。
+那就新建一个专门干这个的 child issue。
 
-这条规则看起来小，其实很要命。它决定了 agent inbox 里出现的是“可以动手的任务”，而不是“一个大概需要你关心的阶段”。
-
-人可以理解含糊话。
-
-Agent 最好少吃含糊话。
 
 ## 五、兜兜转转，又回到老本行
 

--- a/docs/anecdote_Reinventing_agent_scheduler.md
+++ b/docs/anecdote_Reinventing_agent_scheduler.md
@@ -1,0 +1,332 @@
+# Vibe Coding 中的老登式多 Agent 调度经历
+
+（本文是 [`anecdote_Introducing_view_model.md`](https://github.com/farmerhunter/token-panic/blob/main/design_docs/anecdote_Introducing_view_model.md) 的延续。
+
+上一篇故事发生在开发 token-panic 时。这一篇故事已经换到了新项目 tiny-ipa：<https://github.com/farmerhunter/tiny-ipa>。
+
+本文主要由 Codex 撰写（照例感谢）。）
+
+上一篇讲到最后，我已经隐约意识到，所谓 vibe coding，并不是把需求扔给一个万能 AI，然后自己去喝咖啡。
+
+更真实的画面是：一个 agent 写得快，容易局部最优；另一个 agent 稳一点，擅长抽象、review、总结；人类夹在中间，判断方向、调节火候、决定什么时候该停下来揉面。
+
+那时这还只是一个朦胧的感觉。
+
+到了 tiny-ipa，这件事开始长出骨架了。
+
+## 一、老登开始领导两个 Agent 干活
+
+tiny-ipa 是个很小的项目。目标也不花哨：做一个帮自己练英语音标的小工具。
+
+需求听起来朴素：选几百个高质量单词，带英式和美式 IPA，做练习，做一点 TTS 音频，后面能部署到 VPS 上自己用。不是 SaaS，不追求商业化，不需要一上来就设计成十万用户规模。
+
+按理说，这种项目很适合直接开干。
+
+但上一个项目已经教育过我：小项目也会长腿。今天只是一个按钮，明天就变成数据来源、音标质量、TTS 生成、SQLite、练习记录、部署备份、英美音对比。你一边说“先 MVP”，一边发现每一步都在往后面的系统埋钩子。
+
+于是我开始老登式地领导两个 agent。
+
+DeepSeek 那边负责具体 coding。执行力强，给它一个 issue，它能一路把文件改起来、测试跑起来、PR 提起来。
+
+Codex 这边逐渐变成了 architect / reviewer / planner。先把整体架构画到底，决定哪些东西现在做，哪些东西留接口但不提前复杂化；再把 milestone 拆成 issue；等 DeepSeek 做完，再回来 review，看它有没有漏掉边界、测试、文档、手动验证。
+
+一开始我还没有给它们起角色名。只是凭感觉分配任务。
+
+后来发现，名字其实已经在那里了。
+
+一个像 implementer。
+
+一个像 architect。
+
+我，暂时像个拿着茶杯在旁边转悠的 engineering manager。
+
+## 二、我的工作变成了 Copy / Paste
+
+最早这种双 agent 协作非常土。
+
+我在 Codex 这里讨论规划，Codex 生成 milestone 和 issue 草案。我复制到 GitHub。
+
+DeepSeek 在隔壁做完 M0，我回来告诉 Codex：“隔壁 DeepSeek 已经把 M0 做完了，你 review 一下。”
+
+Codex review 出问题，我把 review comment 复制给 DeepSeek。
+
+DeepSeek 修完，我再回来告诉 Codex：“隔壁修好了，你再检查一下。”
+
+Codex 说可以开工 M1，我再去通知 DeepSeek。
+
+这套流程居然能跑。
+
+而且越跑越顺。
+
+两个 agent 之间没有直接通信，也没有什么高大上的 agent orchestration framework。它们甚至不知道对方真实存在。它们只通过我的 copy / paste 彼此感知。
+
+但问题也很明显。
+
+我越来越像一个人肉消息队列。
+
+Architect 说：“这个 issue 需要 implementer 处理。”
+
+我复制。
+
+Implementer 说：“这个 PR 已经完成，请 review。”
+
+我复制。
+
+Architect 说：“这里有 blocker，不能 merge。”
+
+我再复制。
+
+这时老登终于拍了一下桌子：这不就是工作流状态流转吗？这不就是应该自动化的吗？
+
+## 三、从 Issue 到 Milestone，再到 Epic
+
+我们很自然地把工作流放到了 GitHub Project 上。
+
+原因也简单：既然 agent 都能用 `gh`，既然 issue / PR / comment / label 都是可读可写的，那 GitHub 就是最便宜、最稳、最不用自己造后台的协作数据库。
+
+最开始只是用 issue 记 task。
+
+M0 要做什么，开几个 issue。M1 要做什么，再开几个 issue。每个 issue 写清楚背景、约束、验收标准、测试要求。DeepSeek 可以拿一个 issue 开工，Codex 可以基于 issue review。
+
+这已经比“把一大段需求贴给 agent”强很多。
+
+后来我们开始按 milestone 做规划、执行、review。
+
+M0 是 feasibility 和架构骨架。M1 是静态练习闭环。M2 是 SQLite 和服务端判题。M3 是核心 100 单词音频。每个 milestone 下面有一组 issue。做完以后，不是马上往前冲，而是先做 milestone-level review。
+
+这一步很关键。
+
+因为有些问题不是某个 issue 独自负责的。
+
+比如 M1 做完后，单个 issue 看起来都完成了，但整体手动 QA 有没有跑？英式 IPA 的选择题路径有没有真的用 UK accent？前端刷新后状态有没有保住？这些东西更像 integration review，而不是某个按钮 issue 的小尾巴。
+
+于是我们曾经发明了 milestone readiness issue。
+
+看起来合理，但很快又别扭起来。
+
+Milestone 本质上还是线性的。M0 完了再 M1，M1 完了再 M2。它适合一个人排队干活，不适合多个 agent 同时往不同方向推进。
+
+更要命的是，readiness issue 有点像为了弥补 milestone 缺陷硬造出来的夹层。它不是能力本身，只是一个“等我检查完再放行”的门卫。
+
+这时候 Epic 出场了。
+
+我们把 milestone 对应的能力阶段转成 Epic issue：M2 是一个 Epic，下面挂 #10 到 #13；M3 是一个 Epic，下面挂 #14 到 #17。Epic 负责上下文、跨 issue 风险、集成验收、readiness。Child issue 负责具体执行。
+
+这一下舒服多了。
+
+不是“所有人排队等 M2 完了才能看 M3”，而是“每个 Epic 是一个能力容器，里面有可执行任务，任务之间有依赖，有些可以并行，有些需要等 readiness”。
+
+Milestone 退回成历史阶段和路线图标记。
+
+Epic 才是协作单位。
+
+## 四、技术夹层：我们最后揉出来的流程
+
+这一段讲具体流程，不感兴趣可以跳过。
+
+现在 tiny-ipa 的多 agent 协作大概长这样：
+
+```text
+Epic issue = 能力 / 阶段 / 跨 issue 协调中心
+Child issue = 可执行任务和验收单元
+Branch = 一个 child issue 的实现线
+PR = 一个 child issue 的合并请求
+GitHub Project = 人类可看的 Kanban
+needs:* label = agent 可自动检索的 next-action inbox
+```
+
+角色也变得清楚：
+
+```text
+Architect:
+  - 架构设计
+  - Epic 拆解
+  - 把 child issue 从 Backlog 推到 Ready
+  - review PR / issue
+  - 做 Epic readiness 判断
+
+Implementer:
+  - 领取 Ready 的 child issue
+  - 创建 issue branch
+  - 写代码、测试、文档
+  - 开 PR
+  - 响应 review
+  - 写 completion comment
+```
+
+GitHub Project 的状态负责给人看：
+
+```text
+Backlog -> Ready -> In progress -> In Review -> Done
+```
+
+`needs:*` label 负责给 agent 找活：
+
+```text
+needs:implementer -> implementer 应该处理某个 child issue 或 PR
+needs:architect   -> architect 应该 review、merge、规划或做 readiness
+needs:user        -> 需要用户决策
+needs:ci          -> 等 CI
+needs:merge       -> 可以 merge
+blocked           -> 被阻塞，读最新 comment
+```
+
+一个重要修正是：Epic 本身不是 implementer 的工作项。
+
+也就是说，不能因为 M2 的子任务 ready 了，就给 Epic #22 标 `needs:implementer`。Implementer 不应该“领取 Epic”，它应该领取 Epic 下面的 child issue。
+
+如果 Epic-level 的事情需要人执行，比如：
+
+```text
+Run integration QA and close Epic readiness gaps
+Fix cross-issue session / attempt integration gaps
+Add final manual QA evidence for Epic closure
+```
+
+那就新建一个 child issue。
+
+这条规则看起来小，其实很要命。它决定了 agent inbox 里出现的是“可以动手的任务”，而不是“一个大概需要你关心的阶段”。
+
+人可以理解含糊话。
+
+Agent 最好少吃含糊话。
+
+## 五、兜兜转转，又回到老本行
+
+把这些东西捋清楚以后，我突然有一种很微妙的感觉。
+
+这不是我二十年前刚入行时干过的事吗？
+
+那时候我的老本行，就是开发和部署配置管理、代码管理、流程管理系统。需求、任务、版本、分支、权限、状态流转、review、发布、回滚。系统的目标很清楚：让一群碳基程序员不要靠拍脑袋协作，不要靠吼一嗓子同步状态，不要靠“我以为你知道”推进项目。
+
+二十年后，我绕了一圈，又在做同一件事。
+
+只是服务对象变了。
+
+当年的系统是给人用的。
+
+现在这套系统，是给 agent 用的。
+
+人类开发者需要 issue、分支、PR、review、CI，是因为人的记忆会漏，沟通会偏，责任边界会糊。
+
+Agent 也一样。
+
+甚至更需要。
+
+因为 agent 没有稳定的组织记忆。上下文窗口一刷新，它就可能忘了前面为什么这么决定。你跟它说“继续上次的思路”，它也许能猜到，也许猜歪。你把规则写进 issue、comment、label、docs、practice，它就有东西可读，有状态可查，有边界可执行。
+
+这时候我才意识到，所谓“管理 agent”，并不是把 agent 当人一样开会。
+
+而是把软件工程里那些为人类发明的协作结构，重新校准给硅基同事使用。
+
+## 六、第二层顿悟：我在手搓 Agent Scheduler
+
+再往前想一层，就更好笑了。
+
+我本来只是想做个音标练习工具。
+
+做着做着，先变成了多 agent 协作。
+
+协作着协作着，又变成了 GitHub Project + Epic + label inbox + PR review + readiness gate。
+
+再往前推一步，这不就是一个简陋的智能体调度系统吗？
+
+只不过它没有漂亮的 dashboard，没有自动派单算法，没有 agent runtime，没有任务图数据库，也没有什么 MCP 大一统平台。
+
+它很土：
+
+```text
+GitHub issue 是任务对象
+Project Kanban 是状态机
+label 是 routing key
+comment 是消息体
+PR 是交付物
+CI 是自动验收
+人类是仲裁器
+```
+
+但是它已经有了调度系统的味道。
+
+谁该干活？
+
+看 label。
+
+干什么？
+
+看 issue body 和最新 comment。
+
+做到哪了？
+
+看 Project status。
+
+能不能合？
+
+看 PR、CI、review、completion comment。
+
+有没有跨任务风险？
+
+看 Epic。
+
+需要用户拍板吗？
+
+挂 `needs:user`。
+
+这套东西当然还很原始。但在 2026 年中，我很难相信只有我一个人在往这个方向走。
+
+所有严肃的、业余的、半夜不睡觉折腾 agent 的玩家，大概都在某种程度上摸这块石头。
+
+一个 agent 很有用。
+
+两个 agent 开始需要协作。
+
+三个 agent 就会需要调度。
+
+再往后，测试 agent、review agent、文档 agent、planner agent、implementer agent、practice harvester agent、CI fixer agent，各自都有强项，也各自都会犯傻。
+
+这时真正的问题不是“哪个模型最聪明”。
+
+而是“怎么让这些不稳定的聪明，稳定地流过一个工程系统”。
+
+成熟平台迟早会来。也许哪家公司会做出一个漂亮的 agent operating system，把任务拆解、上下文装载、权限隔离、成本控制、review gate、memory、practice 全部打包起来。
+
+但在那之前，手搓一个自己的小型 agent 调度管理系统，简直是每个 geek 很难抗拒的自然反应。
+
+尤其是它还真的能帮你干活。
+
+## 七、老登的茶杯暂时还放不下
+
+所以 tiny-ipa 表面上是一个音标练习工具。
+
+暗线却是另一件事：我们在训练一套多 agent 软件开发流程。
+
+Codex 不只是写文档，它开始扮演 architect。
+
+DeepSeek 不只是写代码，它开始扮演 implementer。
+
+GitHub 不只是代码托管，它变成了 agent 之间的共享工作台。
+
+Issue 不只是任务列表，它变成了上下文包。
+
+Label 不只是分类，它变成了调度信号。
+
+Comment 不只是留言，它变成了 agent-to-agent 的消息。
+
+Epic 不只是大 issue，它变成了跨任务的组织记忆。
+
+我也没有真的甩手。
+
+我只是从“亲自写每一行代码”，退到了“设计协作系统，让 agent 在里面少走弯路”。听起来还是老登，甚至更老登。
+
+但这次有点不一样。
+
+以前带人，流程是给人减轻沟通成本。
+
+现在带 agent，流程是给机器补上组织感。
+
+所谓 vibe coding，也许最后不是一个人对着一个 AI 许愿。
+
+它更像是在一张很小的 GitHub Project 看板上，慢慢搭出一个软件团队的影子。有人快，有人稳，有人 review，有人执行，有人记账，有人总结 practice。
+
+而人类端着茶杯，看着这些硅基同事在 label 和 comment 之间来回流转，偶尔忍不住感叹一句：
+
+兜兜转转，怎么又开始搞配置管理了。

--- a/docs/anecdote_Reinventing_agent_scheduler.md
+++ b/docs/anecdote_Reinventing_agent_scheduler.md
@@ -42,41 +42,17 @@ Codex 这边逐渐变成了 architect / reviewer / planner。先把整体架构�
 
 ## 二、我的工作变成了 Copy / Paste
 
-最早这种双 agent 协作非常土。
+最早这种双 agent 协作非常土，但有效。
 
-我在 Codex 这里讨论规划，Codex 生成 milestone 和 issue 草案。我复制到 GitHub。
+Codex 负责规划和 review，DeepSeek 负责执行。我负责在两个窗口之间转述：把计划贴过去，把完成报告贴回来，把 review 意见再贴过去。
 
-DeepSeek 在隔壁做完 M0，我回来告诉 Codex：“隔壁 DeepSeek 已经把 M0 做完了，你 review 一下。”
+这个模式跑了一阵以后，真正暴露出来的问题不是“agent 不会合作”，而是“合作缺少共享状态”。
 
-Codex review 出问题，我把 review comment 复制给 DeepSeek。
+只要共享状态还在我的剪贴板里，我就会变成人肉消息队列。谁该开工、谁该 review、哪个 issue 已经 ready、哪个 PR 需要补测试，这些信息都不应该靠我记着。
 
-DeepSeek 修完，我再回来告诉 Codex：“隔壁修好了，你再检查一下。”
+到这一步，问题已经不是 prompt engineering，而是 workflow engineering。
 
-Codex 说可以开工 M1，我再去通知 DeepSeek。
-
-这套流程居然能跑。
-
-而且越跑越顺。
-
-两个 agent 之间没有直接通信，也没有什么高大上的 agent orchestration framework。它们甚至不知道对方真实存在。它们只通过我的 copy / paste 彼此感知。
-
-但问题也很明显。
-
-我越来越像一个人肉消息队列。
-
-Architect 说：“这个 issue 需要 implementer 处理。”
-
-我复制。
-
-Implementer 说：“这个 PR 已经完成，请 review。”
-
-我复制。
-
-Architect 说：“这里有 blocker，不能 merge。”
-
-我再复制。
-
-这时老登终于拍了一下桌子：这不就是工作流状态流转吗？这不就是应该自动化的吗？
+所谓自动化，也不是让两个 agent 神秘地互相聊天，而是把“下一步该谁做什么”变成一个可查询、可更新、可审计的系统状态。
 
 ## 三、从 Issue 到 Milestone，再到 Epic
 
@@ -84,41 +60,27 @@ Architect 说：“这里有 blocker，不能 merge。”
 
 原因也简单：既然 agent 都能用 `gh`，既然 issue / PR / comment / label 都是可读可写的，那 GitHub 就是最便宜、最稳、最不用自己造后台的协作数据库。
 
-最开始只是用 issue 记 task。
+第一版很朴素：issue 记录 task，milestone 组织阶段，PR 承载代码交付。这已经足够让 DeepSeek 按 issue 执行，让 Codex 按 issue review。
 
-M0 要做什么，开几个 issue。M1 要做什么，再开几个 issue。每个 issue 写清楚背景、约束、验收标准、测试要求。DeepSeek 可以拿一个 issue 开工，Codex 可以基于 issue review。
+但 milestone 很快显出局限。
 
-这已经比“把一大段需求贴给 agent”强很多。
+Milestone 是时间切片，天然带有线性暗示：M0 完了再 M1，M1 完了再 M2。它适合表达路线图，却不适合表达多 agent 并行协作中的能力边界、依赖关系和集成验收。
 
-后来我们开始按 milestone 做规划、执行、review。
+更具体地说，milestone 有三个问题：
 
-M0 是 feasibility 和架构骨架。M1 是静态练习闭环。M2 是 SQLite 和服务端判题。M3 是核心 100 单词音频。每个 milestone 下面有一组 issue。做完以后，不是马上往前冲，而是先做 milestone-level review。
+* 它不擅长承载跨 issue 的 readiness 语义。一个阶段是否完成，不等于所有 issue mechanically closed。
+* 它容易把工作流串行化。多个 agent 本来可以并行推进不同能力，却被“当前 milestone”这个概念压回一条队列。
+* 它不是一个很好的讨论对象。跨 issue 风险、manual QA、integration gap、后续放行判断，都需要一个可以 comment、label、link child issue 的协调容器。
 
-这一步很关键。
+我们曾经用 milestone readiness issue 补这个洞，但这本质上是在给 milestone 外挂一个临时器官。
 
-因为有些问题不是某个 issue 独自负责的。
+Epic 才是更自然的边界。
 
-比如 M1 做完后，单个 issue 看起来都完成了，但整体手动 QA 有没有跑？英式 IPA 的选择题路径有没有真的用 UK accent？前端刷新后状态有没有保住？这些东西更像 integration review，而不是某个按钮 issue 的小尾巴。
+Epic 对应一个能力阶段，下面挂 child issues。Child issue 是执行单元，Epic 是协调单元。代码、测试、文档、manual QA 这些可以拆到 child issue；跨 issue 风险、readiness、scope decision 则留在 Epic。
 
-于是我们曾经发明了 milestone readiness issue。
+这样 milestone 就退回到路线图和历史阶段，Epic 成为真正的协作单位。
 
-看起来合理，但很快又别扭起来。
-
-Milestone 本质上还是线性的。M0 完了再 M1，M1 完了再 M2。它适合一个人排队干活，不适合多个 agent 同时往不同方向推进。
-
-更要命的是，readiness issue 有点像为了弥补 milestone 缺陷硬造出来的夹层。它不是能力本身，只是一个“等我检查完再放行”的门卫。
-
-这时候 Epic 出场了。
-
-我们把 milestone 对应的能力阶段转成 Epic issue：M2 是一个 Epic，下面挂 #10 到 #13；M3 是一个 Epic，下面挂 #14 到 #17。Epic 负责上下文、跨 issue 风险、集成验收、readiness。Child issue 负责具体执行。
-
-这一下舒服多了。
-
-不是“所有人排队等 M2 完了才能看 M3”，而是“每个 Epic 是一个能力容器，里面有可执行任务，任务之间有依赖，有些可以并行，有些需要等 readiness”。
-
-Milestone 退回成历史阶段和路线图标记。
-
-Epic 才是协作单位。
+这个变化的价值不在“名字更时髦”，而在它打破了线性阶段感，让多 agent 协作可以围绕能力图而不是时间队列展开。
 
 ## 四、技术夹层：我们最后揉出来的流程
 
@@ -221,17 +183,13 @@ Agent 也一样。
 
 ## 六、第二层顿悟：我在手搓 Agent Scheduler
 
-再往前想一层，就更好笑了。
+再往前想一层，这件事就更好笑了。
 
-我本来只是想做个音标练习工具。
+我本来只是想做个音标练习工具，结果先搭出了多 agent 协作流程，再把流程沉淀成 GitHub Project、Epic、label inbox、PR review 和 readiness gate。
 
-做着做着，先变成了多 agent 协作。
+换个名字看，这就是一个简陋的 agent scheduler。
 
-协作着协作着，又变成了 GitHub Project + Epic + label inbox + PR review + readiness gate。
-
-再往前推一步，这不就是一个简陋的智能体调度系统吗？
-
-只不过它没有漂亮的 dashboard，没有自动派单算法，没有 agent runtime，没有任务图数据库，也没有什么 MCP 大一统平台。
+它当然没有漂亮的 dashboard，没有自动派单算法，没有 agent runtime，也没有任务图数据库。
 
 它很土：
 
@@ -245,49 +203,13 @@ CI 是自动验收
 人类是仲裁器
 ```
 
-但是它已经有了调度系统的味道。
+但它已经具备调度系统最小闭环：任务对象、状态机、路由信号、上下文载体、交付物、验收门禁和人类仲裁。
 
-谁该干活？
+2026 年中，我很难相信只有我一个人在摸这块石头。一个 agent 可以靠对话驱动；两个 agent 就开始需要共享上下文；三个 agent 以后，调度、权限、成本、review、memory、handoff 都会变成显性问题。
 
-看 label。
+这时真正的问题不再是“哪个模型最聪明”，而是“怎么让这些不稳定的聪明，稳定地流过一个工程系统”。
 
-干什么？
-
-看 issue body 和最新 comment。
-
-做到哪了？
-
-看 Project status。
-
-能不能合？
-
-看 PR、CI、review、completion comment。
-
-有没有跨任务风险？
-
-看 Epic。
-
-需要用户拍板吗？
-
-挂 `needs:user`。
-
-这套东西当然还很原始。但在 2026 年中，我很难相信只有我一个人在往这个方向走。
-
-所有严肃的、业余的、半夜不睡觉折腾 agent 的玩家，大概都在某种程度上摸这块石头。
-
-一个 agent 很有用。
-
-两个 agent 开始需要协作。
-
-三个 agent 就会需要调度。
-
-再往后，测试 agent、review agent、文档 agent、planner agent、implementer agent、practice harvester agent、CI fixer agent，各自都有强项，也各自都会犯傻。
-
-这时真正的问题不是“哪个模型最聪明”。
-
-而是“怎么让这些不稳定的聪明，稳定地流过一个工程系统”。
-
-成熟平台迟早会来。也许哪家公司会做出一个漂亮的 agent operating system，把任务拆解、上下文装载、权限隔离、成本控制、review gate、memory、practice 全部打包起来。
+成熟平台迟早会来。也许某家公司会做出一个漂亮的 agent operating system，把任务拆解、上下文装载、权限隔离、成本控制、review gate、memory、practice 全部打包起来。
 
 但在那之前，手搓一个自己的小型 agent 调度管理系统，简直是每个 geek 很难抗拒的自然反应。
 
@@ -295,38 +217,18 @@ CI 是自动验收
 
 ## 七、老登的茶杯暂时还放不下
 
-所以 tiny-ipa 表面上是一个音标练习工具。
+所以 tiny-ipa 表面上是一个音标练习工具，暗线却是一套多 agent 软件开发流程的试验。
 
-暗线却是另一件事：我们在训练一套多 agent 软件开发流程。
+Codex 变成 architect，DeepSeek 变成 implementer。GitHub 从代码托管变成共享工作台，issue 变成上下文包，label 变成调度信号，comment 变成 agent-to-agent 的消息，Epic 变成跨任务的组织记忆。
 
-Codex 不只是写文档，它开始扮演 architect。
-
-DeepSeek 不只是写代码，它开始扮演 implementer。
-
-GitHub 不只是代码托管，它变成了 agent 之间的共享工作台。
-
-Issue 不只是任务列表，它变成了上下文包。
-
-Label 不只是分类，它变成了调度信号。
-
-Comment 不只是留言，它变成了 agent-to-agent 的消息。
-
-Epic 不只是大 issue，它变成了跨任务的组织记忆。
-
-我也没有真的甩手。
-
-我只是从“亲自写每一行代码”，退到了“设计协作系统，让 agent 在里面少走弯路”。听起来还是老登，甚至更老登。
-
-但这次有点不一样。
+我也没有真的甩手，只是从“亲自写每一行代码”，退到了“设计协作系统，让 agent 在里面少走弯路”。
 
 以前带人，流程是给人减轻沟通成本。
 
 现在带 agent，流程是给机器补上组织感。
 
-所谓 vibe coding，也许最后不是一个人对着一个 AI 许愿。
+所谓 vibe coding，也许最后不是一个人对着一个 AI 许愿，而是在一张很小的 GitHub Project 看板上，慢慢搭出一个软件团队的影子。
 
-它更像是在一张很小的 GitHub Project 看板上，慢慢搭出一个软件团队的影子。有人快，有人稳，有人 review，有人执行，有人记账，有人总结 practice。
-
-而人类端着茶杯，看着这些硅基同事在 label 和 comment 之间来回流转，偶尔忍不住感叹一句：
+人类端着茶杯，看着这些硅基同事在 label 和 comment 之间来回流转，偶尔忍不住感叹一句：
 
 兜兜转转，怎么又开始搞配置管理了。


### PR DESCRIPTION
## Summary\n- Add an anecdote-style document continuing the token-panic ViewModel anecdote\n- Capture the Tiny IPA multi-agent workflow story, milestone-to-Epic transition, and agent scheduler reflection\n- Link the anecdote from the design index\n\n## Verification\n- Markdown/documentation-only change\n- Branch has been pushed and no working-tree WIP remains