### PR TITLE
[#15] Implement generate_tts_audio.py for US static MP3 assets

### DIFF
--- a/backend/scripts/generate_tts_audio.py
+++ b/backend/scripts/generate_tts_audio.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""Generate static MP3 audio assets for Tiny IPA content.
+
+Uses edge-tts (async) to generate audio files for each word in a content
+JSON. Designed for build-time use, not runtime.
+
+Usage:
+    cd backend && source .venv/bin/activate
+    python scripts/generate_tts_audio.py --source ../content/core_100_words.json
+
+Dry-run (no network):
+    python scripts/generate_tts_audio.py --source ../content/core_100_words.json --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Callable, Dict, List, Optional
+
+_HERE = Path(__file__).resolve().parent
+_REPO = _HERE.parent.parent
+
+DEFAULT_SOURCE = str(_REPO / "content" / "core_100_words.json")
+DEFAULT_OUTPUT_DIR = str(_REPO / "audio" / "us")
+DEFAULT_REPORT = str(_REPO / "content" / "generated" / "audio_report_us.json")
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def load_words(source_path: Path) -> List[dict]:
+    """Load words from JSON, supporting both top-level array and {words: [...]}."""
+    with open(source_path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    if isinstance(data, list):
+        return data
+    if isinstance(data, dict) and "words" in data:
+        return data["words"]
+    raise ValueError(f"Expected array or {{words: [...]}}, got {type(data).__name__}")
+
+
+def output_path_for_word(entry: dict, output_dir: Path, accent: str = "us") -> Path:
+    """Derive the output .mp3 path from a word entry's ``audio_us`` or word_id."""
+    audio_field = f"audio_{accent}"
+    audio_path = entry.get(audio_field, "")
+    if audio_path:
+        # /audio/us/ship.mp3 -> ship.mp3 under output_dir
+        fname = Path(audio_path).name
+    else:
+        wid = entry.get("word_id") or entry.get("word", "unknown")
+        fname = f"{wid}.mp3"
+    return output_dir / fname
+
+
+# ---------------------------------------------------------------------------
+# Generation
+# ---------------------------------------------------------------------------
+
+# Type alias for injectable generator: (text, output_path) -> None on success, raises on failure
+GenerateFn = Callable[[str, Path], None]
+
+
+async def _edge_tts_generate(text: str, out_path: Path) -> None:
+    """Generate an MP3 file using edge-tts (async).
+
+    Raises RuntimeError on failure. The caller is responsible for ensuring
+    ``edge_tts`` is installed (``pip install edge-tts``).
+    """
+    try:
+        import edge_tts  # noqa: F811
+    except ImportError:
+        raise RuntimeError(
+            "edge-tts is not installed. Run: pip install edge-tts"
+        ) from None
+
+    voice = os.getenv("TTS_VOICE_US", "en-US-JennyNeural")
+    communicate = edge_tts.Communicate(text, voice)
+    await communicate.save(str(out_path))
+
+
+async def generate_audio_files(
+    words: List[dict],
+    *,
+    output_dir: Path,
+    accent: str = "us",
+    only_missing: bool = False,
+    dry_run: bool = False,
+    limit: Optional[int] = None,
+    generate_fn: Optional[GenerateFn] = None,
+) -> dict:
+    """Generate MP3 files for a list of word entries.
+
+    Args:
+        words: Word entry dicts with ``word_id`` and ``audio_us``/``audio_uk``.
+        output_dir: Where to write .mp3 files.
+        accent: ``"us"`` or ``"uk"``.
+        only_missing: Skip words whose output file already exists.
+        dry_run: Do everything except actually generate audio.
+        limit: Only process at most this many words.
+        generate_fn: Pluggable generator for testing. Defaults to edge-tts.
+
+    Returns:
+        Report dict with ``generated``, ``skipped``, ``failed``, ``total``,
+        ``failures`` list, and ``dry_run`` boolean.
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    report: dict = {
+        "generated": 0,
+        "skipped": 0,
+        "failed": 0,
+        "total": 0,
+        "dry_run": dry_run,
+        "failures": [],
+    }
+
+    gen = generate_fn or _edge_tts_generate
+    entries = words[:limit] if limit else words
+
+    for entry in entries:
+        report["total"] += 1
+        wid = entry.get("word_id") or entry.get("word", "")
+        out_path = output_path_for_word(entry, output_dir, accent)
+
+        # Skip existing files
+        if only_missing and out_path.exists() and out_path.stat().st_size > 0:
+            report["skipped"] += 1
+            continue
+
+        if dry_run:
+            report["generated"] += 1
+            continue
+
+        try:
+            # Determine TTS text: use the word itself
+            text = entry.get("word", str(wid))
+            await gen(text, out_path)
+            report["generated"] += 1
+        except Exception as exc:
+            report["failed"] += 1
+            report["failures"].append({
+                "word_id": wid,
+                "word": entry.get("word", ""),
+                "output": str(out_path),
+                "reason": str(exc),
+            })
+
+    return report
+
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+
+
+def write_report(report: dict, report_path: Path) -> None:
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(report_path, "w", encoding="utf-8") as f:
+        json.dump(report, f, indent=2, ensure_ascii=False)
+
+
+def print_report(report: dict) -> None:
+    print("=" * 60)
+    print("Tiny IPA Audio Generation Report")
+    print("=" * 60)
+    mode = "DRY RUN" if report["dry_run"] else "LIVE"
+    print(f"Mode:      {mode}")
+    print(f"Total:     {report['total']}")
+    print(f"Generated: {report['generated']}")
+    print(f"Skipped:   {report['skipped']}")
+    print(f"Failed:    {report['failed']}")
+    if report["failures"]:
+        print()
+        print("--- Failures ---")
+        for f in report["failures"]:
+            print(f"  {f['word_id']}: {f['reason']}")
+    print("=" * 60)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate static MP3 audio for Tiny IPA content."
+    )
+    parser.add_argument("--source", default=DEFAULT_SOURCE, help="Path to words JSON.")
+    parser.add_argument("--accent", default="us", choices=["us", "uk"], help="Accent (default: us).")
+    parser.add_argument("--output-dir", default=None, help="Output directory (default: ../audio/<accent>).")
+    parser.add_argument("--only-missing", action="store_true", help="Skip words with existing audio files.")
+    parser.add_argument("--dry-run", action="store_true", help="Run without making network calls.")
+    parser.add_argument("--limit", type=int, default=None, help="Limit to N words (for testing).")
+    parser.add_argument("--report", default=None, help="Path to write JSON report.")
+    parser.add_argument("--json", action="store_true", help="Print report as JSON to stdout.")
+    args = parser.parse_args()
+
+    source_path = Path(args.source)
+    if not source_path.exists():
+        print(f"Error: source file not found: {source_path}", file=sys.stderr)
+        sys.exit(1)
+
+    output_dir = Path(args.output_dir) if args.output_dir else Path(DEFAULT_OUTPUT_DIR)
+
+    words = load_words(source_path)
+
+    async def _run():
+        return await generate_audio_files(
+            words,
+            output_dir=output_dir,
+            accent=args.accent,
+            only_missing=args.only_missing,
+            dry_run=args.dry_run,
+            limit=args.limit,
+        )
+
+    report = asyncio.run(_run())
+
+    report_path = Path(args.report) if args.report else Path(DEFAULT_REPORT)
+    write_report(report, report_path)
+
+    if args.json:
+        print(json.dumps(report, indent=2, default=str))
+    else:
+        print_report(report)
+
+    if report["failed"]:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/scripts/generate_tts_audio.py
+++ b/backend/scripts/generate_tts_audio.py
@@ -211,6 +211,8 @@ def main() -> None:
                         help="Output directory (default: ../audio/<accent>).")
     parser.add_argument("--overwrite", action="store_true",
                         help="Overwrite existing audio files (default: skip existing).")
+    parser.add_argument("--only-missing", action="store_true",
+                        help="Compatibility alias — existing files are skipped by default.")
     parser.add_argument("--voice", default="",
                         help="TTS voice name, e.g. en-US-JennyNeural (default: env or edge-tts default).")
     parser.add_argument("--dry-run", action="store_true",

--- a/backend/scripts/generate_tts_audio.py
+++ b/backend/scripts/generate_tts_audio.py
@@ -10,6 +10,9 @@ Usage:
 
 Dry-run (no network):
     python scripts/generate_tts_audio.py --source ../content/core_100_words.json --dry-run
+
+Default behaviour: existing files are never overwritten unless
+``--overwrite`` is passed.
 """
 
 from __future__ import annotations
@@ -20,14 +23,21 @@ import json
 import os
 import sys
 from pathlib import Path
-from typing import Callable, Dict, List, Optional
+from typing import Callable, List, Optional
 
 _HERE = Path(__file__).resolve().parent
 _REPO = _HERE.parent.parent
 
 DEFAULT_SOURCE = str(_REPO / "content" / "core_100_words.json")
-DEFAULT_OUTPUT_DIR = str(_REPO / "audio" / "us")
-DEFAULT_REPORT = str(_REPO / "content" / "generated" / "audio_report_us.json")
+
+
+def _default_output_dir(accent: str) -> str:
+    return str(_REPO / "audio" / accent)
+
+
+def _default_report(accent: str) -> str:
+    return str(_REPO / "content" / "generated" / f"audio_report_{accent}.json")
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -50,7 +60,6 @@ def output_path_for_word(entry: dict, output_dir: Path, accent: str = "us") -> P
     audio_field = f"audio_{accent}"
     audio_path = entry.get(audio_field, "")
     if audio_path:
-        # /audio/us/ship.mp3 -> ship.mp3 under output_dir
         fname = Path(audio_path).name
     else:
         wid = entry.get("word_id") or entry.get("word", "unknown")
@@ -62,11 +71,11 @@ def output_path_for_word(entry: dict, output_dir: Path, accent: str = "us") -> P
 # Generation
 # ---------------------------------------------------------------------------
 
-# Type alias for injectable generator: (text, output_path) -> None on success, raises on failure
-GenerateFn = Callable[[str, Path], None]
+# Type alias for injectable generator
+GenerateFn = Callable[[str, Path, str], None]
 
 
-async def _edge_tts_generate(text: str, out_path: Path) -> None:
+async def _edge_tts_generate(text: str, out_path: Path, voice: str = "") -> None:
     """Generate an MP3 file using edge-tts (async).
 
     Raises RuntimeError on failure. The caller is responsible for ensuring
@@ -79,8 +88,8 @@ async def _edge_tts_generate(text: str, out_path: Path) -> None:
             "edge-tts is not installed. Run: pip install edge-tts"
         ) from None
 
-    voice = os.getenv("TTS_VOICE_US", "en-US-JennyNeural")
-    communicate = edge_tts.Communicate(text, voice)
+    v = voice or os.getenv("TTS_VOICE_US", "en-US-JennyNeural")
+    communicate = edge_tts.Communicate(text, v)
     await communicate.save(str(out_path))
 
 
@@ -89,9 +98,10 @@ async def generate_audio_files(
     *,
     output_dir: Path,
     accent: str = "us",
-    only_missing: bool = False,
+    overwrite: bool = False,
     dry_run: bool = False,
     limit: Optional[int] = None,
+    voice: str = "",
     generate_fn: Optional[GenerateFn] = None,
 ) -> dict:
     """Generate MP3 files for a list of word entries.
@@ -100,9 +110,12 @@ async def generate_audio_files(
         words: Word entry dicts with ``word_id`` and ``audio_us``/``audio_uk``.
         output_dir: Where to write .mp3 files.
         accent: ``"us"`` or ``"uk"``.
-        only_missing: Skip words whose output file already exists.
+        overwrite: If True, overwrite existing files. Defaults to False
+                   (existing non-empty files are skipped).
         dry_run: Do everything except actually generate audio.
         limit: Only process at most this many words.
+        voice: TTS voice name (e.g. ``"en-US-JennyNeural"``). If empty,
+               falls back to env var or edge-tts default.
         generate_fn: Pluggable generator for testing. Defaults to edge-tts.
 
     Returns:
@@ -128,8 +141,8 @@ async def generate_audio_files(
         wid = entry.get("word_id") or entry.get("word", "")
         out_path = output_path_for_word(entry, output_dir, accent)
 
-        # Skip existing files
-        if only_missing and out_path.exists() and out_path.stat().st_size > 0:
+        # Default: skip existing non-empty files unless --overwrite
+        if not overwrite and out_path.exists() and out_path.stat().st_size > 0:
             report["skipped"] += 1
             continue
 
@@ -138,9 +151,8 @@ async def generate_audio_files(
             continue
 
         try:
-            # Determine TTS text: use the word itself
             text = entry.get("word", str(wid))
-            await gen(text, out_path)
+            await gen(text, out_path, voice)
             report["generated"] += 1
         except Exception as exc:
             report["failed"] += 1
@@ -193,13 +205,22 @@ def main() -> None:
         description="Generate static MP3 audio for Tiny IPA content."
     )
     parser.add_argument("--source", default=DEFAULT_SOURCE, help="Path to words JSON.")
-    parser.add_argument("--accent", default="us", choices=["us", "uk"], help="Accent (default: us).")
-    parser.add_argument("--output-dir", default=None, help="Output directory (default: ../audio/<accent>).")
-    parser.add_argument("--only-missing", action="store_true", help="Skip words with existing audio files.")
-    parser.add_argument("--dry-run", action="store_true", help="Run without making network calls.")
-    parser.add_argument("--limit", type=int, default=None, help="Limit to N words (for testing).")
-    parser.add_argument("--report", default=None, help="Path to write JSON report.")
-    parser.add_argument("--json", action="store_true", help="Print report as JSON to stdout.")
+    parser.add_argument("--accent", default="us", choices=["us", "uk"],
+                        help="Accent (default: us). Determines output/report defaults.")
+    parser.add_argument("--output-dir", default=None,
+                        help="Output directory (default: ../audio/<accent>).")
+    parser.add_argument("--overwrite", action="store_true",
+                        help="Overwrite existing audio files (default: skip existing).")
+    parser.add_argument("--voice", default="",
+                        help="TTS voice name, e.g. en-US-JennyNeural (default: env or edge-tts default).")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Run without making network calls.")
+    parser.add_argument("--limit", type=int, default=None,
+                        help="Limit to N words (for testing).")
+    parser.add_argument("--report", default=None,
+                        help="Path to write JSON report (default: content/generated/audio_report_<accent>.json).")
+    parser.add_argument("--json", action="store_true",
+                        help="Print report as JSON to stdout.")
     args = parser.parse_args()
 
     source_path = Path(args.source)
@@ -207,7 +228,9 @@ def main() -> None:
         print(f"Error: source file not found: {source_path}", file=sys.stderr)
         sys.exit(1)
 
-    output_dir = Path(args.output_dir) if args.output_dir else Path(DEFAULT_OUTPUT_DIR)
+    accent = args.accent
+    output_dir = Path(args.output_dir) if args.output_dir else Path(_default_output_dir(accent))
+    report_path = Path(args.report) if args.report else Path(_default_report(accent))
 
     words = load_words(source_path)
 
@@ -215,15 +238,14 @@ def main() -> None:
         return await generate_audio_files(
             words,
             output_dir=output_dir,
-            accent=args.accent,
-            only_missing=args.only_missing,
+            accent=accent,
+            overwrite=args.overwrite,
             dry_run=args.dry_run,
             limit=args.limit,
+            voice=args.voice,
         )
 
     report = asyncio.run(_run())
-
-    report_path = Path(args.report) if args.report else Path(DEFAULT_REPORT)
     write_report(report, report_path)
 
     if args.json:

--- a/backend/tests/test_generate_tts_audio.py
+++ b/backend/tests/test_generate_tts_audio.py
@@ -28,9 +28,9 @@ FIXTURES = Path(__file__).resolve().parent / "fixtures"
 # ---------------------------------------------------------------------------
 
 
-async def _fake_generate(text: str, out_path: Path) -> None:
+async def _fake_generate(text: str, out_path: Path, voice: str = "") -> None:
     out_path.parent.mkdir(parents=True, exist_ok=True)
-    out_path.write_text(f"fake mp3: {text}\n")
+    out_path.write_text(f"fake mp3: {text} voice={voice}\n")
 
 
 # ---------------------------------------------------------------------------
@@ -99,7 +99,8 @@ class TestGenerateAudio:
         assert (tmp_path / "ship.mp3").exists()
         assert (tmp_path / "cat.mp3").exists()
 
-    def test_only_missing_skips_existing(self, tmp_path):
+    def test_skips_existing_by_default(self, tmp_path):
+        """Default behaviour: existing non-empty files are skipped (no overwrite)."""
         existing = tmp_path / "ship.mp3"
         existing.write_text("already here")
         words = [
@@ -107,12 +108,27 @@ class TestGenerateAudio:
             {"word_id": "cat", "word": "cat", "audio_us": "/audio/us/cat.mp3"},
         ]
         report = asyncio.run(generate_audio_files(
-            words, output_dir=tmp_path, accent="us",
-            only_missing=True, generate_fn=_fake_generate,
+            words, output_dir=tmp_path, accent="us", generate_fn=_fake_generate,
         ))
         assert report["skipped"] == 1
         assert report["generated"] == 1
         assert existing.read_text() == "already here"
+
+    def test_overwrite_replaces_existing(self, tmp_path):
+        """With --overwrite, existing files are overwritten."""
+        existing = tmp_path / "ship.mp3"
+        existing.write_text("old content")
+        words = [
+            {"word_id": "ship", "word": "ship", "audio_us": "/audio/us/ship.mp3"},
+        ]
+        report = asyncio.run(generate_audio_files(
+            words, output_dir=tmp_path, accent="us",
+            overwrite=True, generate_fn=_fake_generate,
+        ))
+        assert report["generated"] == 1
+        assert report["skipped"] == 0
+        # Content was overwritten
+        assert "fake mp3" in existing.read_text()
 
     def test_per_word_failure(self, tmp_path):
         words = [
@@ -121,7 +137,7 @@ class TestGenerateAudio:
             {"word_id": "bad", "word": "bad"},
         ]
 
-        async def _selective_fail(text: str, out_path: Path) -> None:
+        async def _selective_fail(text: str, out_path: Path, voice: str = "") -> None:
             if text in ("fail", "bad"):
                 raise RuntimeError(f"test failure: {text}")
             await _fake_generate(text, out_path)

--- a/backend/tests/test_generate_tts_audio.py
+++ b/backend/tests/test_generate_tts_audio.py
@@ -1,0 +1,181 @@
+"""Tests for generate_tts_audio.py — no real network calls."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+from generate_tts_audio import (  # noqa: E402
+    generate_audio_files,
+    load_words,
+    output_path_for_word,
+    write_report,
+)
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures"
+
+
+# ---------------------------------------------------------------------------
+# Fake generator
+# ---------------------------------------------------------------------------
+
+
+async def _fake_generate(text: str, out_path: Path) -> None:
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(f"fake mp3: {text}\n")
+
+
+# ---------------------------------------------------------------------------
+# Output path derivation
+# ---------------------------------------------------------------------------
+
+
+class TestOutputPath:
+    def test_from_audio_us_field(self, tmp_path):
+        entry = {"word_id": "ship", "word": "ship", "audio_us": "/audio/us/ship.mp3"}
+        got = output_path_for_word(entry, tmp_path, "us")
+        assert got == tmp_path / "ship.mp3"
+
+    def test_fallback_from_word_id(self, tmp_path):
+        entry = {"word_id": "ship", "word": "ship"}
+        got = output_path_for_word(entry, tmp_path, "us")
+        assert got == tmp_path / "ship.mp3"
+
+    def test_uk_accent(self, tmp_path):
+        entry = {"word_id": "ship", "word": "ship", "audio_uk": "/audio/uk/ship.mp3"}
+        got = output_path_for_word(entry, tmp_path, "uk")
+        assert got == tmp_path / "ship.mp3"
+
+
+# ---------------------------------------------------------------------------
+# Word loading
+# ---------------------------------------------------------------------------
+
+
+class TestLoadWords:
+    def test_load_array(self, tmp_path):
+        p = tmp_path / "words.json"
+        p.write_text(json.dumps([{"word_id": "a"}, {"word_id": "b"}]))
+        words = load_words(p)
+        assert len(words) == 2
+
+    def test_load_words_key(self, tmp_path):
+        p = tmp_path / "words.json"
+        p.write_text(json.dumps({"_note": "core 100", "words": [{"word_id": "x"}]}))
+        words = load_words(p)
+        assert len(words) == 1
+
+    def test_load_invalid(self, tmp_path):
+        p = tmp_path / "words.json"
+        p.write_text('{"not_words": 1}')
+        with pytest.raises(ValueError):
+            load_words(p)
+
+
+# ---------------------------------------------------------------------------
+# Generation (using asyncio.run — no pytest-asyncio dependency)
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateAudio:
+    def test_generates_files(self, tmp_path):
+        words = [
+            {"word_id": "ship", "word": "ship", "audio_us": "/audio/us/ship.mp3"},
+            {"word_id": "cat", "word": "cat", "audio_us": "/audio/us/cat.mp3"},
+        ]
+        report = asyncio.run(generate_audio_files(
+            words, output_dir=tmp_path, accent="us", generate_fn=_fake_generate,
+        ))
+        assert report["generated"] == 2
+        assert report["failed"] == 0
+        assert (tmp_path / "ship.mp3").exists()
+        assert (tmp_path / "cat.mp3").exists()
+
+    def test_only_missing_skips_existing(self, tmp_path):
+        existing = tmp_path / "ship.mp3"
+        existing.write_text("already here")
+        words = [
+            {"word_id": "ship", "word": "ship", "audio_us": "/audio/us/ship.mp3"},
+            {"word_id": "cat", "word": "cat", "audio_us": "/audio/us/cat.mp3"},
+        ]
+        report = asyncio.run(generate_audio_files(
+            words, output_dir=tmp_path, accent="us",
+            only_missing=True, generate_fn=_fake_generate,
+        ))
+        assert report["skipped"] == 1
+        assert report["generated"] == 1
+        assert existing.read_text() == "already here"
+
+    def test_per_word_failure(self, tmp_path):
+        words = [
+            {"word_id": "good", "word": "good"},
+            {"word_id": "fail", "word": "fail"},
+            {"word_id": "bad", "word": "bad"},
+        ]
+
+        async def _selective_fail(text: str, out_path: Path) -> None:
+            if text in ("fail", "bad"):
+                raise RuntimeError(f"test failure: {text}")
+            await _fake_generate(text, out_path)
+
+        report = asyncio.run(generate_audio_files(
+            words, output_dir=tmp_path, accent="us", generate_fn=_selective_fail,
+        ))
+        assert report["generated"] == 1
+        assert report["failed"] == 2
+        assert len(report["failures"]) == 2
+        assert report["failures"][0]["word_id"] == "fail"
+        assert report["failures"][1]["word_id"] == "bad"
+        assert (tmp_path / "good.mp3").exists()
+
+    def test_dry_run_no_files(self, tmp_path):
+        words = [
+            {"word_id": "ship", "word": "ship"},
+            {"word_id": "cat", "word": "cat"},
+        ]
+        report = asyncio.run(generate_audio_files(
+            words, output_dir=tmp_path, accent="us",
+            dry_run=True, generate_fn=_fake_generate,
+        ))
+        assert report["generated"] == 2
+        assert report["dry_run"] is True
+        assert not (tmp_path / "ship.mp3").exists()
+
+    def test_limit(self, tmp_path):
+        words = [{"word_id": f"w{i}", "word": f"w{i}"} for i in range(10)]
+        report = asyncio.run(generate_audio_files(
+            words, output_dir=tmp_path, accent="us",
+            limit=3, generate_fn=_fake_generate,
+        ))
+        assert report["total"] == 3
+        assert report["generated"] == 3
+
+    def test_report_shape(self, tmp_path):
+        words = [{"word_id": "x", "word": "x"}]
+        report = asyncio.run(generate_audio_files(
+            words, output_dir=tmp_path, accent="us", generate_fn=_fake_generate,
+        ))
+        for key in ("generated", "skipped", "failed", "total", "failures", "dry_run"):
+            assert key in report, f"missing key: {key}"
+
+
+# ---------------------------------------------------------------------------
+# Report writing
+# ---------------------------------------------------------------------------
+
+
+class TestReport:
+    def test_write_report(self, tmp_path):
+        rp = tmp_path / "report.json"
+        write_report({"generated": 1, "skipped": 0, "failed": 0, "total": 1}, rp)
+        assert rp.exists()
+        data = json.loads(rp.read_text())
+        assert data["generated"] == 1


### PR DESCRIPTION
Closes #15

## Scope completed
- `generate_tts_audio.py` — async edge-tts audio generation script
  - `--source`, `--accent`, `--output-dir`, `--only-missing`, `--dry-run`, `--limit`
  - Pluggable generate_fn for testing
  - Per-word failure reporting
  - Writes audio report JSON
- `test_generate_tts_audio.py` — 13 tests (no network calls)

## Verification
- Dry-run on Core 100: 100/100 would generate, 0 failures
- All 97 backend tests pass (0 regressions)