### PR TITLE
Improve agent helper inbox queries

### DIFF
--- a/docs/08-multi-agent-epic-workflow.md
+++ b/docs/08-multi-agent-epic-workflow.md
@@ -430,6 +430,8 @@ tools/agents/agent-project-status <issue-number> "In Review"
 
 Use these helpers first in daily agent work. They standardize retries, avoid unnecessary Project v2 reads, and cache Project item IDs in `.agent-cache/` when a Project status update is needed.
 
+Inbox and issue-context helpers should prefer GitHub REST API reads over `gh issue list/view`, because `gh issue list/view` can use GraphQL and has repeatedly hit TLS timeouts in this project. Project v2 remains separate and low-frequency.
+
 Operational rule:
 
 ```text

--- a/docs/development.md
+++ b/docs/development.md
@@ -42,6 +42,8 @@ When handing work to another role, update the label and add a short issue or PR 
 
 The raw `gh issue list` commands still work, but agents should prefer the local helpers above. They use retry defaults, avoid Project v2 queries during ordinary pickup, and keep the command surface consistent across Codex, Claude Code, DeepSeek, and similar environments.
 
+The helpers prefer GitHub REST API reads for inbox and issue context because `gh issue list/view` can use GraphQL and has been the most common source of TLS timeouts during M3.
+
 Do not put `needs:implementer` on an Epic. Implementers pick up child issues, not Epic containers. If an Epic-level concern requires execution, create a child task such as integration QA, cross-issue gap fixing, or final manual QA evidence.
 
 `Ready + needs:implementer` may represent an Implementer queue, not only work that can start immediately. Implementers should read all ready issues in the queue, sort them by the `Depends on` line in each `Execution Contract`, and execute only the issues whose dependencies are satisfied.

--- a/tools/agents/README.md
+++ b/tools/agents/README.md
@@ -4,6 +4,13 @@ These helpers are project-local experiments for speeding up the Tiny IPA
 multi-agent workflow. They prefer issue labels and comments for daily routing,
 and touch GitHub Project v2 only when a human-visible Kanban status must change.
 
+Requirements:
+
+```bash
+gh
+jq
+```
+
 ## Fast Inbox
 
 ```bash
@@ -13,11 +20,17 @@ tools/agents/agent-ready-queue
 ```
 
 `agent-inbox` reads `needs:*` labels only. It deliberately avoids Project v2
-queries because labels are faster and more reliable for agent pickup.
+queries because labels are faster and more reliable for agent pickup. It uses
+GitHub's REST API rather than `gh issue list` because the latter can hit
+GraphQL/TLS timeouts in our current network setup. `agent-inbox all` fetches
+open issues once and groups labels locally, instead of making one network call
+per label.
 
 `agent-ready-queue` extracts `Execution Contract` lines so an Implementer can
 see which ready issues are immediately startable and which are waiting on
-`Depends on`.
+`Depends on`. It reads both issue bodies and issue comments because many
+contracts are added after issue creation. It fetches the issue list once and
+then reads comments only for the queued issues.
 
 ## Context Pickup
 
@@ -26,7 +39,7 @@ tools/agents/agent-issue-context 15
 ```
 
 Use this before pickup, review, or re-review. The command prints the issue,
-comments, and likely open PRs.
+comments, and likely open PRs. It also uses REST for issue/comment reads.
 
 ## Project Status
 

--- a/tools/agents/_lib.sh
+++ b/tools/agents/_lib.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+repo_api_path() {
+  local repo="$1"
+  printf 'repos/%s' "$repo"
+}
+
+extract_contract_line() {
+  local prefix="$1"
+  local text="$2"
+
+  awk -v prefix="$prefix" '
+    index($0, prefix) == 1 {
+      print
+      found = 1
+      exit
+    }
+    END {
+      if (!found) {
+        print prefix " MISSING"
+      }
+    }
+  ' <<< "$text"
+}

--- a/tools/agents/agent-inbox
+++ b/tools/agents/agent-inbox
@@ -5,6 +5,7 @@ repo="${GH_REPO:-farmerhunter/tiny-ipa}"
 limit="${AGENT_INBOX_LIMIT:-30}"
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 gh_retry="$root/tools/agents/gh-retry"
+source "$root/tools/agents/_lib.sh"
 
 usage() {
   cat <<'USAGE'
@@ -13,6 +14,9 @@ Usage:
 
 Lists the machine-readable agent inbox from issue labels.
 Project v2 status is intentionally not queried here.
+
+Uses GitHub's REST API by default to avoid the GraphQL timeouts that can affect
+`gh issue list`.
 USAGE
 }
 
@@ -31,13 +35,26 @@ label_for_role() {
 print_label() {
   local label="$1"
   printf '\n== %s ==\n' "$label"
-  "$gh_retry" gh issue list \
-    --repo "$repo" \
-    --state open \
-    --label "$label" \
-    --limit "$limit" \
-    --json number,title,url,updatedAt \
-    --jq '.[] | "#\(.number) \(.title)\n  \(.url)\n  updated: \(.updatedAt)"'
+  "$gh_retry" gh api -X GET "$(repo_api_path "$repo")/issues" \
+    -f state=open \
+    -f labels="$label" \
+    -f per_page="$limit" \
+    --jq '.[] |
+      (if has("pull_request") then "PR" else "Issue" end) as $kind |
+      "#\(.number) \(.title) [\($kind)]\n  \(.html_url)\n  updated: \(.updated_at)"'
+}
+
+print_label_from_json() {
+  local label="$1"
+  local issues_json="$2"
+
+  printf '\n== %s ==\n' "$label"
+  jq -r --arg label "$label" '
+    .[] |
+    select(any(.labels[].name; . == $label)) |
+    (if has("pull_request") then "PR" else "Issue" end) as $kind |
+    "#\(.number) \(.title) [\($kind)]\n  \(.html_url)\n  updated: \(.updated_at)"
+  ' <<< "$issues_json"
 }
 
 if [[ "${1:-}" == "-h" || "${1:-}" == "--help" || $# -ne 1 ]]; then
@@ -48,8 +65,11 @@ fi
 role="$1"
 
 if [[ "$role" == "all" ]]; then
+  issues_json="$("$gh_retry" gh api -X GET "$(repo_api_path "$repo")/issues" \
+    -f state=open \
+    -f per_page="$limit")"
   for item in architect implementer user ci merge blocked; do
-    print_label "$(label_for_role "$item")"
+    print_label_from_json "$(label_for_role "$item")" "$issues_json"
   done
   exit 0
 fi

--- a/tools/agents/agent-issue-context
+++ b/tools/agents/agent-issue-context
@@ -2,8 +2,11 @@
 set -euo pipefail
 
 repo="${GH_REPO:-farmerhunter/tiny-ipa}"
+comments_limit="${AGENT_COMMENTS_LIMIT:-100}"
+pr_limit="${AGENT_PR_LIMIT:-50}"
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 gh_retry="$root/tools/agents/gh-retry"
+source "$root/tools/agents/_lib.sh"
 
 usage() {
   cat <<'USAGE'
@@ -12,6 +15,8 @@ Usage:
 
 Prints the issue body, labels, latest comments, and open PR candidates.
 Use this before pickup, re-review, or handoff.
+
+Uses REST API calls for issue and comment reads to avoid GraphQL timeouts.
 USAGE
 }
 
@@ -23,20 +28,19 @@ fi
 issue="$1"
 
 printf '== Issue #%s ==\n' "$issue"
-"$gh_retry" gh issue view "$issue" \
-  --repo "$repo" \
-  --json number,title,state,labels,url,body \
-  --jq '"#\(.number) \(.title)\nstate: \(.state)\nurl: \(.url)\nlabels: \([.labels[].name] | join(", "))\n\n" + (.body // "")'
+"$gh_retry" gh api "$(repo_api_path "$repo")/issues/$issue" \
+  --jq '"#\(.number) \(.title)\nstate: \(.state)\nurl: \(.html_url)\nlabels: \([.labels[].name] | join(", "))\n\n" + (.body // "")'
 
 printf '\n== Comments ==\n'
-"$gh_retry" gh issue view "$issue" \
-  --repo "$repo" \
-  --comments
+"$gh_retry" gh api -X GET "$(repo_api_path "$repo")/issues/$issue/comments" \
+  -f per_page="$comments_limit" \
+  --jq '.[] |
+    "author: \(.user.login)\ncreated: \(.created_at)\nurl: \(.html_url)\n--\n\(.body)\n"'
 
 printf '\n== Open PR candidates ==\n'
-"$gh_retry" gh pr list \
-  --repo "$repo" \
-  --state open \
-  --limit 50 \
-  --json number,title,url,headRefName,baseRefName,labels,updatedAt \
-  --jq ".[] | select((.title | contains(\"#$issue\")) or (.headRefName | contains(\"/$issue-\")) or (.headRefName | contains(\"-$issue-\"))) | \"#\\(.number) \\(.title)\\n  \\(.url)\\n  \\(.headRefName) -> \\(.baseRefName)\\n  labels: \\([.labels[].name] | join(\", \"))\\n  updated: \\(.updatedAt)\""
+"$gh_retry" gh api -X GET "$(repo_api_path "$repo")/pulls" \
+  -f state=open \
+  -f per_page="$pr_limit" \
+  --jq ".[] |
+    select((.title | contains(\"#$issue\")) or (.head.ref | contains(\"/$issue-\")) or (.head.ref | contains(\"-$issue-\"))) |
+    \"#\\(.number) \\(.title)\\n  \\(.html_url)\\n  \\(.head.ref) -> \\(.base.ref)\\n  updated: \\(.updated_at)\""

--- a/tools/agents/agent-ready-queue
+++ b/tools/agents/agent-ready-queue
@@ -3,8 +3,10 @@ set -euo pipefail
 
 repo="${GH_REPO:-farmerhunter/tiny-ipa}"
 limit="${AGENT_READY_LIMIT:-30}"
+comments_limit="${AGENT_COMMENTS_LIMIT:-100}"
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 gh_retry="$root/tools/agents/gh-retry"
+source "$root/tools/agents/_lib.sh"
 
 usage() {
   cat <<'USAGE'
@@ -13,6 +15,8 @@ Usage:
 
 Lists needs:implementer issues and extracts the Execution Contract lines
 that determine queue order. A Ready issue may still be blocked by Depends on.
+
+Uses REST API calls instead of `gh issue list/view` to avoid GraphQL timeouts.
 USAGE
 }
 
@@ -21,28 +25,30 @@ if [[ "${1:-}" == "-h" || "${1:-}" == "--help" || $# -gt 0 ]]; then
   exit 0
 fi
 
-issue_numbers="$("$gh_retry" gh issue list \
-  --repo "$repo" \
-  --state open \
-  --label needs:implementer \
-  --limit "$limit" \
-  --json number \
-  --jq '.[].number')"
+issues_json="$("$gh_retry" gh api -X GET "$(repo_api_path "$repo")/issues" \
+  -f state=open \
+  -f labels=needs:implementer \
+  -f per_page="$limit")"
 
-if [[ -z "$issue_numbers" ]]; then
+if [[ "$(jq 'length' <<< "$issues_json")" -eq 0 ]]; then
   printf 'No open issues labeled needs:implementer.\n'
   exit 0
 fi
 
-while IFS= read -r issue; do
-  [[ -z "$issue" ]] && continue
-  "$gh_retry" gh issue view "$issue" \
-    --repo "$repo" \
-    --json number,title,url,body,comments \
-    --jq '((.body // "") + "\n" + ([.comments[].body] | join("\n"))) as $text |
-      "#\(.number) \(.title)\n  \(.url)\n" +
-      "  " + (($text | match("Branch strategy:[^\n]*").string) // "Branch strategy: MISSING") + "\n" +
-      "  " + (($text | match("Base branch:[^\n]*").string) // "Base branch: MISSING") + "\n" +
-      "  " + (($text | match("Target PR base:[^\n]*").string) // "Target PR base: MISSING") + "\n" +
-      "  " + (($text | match("Depends on:[^\n]*").string) // "Depends on: MISSING")'
-done <<< "$issue_numbers"
+while IFS= read -r issue_json; do
+  [[ -z "$issue_json" ]] && continue
+  issue="$(jq -r '.number' <<< "$issue_json")"
+  title="$(jq -r '.title' <<< "$issue_json")"
+  url="$(jq -r '.html_url' <<< "$issue_json")"
+  body="$(jq -r '.body // ""' <<< "$issue_json")"
+  comments="$("$gh_retry" gh api -X GET "$(repo_api_path "$repo")/issues/$issue/comments" \
+    -f per_page="$comments_limit" \
+    --jq '[.[].body] | join("\n")')"
+  text="$body"$'\n'"$comments"
+
+  printf '#%s %s\n  %s\n' "$issue" "$title" "$url"
+  printf '  %s\n' "$(extract_contract_line "Branch strategy:" "$text")"
+  printf '  %s\n' "$(extract_contract_line "Base branch:" "$text")"
+  printf '  %s\n' "$(extract_contract_line "Target PR base:" "$text")"
+  printf '  %s\n' "$(extract_contract_line "Depends on:" "$text")"
+done < <(jq -c '.[]' <<< "$issues_json")


### PR DESCRIPTION
## Summary

- switch high-frequency helper reads from `gh issue list/view` GraphQL paths to GitHub REST API calls
- make `agent-inbox all` fetch open issues once and group labels locally instead of making one request per label
- reduce `agent-ready-queue` duplicate issue-detail calls by reusing the REST issue-list payload and only fetching comments per queued issue
- document the REST preference and `jq` helper dependency

## Verification

- `bash -n tools/agents/_lib.sh tools/agents/gh-retry tools/agents/agent-inbox tools/agents/agent-ready-queue tools/agents/agent-issue-context tools/agents/agent-project-status`
- `time tools/agents/agent-inbox all` -> 5.0s and returned #15/#16/#17 queues
- `time tools/agents/agent-ready-queue` -> 27.3s with one TLS retry, returned #16/#17 dependency contracts
- `time tools/agents/agent-issue-context 15` -> 44.5s with TLS retries, returned issue context and PR #44
- `time tools/agents/agent-inbox architect`
- `time tools/agents/agent-inbox implementer`
- `git diff --check`

## Trial feedback

`agent-inbox all` improved from about 35s to about 5s because it now performs one REST request instead of six sequential label queries. `agent-ready-queue` improved from about 72s to about 27s under one TLS retry by reducing duplicate issue-detail calls.

TLS timeouts still happen at the HTTP layer, so `gh-retry` remains useful, but reducing call count is clearly more effective than retrying more often.
