### PR TITLE
Document ready queue dependency workflow

### DIFF
--- a/docs/08-multi-agent-epic-workflow.md
+++ b/docs/08-multi-agent-epic-workflow.md
@@ -133,6 +133,26 @@ Merge rule: ...
 Verification required: ...
 ```
 
+`Ready` means the issue is planned, specified, and available for Implementer queue management. It does not always mean the issue can be coded immediately. The `Depends on` line is the executable gate.
+
+Architects may move a dependent sequence of child issues to `Ready` at the same time and label them `needs:implementer` when:
+
+- every issue has an execution contract
+- dependencies are explicit and checkable
+- all issue branches target the same Epic integration branch unless an exception is documented
+- the Implementer can continue the queue without another Architect handoff
+
+Implementers may queue multiple ready issues, but must execute them in dependency order. Do not create a working branch, code changes, or a PR for a dependent issue until its `Depends on` condition is satisfied.
+
+If a dependency is not satisfied yet, the Implementer may leave a queue comment:
+
+```markdown
+## Queued by Implementer
+
+Dependency not satisfied yet.
+Waiting for #... to merge into `epic/...`.
+```
+
 For the default Epic integration path:
 
 ```markdown
@@ -161,6 +181,8 @@ Working branch: `agent/<issue-number>-...`
 PR base: `...`
 Verification plan: ...
 ```
+
+Use `Pickup confirmed` only when dependencies are satisfied and implementation is actually starting.
 
 If the execution contract is missing or the intended PR base is unclear, the Implementer should move the issue to `needs:architect` instead of starting work.
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -39,6 +39,8 @@ When handing work to another role, update the label and add a short issue or PR 
 
 Do not put `needs:implementer` on an Epic. Implementers pick up child issues, not Epic containers. If an Epic-level concern requires execution, create a child task such as integration QA, cross-issue gap fixing, or final manual QA evidence.
 
+`Ready + needs:implementer` may represent an Implementer queue, not only work that can start immediately. Implementers should read all ready issues in the queue, sort them by the `Depends on` line in each `Execution Contract`, and execute only the issues whose dependencies are satisfied.
+
 When an issue returns from Architect review, read both the issue handoff comment and the linked PR comment:
 
 ```bash
@@ -69,12 +71,22 @@ Example: `agent/2-scaffold-fastapi-react-skeleton`
 1. Read the docs referenced in the issue body.
 2. Check the parent Epic for dependencies and readiness notes.
 3. Confirm the child issue is in `Ready`.
-4. Move the child issue to `In progress`.
-5. Read the issue's `Execution Contract`.
-6. Comment with `Pickup confirmed`, including branch strategy, working branch, PR base, and verification plan.
-7. Create the issue branch from the contract's base branch.
+4. Read the issue's `Execution Contract`.
+5. Confirm every `Depends on` condition is satisfied.
+6. Move the child issue to `In progress`.
+7. Comment with `Pickup confirmed`, including branch strategy, working branch, PR base, and verification plan.
+8. Create the issue branch from the contract's base branch.
 
 Do not start implementation if the `Execution Contract` is missing or the PR base is ambiguous. Move the issue to `needs:architect` and ask for the missing branch strategy.
+
+Do not start implementation for a dependent issue whose `Depends on` condition is not satisfied yet. Leave the issue in `Ready` and optionally add:
+
+```markdown
+## Queued by Implementer
+
+Dependency not satisfied yet.
+Waiting for #... to merge into `epic/...`.
+```
 
 ### When completing an issue
 
@@ -115,6 +127,8 @@ Residual risks:
 ### Branch strategy
 
 The Architect decides branch strategy before moving a child issue to `Ready`.
+
+The Architect may move a whole dependent issue sequence to `Ready` at once when each issue has an `Execution Contract`. This avoids repeated Architect handoffs between issues. The Implementer owns queue ordering from that point, but dependency gates still apply.
 
 Default:
 


### PR DESCRIPTION
## Summary

- clarify that `Ready + needs:implementer` can represent an ordered Implementer queue
- require Implementers to gate actual coding on `Execution Contract.Depends on`
- add `Queued by Implementer` guidance for dependent issues that are not ready to code yet
- update local development pickup steps to avoid repeated Architect handoffs between dependent issues

## Verification

- Documentation-only change; reviewed diff for consistency with the M3 queue handoff.
