### PR TITLE
Add agent GitHub workflow helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ content/sources/
 .env
 .env.*
 !.env.example
+
+# Local agent helper cache
+.agent-cache/

--- a/docs/08-multi-agent-epic-workflow.md
+++ b/docs/08-multi-agent-epic-workflow.md
@@ -144,6 +144,14 @@ Architects may move a dependent sequence of child issues to `Ready` at the same 
 
 Implementers may queue multiple ready issues, but must execute them in dependency order. Do not create a working branch, code changes, or a PR for a dependent issue until its `Depends on` condition is satisfied.
 
+Avoid making review of each earlier issue a default queue-wide blocker. A child issue review blocks later implementation only when:
+
+- the later issue has an explicit `Depends on` gate that is not satisfied
+- the Architect adds a clear Epic-level hold comment
+- the review finding changes a shared contract that later issues would build on
+
+Otherwise, later ready issues can continue while earlier PRs are being reviewed. This keeps the workflow closer to fail-fast iteration instead of turning the Architect into a manual release valve after every child issue.
+
 If a dependency is not satisfied yet, the Implementer may leave a queue comment:
 
 ```markdown
@@ -275,16 +283,19 @@ Agent pickup commands:
 
 ```bash
 # Architect inbox
-gh issue list -R farmerhunter/tiny-ipa --state open --label needs:architect
+tools/agents/agent-inbox architect
 
 # Implementer inbox
-gh issue list -R farmerhunter/tiny-ipa --state open --label needs:implementer
+tools/agents/agent-inbox implementer
+
+# Implementer queue with dependency gates
+tools/agents/agent-ready-queue
 
 # User-decision queue
-gh issue list -R farmerhunter/tiny-ipa --state open --label needs:user
+tools/agents/agent-inbox user
 
 # Merge queue
-gh issue list -R farmerhunter/tiny-ipa --state open --label needs:merge
+tools/agents/agent-inbox merge
 ```
 
 When changing handoff ownership, always add a short comment that states what changed and what the next agent should do. The label is the routing signal; the comment is the context.
@@ -330,8 +341,8 @@ Do not rely on issue comments alone for a PR-specific or stacked-branch handoff.
 Implementer re-review pickup command:
 
 ```bash
-gh issue list -R farmerhunter/tiny-ipa --state open --label needs:implementer
-gh issue view <issue-number> -R farmerhunter/tiny-ipa --comments
+tools/agents/agent-inbox implementer
+tools/agents/agent-issue-context <issue-number>
 gh pr view <pr-number> -R farmerhunter/tiny-ipa --comments
 ```
 
@@ -406,6 +417,26 @@ The readiness comment should state whether downstream Epics may move from `Backl
 ## GitHub CLI Notes
 
 Prefer labels for agent pickup because they are fast, portable, and supported by `gh issue list`. GitHub Project v2 fields are still useful as the visual board, but Project item updates require Project item IDs, field IDs, and option IDs, which makes automation slower and more brittle.
+
+Tiny IPA has project-local helpers under `tools/agents/`:
+
+```bash
+tools/agents/agent-inbox architect
+tools/agents/agent-inbox implementer
+tools/agents/agent-ready-queue
+tools/agents/agent-issue-context <issue-number>
+tools/agents/agent-project-status <issue-number> "In Review"
+```
+
+Use these helpers first in daily agent work. They standardize retries, avoid unnecessary Project v2 reads, and cache Project item IDs in `.agent-cache/` when a Project status update is needed.
+
+Operational rule:
+
+```text
+Daily routing: labels + issue/PR comments
+Human board sync: Project status, updated after labels/comments
+Full Project scans: rare, cached, and not part of ordinary inbox lookup
+```
 
 Observed limitations and mitigations:
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -23,28 +23,35 @@ Use `needs:*` labels as the cross-agent handoff inbox. Project status remains th
 
 ```bash
 # Architect: planning, review, merge, readiness
-gh issue list -R farmerhunter/tiny-ipa --state open --label needs:architect
+tools/agents/agent-inbox architect
 
 # Implementer: coding, fixes, verification
-gh issue list -R farmerhunter/tiny-ipa --state open --label needs:implementer
+tools/agents/agent-inbox implementer
+
+# Implementer queue with dependency gates
+tools/agents/agent-ready-queue
 
 # User decision needed
-gh issue list -R farmerhunter/tiny-ipa --state open --label needs:user
+tools/agents/agent-inbox user
 
 # Ready to merge
-gh issue list -R farmerhunter/tiny-ipa --state open --label needs:merge
+tools/agents/agent-inbox merge
 ```
 
 When handing work to another role, update the label and add a short issue or PR comment explaining the next action.
+
+The raw `gh issue list` commands still work, but agents should prefer the local helpers above. They use retry defaults, avoid Project v2 queries during ordinary pickup, and keep the command surface consistent across Codex, Claude Code, DeepSeek, and similar environments.
 
 Do not put `needs:implementer` on an Epic. Implementers pick up child issues, not Epic containers. If an Epic-level concern requires execution, create a child task such as integration QA, cross-issue gap fixing, or final manual QA evidence.
 
 `Ready + needs:implementer` may represent an Implementer queue, not only work that can start immediately. Implementers should read all ready issues in the queue, sort them by the `Depends on` line in each `Execution Contract`, and execute only the issues whose dependencies are satisfied.
 
+Do not make every child issue review a queue-wide stop. A previous issue's review blocks later implementation only when the later issue's `Execution Contract` says so with a hard `Depends on` gate, or when the Architect posts an explicit hold on the Epic. Otherwise the Implementer may continue through the ready queue and let review feedback converge through the normal PR cycle.
+
 When an issue returns from Architect review, read both the issue handoff comment and the linked PR comment:
 
 ```bash
-gh issue view <issue-number> -R farmerhunter/tiny-ipa --comments
+tools/agents/agent-issue-context <issue-number>
 gh pr view <pr-number> -R farmerhunter/tiny-ipa --comments
 ```
 
@@ -157,6 +164,17 @@ Backlog -> Ready -> In progress -> In Review -> Done
 ```
 
 Architect moves work from `Backlog` to `Ready`. Implementer moves claimed work to `In progress` and then `In Review` once the PR is open. Architect moves it to `Done` only after merge, issue closure, and required verification.
+
+Use labels and comments first; sync Project status after the routing signal is already durable. For Project updates, prefer:
+
+```bash
+tools/agents/agent-project-status <issue-number> Ready
+tools/agents/agent-project-status <issue-number> "In progress"
+tools/agents/agent-project-status <issue-number> "In Review"
+tools/agents/agent-project-status <issue-number> Done
+```
+
+The helper caches Project item IDs under `.agent-cache/` to avoid repeated full Project scans.
 
 Handoff labels must match the current owner of the next action:
 

--- a/tools/agents/README.md
+++ b/tools/agents/README.md
@@ -1,0 +1,47 @@
+# Agent GitHub Helpers
+
+These helpers are project-local experiments for speeding up the Tiny IPA
+multi-agent workflow. They prefer issue labels and comments for daily routing,
+and touch GitHub Project v2 only when a human-visible Kanban status must change.
+
+## Fast Inbox
+
+```bash
+tools/agents/agent-inbox architect
+tools/agents/agent-inbox implementer
+tools/agents/agent-ready-queue
+```
+
+`agent-inbox` reads `needs:*` labels only. It deliberately avoids Project v2
+queries because labels are faster and more reliable for agent pickup.
+
+`agent-ready-queue` extracts `Execution Contract` lines so an Implementer can
+see which ready issues are immediately startable and which are waiting on
+`Depends on`.
+
+## Context Pickup
+
+```bash
+tools/agents/agent-issue-context 15
+```
+
+Use this before pickup, review, or re-review. The command prints the issue,
+comments, and likely open PRs.
+
+## Project Status
+
+```bash
+tools/agents/agent-project-status 15 "In progress"
+tools/agents/agent-project-status 15 "In Review"
+tools/agents/agent-project-status 15 Done
+```
+
+Project v2 item IDs are cached in `.agent-cache/project-items.tsv`. Refresh
+manually when needed:
+
+```bash
+tools/agents/agent-project-status --refresh
+```
+
+Do not use Project status as the only routing signal. Update labels and comments
+first, then sync Project status for the visual board.

--- a/tools/agents/agent-inbox
+++ b/tools/agents/agent-inbox
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo="${GH_REPO:-farmerhunter/tiny-ipa}"
+limit="${AGENT_INBOX_LIMIT:-30}"
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+gh_retry="$root/tools/agents/gh-retry"
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  tools/agents/agent-inbox <architect|implementer|user|ci|merge|blocked|all>
+
+Lists the machine-readable agent inbox from issue labels.
+Project v2 status is intentionally not queried here.
+USAGE
+}
+
+label_for_role() {
+  case "$1" in
+    architect) echo "needs:architect" ;;
+    implementer) echo "needs:implementer" ;;
+    user) echo "needs:user" ;;
+    ci) echo "needs:ci" ;;
+    merge) echo "needs:merge" ;;
+    blocked) echo "blocked" ;;
+    *) return 1 ;;
+  esac
+}
+
+print_label() {
+  local label="$1"
+  printf '\n== %s ==\n' "$label"
+  "$gh_retry" gh issue list \
+    --repo "$repo" \
+    --state open \
+    --label "$label" \
+    --limit "$limit" \
+    --json number,title,url,updatedAt \
+    --jq '.[] | "#\(.number) \(.title)\n  \(.url)\n  updated: \(.updatedAt)"'
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" || $# -ne 1 ]]; then
+  usage
+  exit 0
+fi
+
+role="$1"
+
+if [[ "$role" == "all" ]]; then
+  for item in architect implementer user ci merge blocked; do
+    print_label "$(label_for_role "$item")"
+  done
+  exit 0
+fi
+
+label="$(label_for_role "$role")" || {
+  usage >&2
+  exit 2
+}
+
+print_label "$label"

--- a/tools/agents/agent-issue-context
+++ b/tools/agents/agent-issue-context
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo="${GH_REPO:-farmerhunter/tiny-ipa}"
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+gh_retry="$root/tools/agents/gh-retry"
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  tools/agents/agent-issue-context <issue-number>
+
+Prints the issue body, labels, latest comments, and open PR candidates.
+Use this before pickup, re-review, or handoff.
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" || $# -ne 1 ]]; then
+  usage
+  exit 0
+fi
+
+issue="$1"
+
+printf '== Issue #%s ==\n' "$issue"
+"$gh_retry" gh issue view "$issue" \
+  --repo "$repo" \
+  --json number,title,state,labels,url,body \
+  --jq '"#\(.number) \(.title)\nstate: \(.state)\nurl: \(.url)\nlabels: \([.labels[].name] | join(", "))\n\n" + (.body // "")'
+
+printf '\n== Comments ==\n'
+"$gh_retry" gh issue view "$issue" \
+  --repo "$repo" \
+  --comments
+
+printf '\n== Open PR candidates ==\n'
+"$gh_retry" gh pr list \
+  --repo "$repo" \
+  --state open \
+  --limit 50 \
+  --json number,title,url,headRefName,baseRefName,labels,updatedAt \
+  --jq ".[] | select((.title | contains(\"#$issue\")) or (.headRefName | contains(\"/$issue-\")) or (.headRefName | contains(\"-$issue-\"))) | \"#\\(.number) \\(.title)\\n  \\(.url)\\n  \\(.headRefName) -> \\(.baseRefName)\\n  labels: \\([.labels[].name] | join(\", \"))\\n  updated: \\(.updatedAt)\""

--- a/tools/agents/agent-project-status
+++ b/tools/agents/agent-project-status
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo="${GH_REPO:-farmerhunter/tiny-ipa}"
+owner="${GH_PROJECT_OWNER:-farmerhunter}"
+project_number="${GH_PROJECT_NUMBER:-2}"
+project_id="${GH_PROJECT_ID:-PVT_kwHOAaWXD84BZ3xw}"
+status_field_id="${GH_PROJECT_STATUS_FIELD_ID:-PVTSSF_lAHOAaWXD84BZ3xwzhUzcCU}"
+cache_dir="${AGENT_CACHE_DIR:-.agent-cache}"
+cache_file="$cache_dir/project-items.tsv"
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+gh_retry="$root/tools/agents/gh-retry"
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  tools/agents/agent-project-status <issue-number> <Backlog|Ready|In progress|In Review|Done>
+  tools/agents/agent-project-status --refresh
+
+Updates GitHub Project v2 status for a known issue.
+This is intentionally separate from inbox lookup because Project v2 is slower
+and more brittle than issue labels.
+USAGE
+}
+
+option_id_for_status() {
+  case "$1" in
+    Backlog) echo "f75ad846" ;;
+    Ready) echo "61e4505c" ;;
+    "In progress") echo "47fc9ee4" ;;
+    "In Review") echo "df73e18b" ;;
+    Done) echo "98236657" ;;
+    *) return 1 ;;
+  esac
+}
+
+refresh_cache() {
+  mkdir -p "$cache_dir"
+  "$gh_retry" gh project item-list "$project_number" \
+    --owner "$owner" \
+    --format json \
+    --limit 200 \
+    --jq '.items[] | select(.content.type == "Issue") | [.content.number, .id] | @tsv' \
+    > "$cache_file"
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" || $# -eq 0 ]]; then
+  usage
+  exit 0
+fi
+
+if [[ "${1:-}" == "--refresh" ]]; then
+  refresh_cache
+  printf 'Refreshed %s\n' "$cache_file"
+  exit 0
+fi
+
+if [[ $# -ne 2 ]]; then
+  usage >&2
+  exit 2
+fi
+
+issue="$1"
+status="$2"
+option_id="$(option_id_for_status "$status")" || {
+  printf 'Unknown status: %s\n' "$status" >&2
+  exit 2
+}
+
+if [[ ! -f "$cache_file" ]] || ! grep -q "^${issue}[[:space:]]" "$cache_file"; then
+  refresh_cache
+fi
+
+item_id="$(awk -v issue="$issue" '$1 == issue { print $2; exit }' "$cache_file")"
+if [[ -z "$item_id" ]]; then
+  printf 'Issue #%s was not found in project cache. Try adding it to the Project first.\n' "$issue" >&2
+  exit 1
+fi
+
+"$gh_retry" gh project item-edit \
+  --id "$item_id" \
+  --project-id "$project_id" \
+  --field-id "$status_field_id" \
+  --single-select-option-id "$option_id"
+
+printf 'Updated issue #%s Project status to %s\n' "$issue" "$status"

--- a/tools/agents/agent-ready-queue
+++ b/tools/agents/agent-ready-queue
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo="${GH_REPO:-farmerhunter/tiny-ipa}"
+limit="${AGENT_READY_LIMIT:-30}"
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+gh_retry="$root/tools/agents/gh-retry"
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  tools/agents/agent-ready-queue
+
+Lists needs:implementer issues and extracts the Execution Contract lines
+that determine queue order. A Ready issue may still be blocked by Depends on.
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" || $# -gt 0 ]]; then
+  usage
+  exit 0
+fi
+
+issue_numbers="$("$gh_retry" gh issue list \
+  --repo "$repo" \
+  --state open \
+  --label needs:implementer \
+  --limit "$limit" \
+  --json number \
+  --jq '.[].number')"
+
+if [[ -z "$issue_numbers" ]]; then
+  printf 'No open issues labeled needs:implementer.\n'
+  exit 0
+fi
+
+while IFS= read -r issue; do
+  [[ -z "$issue" ]] && continue
+  "$gh_retry" gh issue view "$issue" \
+    --repo "$repo" \
+    --json number,title,url,body,comments \
+    --jq '((.body // "") + "\n" + ([.comments[].body] | join("\n"))) as $text |
+      "#\(.number) \(.title)\n  \(.url)\n" +
+      "  " + (($text | match("Branch strategy:[^\n]*").string) // "Branch strategy: MISSING") + "\n" +
+      "  " + (($text | match("Base branch:[^\n]*").string) // "Base branch: MISSING") + "\n" +
+      "  " + (($text | match("Target PR base:[^\n]*").string) // "Target PR base: MISSING") + "\n" +
+      "  " + (($text | match("Depends on:[^\n]*").string) // "Depends on: MISSING")'
+done <<< "$issue_numbers"

--- a/tools/agents/gh-retry
+++ b/tools/agents/gh-retry
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  tools/agents/gh-retry <gh-or-git-command> [args...]
+
+Retries a GitHub-related command when network/TLS/HTTP2 hiccups occur.
+
+Environment:
+  GH_RETRY_ATTEMPTS  default: 3
+  GH_RETRY_SLEEP     default: 2
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" || $# -eq 0 ]]; then
+  usage
+  exit 0
+fi
+
+attempts="${GH_RETRY_ATTEMPTS:-3}"
+sleep_seconds="${GH_RETRY_SLEEP:-2}"
+
+export GH_NO_UPDATE_NOTIFIER=1
+export GH_PROMPT_DISABLED=1
+
+try=1
+while true; do
+  set +e
+  "$@"
+  status=$?
+  set -e
+
+  if [[ "$status" -eq 0 ]]; then
+    exit 0
+  fi
+
+  if (( try >= attempts )); then
+    exit "$status"
+  fi
+
+  printf 'Command failed with status %s. Retry %s/%s in %ss...\n' \
+    "$status" "$((try + 1))" "$attempts" "$sleep_seconds" >&2
+  sleep "$sleep_seconds"
+  try=$((try + 1))
+done


### PR DESCRIPTION
## Summary

- add project-local `tools/agents/` helpers for fast label-based inbox lookup, issue context pickup, ready-queue dependency extraction, gh retry, and cached Project status updates
- update workflow docs to prefer helpers over raw Project v2 scans for daily agent routing
- clarify that per-issue review should not block the whole Implementer queue unless an explicit dependency, Epic hold, or shared contract change says so

## Verification

- `bash -n tools/agents/gh-retry tools/agents/agent-inbox tools/agents/agent-issue-context tools/agents/agent-ready-queue tools/agents/agent-project-status`
- `tools/agents/agent-inbox architect`
- `tools/agents/agent-inbox all`
- `tools/agents/agent-ready-queue`
- `tools/agents/agent-issue-context 15`
- `tools/agents/agent-project-status --refresh`
- `git diff --check`

## Notes

This is a project-local experiment. If it keeps reducing handoff latency and Project v2 friction, we can harvest the pattern into agent-foundry later.
