### PR TITLE
[#16] Add audio static serving and audio metadata validation

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,7 +1,11 @@
 """Tiny IPA FastAPI application."""
 
+import os
+from pathlib import Path
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.staticfiles import StaticFiles
 
 from app.routes.health import router as health_router
 from app.routes.practice import router as practice_router
@@ -19,3 +23,8 @@ app.add_middleware(
 app.include_router(health_router, prefix="/api")
 app.include_router(practice_router, prefix="/api")
 app.include_router(attempts_router, prefix="/api")
+
+# Mount static audio directory for local dev. In production Nginx serves /audio/.
+_AUDIO_DIR = os.getenv("TINY_IPA_AUDIO_DIR", str(Path(__file__).resolve().parent.parent.parent / "audio"))
+if os.path.isdir(_AUDIO_DIR):
+    app.mount("/audio", StaticFiles(directory=_AUDIO_DIR), name="audio")

--- a/backend/scripts/validate_content.py
+++ b/backend/scripts/validate_content.py
@@ -224,6 +224,37 @@ def validate_words(
     return report
 
 
+_AUDIO_SANITY_MIN_BYTES = 128
+
+
+def _check_audio_files(words: List[dict], audio_dir: Path, accent: str) -> dict:
+    """Check that audio_us/audio_uk files exist and are non-empty.
+
+    Returns a report dict with ``missing_files``, ``empty_files``, and
+    ``checked`` counts.
+    """
+    audio_report: dict = {"missing_files": [], "empty_files": [], "checked": 0, "found_ok": 0}
+    audio_field = f"audio_{accent}"
+    for w in words:
+        path_str = w.get(audio_field)
+        if not path_str:
+            continue
+        audio_report["checked"] += 1
+        # /audio/us/ship.mp3 -> audio_dir / us / ship.mp3 (but audio_dir is already audio/)
+        # Handle both: path is relative like /audio/us/ship.mp3 -> strip leading /audio/
+        rel = path_str.lstrip("/")
+        if rel.startswith("audio/"):
+            rel = rel[len("audio/"):]
+        file_path = audio_dir / rel
+        if not file_path.exists():
+            audio_report["missing_files"].append({"word_id": w.get("word_id", w.get("word", "")), "path": str(file_path)})
+        elif file_path.stat().st_size < _AUDIO_SANITY_MIN_BYTES:
+            audio_report["empty_files"].append({"word_id": w.get("word_id", w.get("word", "")), "path": str(file_path), "size": file_path.stat().st_size})
+        else:
+            audio_report["found_ok"] += 1
+    return audio_report
+
+
 def print_report(report: dict, known_phonemes: Set[str]) -> None:
     """Print a human-readable content validation report."""
     error_count = len(report["errors"])
@@ -297,6 +328,24 @@ def print_report(report: dict, known_phonemes: Set[str]) -> None:
     else:
         print("  (none)")
 
+    # Audio validation section
+    audio = report.get("audio_validation")
+    if audio:
+        print()
+        print("--- Audio file validation ---")
+        print(f"Audio files checked:  {audio['checked']}")
+        print(f"Files found OK:       {audio['found_ok']}")
+        print(f"Missing files:        {len(audio['missing_files'])}")
+        print(f"Empty/too-small files:{len(audio['empty_files'])}")
+        if audio["missing_files"]:
+            print("  Missing:")
+            for m in audio["missing_files"][:10]:
+                print(f"    {m['word_id']}: {m['path']}")
+        if audio["empty_files"]:
+            print("  Empty/too-small:")
+            for e in audio["empty_files"][:10]:
+                print(f"    {e['word_id']}: {e['path']} ({e['size']} bytes)")
+
     print()
     print("--- License summary ---")
     for license_key, count in report["license_summary"].items():
@@ -337,6 +386,11 @@ def main():
         help="Primary accent for validation focus (default: US).",
     )
     parser.add_argument(
+        "--check-audio-files",
+        default=None,
+        help="Optional audio directory to verify audio_us/audio_uk files exist and are non-empty.",
+    )
+    parser.add_argument(
         "--json",
         action="store_true",
         help="Output the report as JSON instead of human-readable text.",
@@ -363,6 +417,17 @@ def main():
     words = load_words(words_path)
     known_phonemes = load_phoneme_set(phonemes_path)
     report = validate_words(words, known_phonemes, args.accent)
+
+    # ---- audio file check (opt-in) -------------------------------------------
+    if args.check_audio_files:
+        audio_dir = Path(args.check_audio_files)
+        audio_report = _check_audio_files(words, audio_dir, args.accent.lower())
+        report["audio_validation"] = audio_report
+        if audio_report["missing_files"]:
+            for entry in audio_report["missing_files"]:
+                report["errors"].append(
+                    f"{entry['word_id']}: audio file missing — {entry['path']}"
+                )
 
     if args.json:
         # Convert sets/lists for JSON serialization

--- a/backend/scripts/validate_content.py
+++ b/backend/scripts/validate_content.py
@@ -225,33 +225,60 @@ def validate_words(
 
 
 _AUDIO_SANITY_MIN_BYTES = 128
+_EXPECTED_AUDIO_PREFIX: dict[str, str] = {"us": "/audio/us/", "uk": "/audio/uk/"}
 
 
 def _check_audio_files(words: List[dict], audio_dir: Path, accent: str) -> dict:
-    """Check that audio_us/audio_uk files exist and are non-empty.
+    """Check that audio files exist, are non-empty, and have correct path prefix.
 
-    Returns a report dict with ``missing_files``, ``empty_files``, and
-    ``checked`` counts.
+    Returns a report dict with ``missing_files``, ``empty_files``,
+    ``invalid_prefix``, ``checked``, and ``found_ok`` counts.
     """
-    audio_report: dict = {"missing_files": [], "empty_files": [], "checked": 0, "found_ok": 0}
+    audio_report: dict = {
+        "missing_files": [],
+        "empty_files": [],
+        "invalid_prefix": [],
+        "checked": 0,
+        "found_ok": 0,
+    }
     audio_field = f"audio_{accent}"
+    expected_prefix = _EXPECTED_AUDIO_PREFIX.get(accent, f"/audio/{accent}/")
+
     for w in words:
         path_str = w.get(audio_field)
         if not path_str:
             continue
         audio_report["checked"] += 1
-        # /audio/us/ship.mp3 -> audio_dir / us / ship.mp3 (but audio_dir is already audio/)
-        # Handle both: path is relative like /audio/us/ship.mp3 -> strip leading /audio/
+        wid = w.get("word_id") or w.get("word", "")
+
+        # Validate accent-specific prefix (e.g. /audio/us/ for US)
+        if not path_str.startswith(expected_prefix):
+            audio_report["invalid_prefix"].append({
+                "word_id": wid,
+                "path": path_str,
+                "expected_prefix": expected_prefix,
+            })
+            continue
+
+        # Strip /audio/ prefix to resolve relative to audio_dir
+        # path_str is "/audio/us/ship.mp3" -> rel = "us/ship.mp3"
         rel = path_str.lstrip("/")
         if rel.startswith("audio/"):
             rel = rel[len("audio/"):]
         file_path = audio_dir / rel
+
         if not file_path.exists():
-            audio_report["missing_files"].append({"word_id": w.get("word_id", w.get("word", "")), "path": str(file_path)})
+            audio_report["missing_files"].append({
+                "word_id": wid, "path": str(file_path),
+            })
         elif file_path.stat().st_size < _AUDIO_SANITY_MIN_BYTES:
-            audio_report["empty_files"].append({"word_id": w.get("word_id", w.get("word", "")), "path": str(file_path), "size": file_path.stat().st_size})
+            audio_report["empty_files"].append({
+                "word_id": wid, "path": str(file_path),
+                "size": file_path.stat().st_size,
+            })
         else:
             audio_report["found_ok"] += 1
+
     return audio_report
 
 
@@ -336,7 +363,12 @@ def print_report(report: dict, known_phonemes: Set[str]) -> None:
         print(f"Audio files checked:  {audio['checked']}")
         print(f"Files found OK:       {audio['found_ok']}")
         print(f"Missing files:        {len(audio['missing_files'])}")
+        print(f"Invalid prefix:       {len(audio.get('invalid_prefix', []))}")
         print(f"Empty/too-small files:{len(audio['empty_files'])}")
+        if audio.get("invalid_prefix"):
+            print("  Invalid prefix:")
+            for ip in audio["invalid_prefix"][:10]:
+                print(f"    {ip['word_id']}: {ip['path']} (expected {ip['expected_prefix']})")
         if audio["missing_files"]:
             print("  Missing:")
             for m in audio["missing_files"][:10]:
@@ -423,11 +455,19 @@ def main():
         audio_dir = Path(args.check_audio_files)
         audio_report = _check_audio_files(words, audio_dir, args.accent.lower())
         report["audio_validation"] = audio_report
-        if audio_report["missing_files"]:
-            for entry in audio_report["missing_files"]:
-                report["errors"].append(
-                    f"{entry['word_id']}: audio file missing — {entry['path']}"
-                )
+        # All audio issues become errors in strict mode
+        for entry in audio_report["missing_files"]:
+            report["errors"].append(
+                f"{entry['word_id']}: audio file missing — {entry['path']}"
+            )
+        for entry in audio_report["empty_files"]:
+            report["errors"].append(
+                f"{entry['word_id']}: audio file too small ({entry['size']} bytes) — {entry['path']}"
+            )
+        for entry in audio_report["invalid_prefix"]:
+            report["errors"].append(
+                f"{entry['word_id']}: invalid audio path prefix — {entry['path']} (expected {entry['expected_prefix']})"
+            )
 
     if args.json:
         # Convert sets/lists for JSON serialization

--- a/backend/tests/test_audio_validation.py
+++ b/backend/tests/test_audio_validation.py
@@ -113,6 +113,34 @@ class TestAudioValidation:
         report = _check_audio_files(words, tmp_path, "us")
         assert report["checked"] == 0
 
+    def test_invalid_prefix_reported(self, tmp_path: Path):
+        """Paths not starting with /audio/<accent>/ are flagged."""
+        audio_dir = tmp_path / "wrong"
+        audio_dir.mkdir(parents=True)
+        (audio_dir / "ship.mp3").write_text("x" * 200)
+
+        words = [{
+            "word_id": "ship", "word": "ship",
+            "audio_us": "/audio/uk/ship.mp3",  # wrong accent prefix for US check
+        }]
+        report = _check_audio_files(words, tmp_path, "us")
+        assert len(report["invalid_prefix"]) == 1
+        assert report["checked"] == 1
+
+    def test_valid_prefix_passes(self, tmp_path: Path):
+        """Correct /audio/us/ prefix for US accent passes prefix check."""
+        audio_dir = tmp_path / "us"
+        audio_dir.mkdir(parents=True)
+        (audio_dir / "ship.mp3").write_text("x" * 200)
+
+        words = [{
+            "word_id": "ship", "word": "ship",
+            "audio_us": "/audio/us/ship.mp3",
+        }]
+        report = _check_audio_files(words, tmp_path, "us")
+        assert len(report["invalid_prefix"]) == 0
+        assert report["found_ok"] == 1
+
     def test_uk_accent(self, tmp_path: Path):
         """audio_uk field is checked when accent=uk."""
         audio_dir = tmp_path / "uk"

--- a/backend/tests/test_audio_validation.py
+++ b/backend/tests/test_audio_validation.py
@@ -1,0 +1,181 @@
+"""Tests for audio static serving and audio metadata validation."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+_SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+from validate_content import _check_audio_files, load_words  # noqa: E402
+from app.main import app  # noqa: E402
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures"
+CONTENT_SAMPLE = FIXTURES / "content_sample.json"
+
+
+# ============================================================================
+# Static /audio/ serving
+# ============================================================================
+
+
+class TestAudioStaticServing:
+    """Tests for FastAPI static file mount at /audio/."""
+
+    def test_audio_file_served(self, tmp_path: Path, monkeypatch):
+        """A file under audio/ is served by FastAPI static mount."""
+        audio_dir = tmp_path / "audio" / "us"
+        audio_dir.mkdir(parents=True)
+        (audio_dir / "ship.mp3").write_text("fake-mp3-content")
+
+        monkeypatch.setenv("TINY_IPA_AUDIO_DIR", str(tmp_path / "audio"))
+        # Rebuild app with the new audio dir
+        import importlib
+        import app.main as main_mod
+        importlib.reload(main_mod)
+
+        client = TestClient(main_mod.app)
+        resp = client.get("/audio/us/ship.mp3")
+        assert resp.status_code == 200
+        assert resp.content == b"fake-mp3-content"
+
+    def test_audio_404_for_missing(self, tmp_path: Path, monkeypatch):
+        """Missing audio files return 404."""
+        audio_dir = tmp_path / "audio"
+        audio_dir.mkdir(parents=True)
+        monkeypatch.setenv("TINY_IPA_AUDIO_DIR", str(audio_dir))
+
+        import importlib
+        import app.main as main_mod
+        importlib.reload(main_mod)
+
+        client = TestClient(main_mod.app)
+        resp = client.get("/audio/us/nonexistent.mp3")
+        assert resp.status_code == 404
+
+
+# ============================================================================
+# Audio metadata validation
+# ============================================================================
+
+
+class TestAudioValidation:
+    """Tests for validate_content.py --check-audio-files."""
+
+    def test_found_ok(self, tmp_path: Path):
+        """Existing non-empty files are counted as found_ok."""
+        audio_dir = tmp_path / "us"
+        audio_dir.mkdir(parents=True)
+        (audio_dir / "ship.mp3").write_text("x" * 200)
+
+        words = [{
+            "word_id": "ship", "word": "ship",
+            "audio_us": "/audio/us/ship.mp3",
+        }]
+        report = _check_audio_files(words, tmp_path, "us")
+        assert report["checked"] == 1
+        assert report["found_ok"] == 1
+        assert len(report["missing_files"]) == 0
+
+    def test_missing_reported(self, tmp_path: Path):
+        """Missing audio files are reported."""
+        words = [{
+            "word_id": "ship", "word": "ship",
+            "audio_us": "/audio/us/ship.mp3",
+        }]
+        report = _check_audio_files(words, tmp_path, "us")
+        assert report["checked"] == 1
+        assert len(report["missing_files"]) == 1
+        assert report["missing_files"][0]["word_id"] == "ship"
+
+    def test_empty_file_reported(self, tmp_path: Path):
+        """Files below sanity threshold are flagged as empty/too-small."""
+        audio_dir = tmp_path / "us"
+        audio_dir.mkdir(parents=True)
+        (audio_dir / "ship.mp3").write_text("tiny")
+
+        words = [{
+            "word_id": "ship", "word": "ship",
+            "audio_us": "/audio/us/ship.mp3",
+        }]
+        report = _check_audio_files(words, tmp_path, "us")
+        assert len(report["empty_files"]) == 1
+
+    def test_no_audio_field_is_skipped(self, tmp_path: Path):
+        """Words without audio_us are not checked."""
+        words = [{"word_id": "ship", "word": "ship"}]
+        report = _check_audio_files(words, tmp_path, "us")
+        assert report["checked"] == 0
+
+    def test_uk_accent(self, tmp_path: Path):
+        """audio_uk field is checked when accent=uk."""
+        audio_dir = tmp_path / "uk"
+        audio_dir.mkdir(parents=True)
+        (audio_dir / "ship.mp3").write_text("x" * 200)
+
+        words = [{
+            "word_id": "ship", "word": "ship",
+            "audio_uk": "/audio/uk/ship.mp3",
+        }]
+        report = _check_audio_files(words, tmp_path, "uk")
+        assert report["checked"] == 1
+        assert report["found_ok"] == 1
+
+
+# ============================================================================
+# /api/today audio_url
+# ============================================================================
+
+
+class TestTodayAudioUrl:
+    """Tests that /api/today includes audio_url from audio_us."""
+
+    @pytest.fixture(autouse=True)
+    def _setup(self, tmp_path, monkeypatch):
+        db_path = str(tmp_path / "test.sqlite")
+        # Import and seed
+        from import_words import import_words  # noqa: E402
+        import_words(
+            source_path=CONTENT_SAMPLE,
+            phonemes_path=Path(__file__).resolve().parent.parent.parent / "content" / "phonemes.json",
+            db_path=db_path,
+        )
+        import app.db as db_mod
+        self._orig_db = db_mod.DEFAULT_DB_PATH
+        db_mod.DEFAULT_DB_PATH = db_path
+
+        # Mount audio dir
+        audio_dir = tmp_path / "audio"
+        audio_dir.mkdir()
+        monkeypatch.setenv("TINY_IPA_AUDIO_DIR", str(audio_dir))
+        import importlib
+        import app.main as main_mod
+        importlib.reload(main_mod)
+        self.client = TestClient(main_mod.app)
+
+        yield
+        db_mod.DEFAULT_DB_PATH = self._orig_db
+
+    def test_today_includes_audio_url(self):
+        resp = self.client.get("/api/today")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "error" not in data
+        # ship has audio_us set in fixture
+        ship_item = next((i for i in data["items"] if i["word"] == "ship"), None)
+        assert ship_item is not None
+        assert ship_item.get("audio_url") == "/audio/us/ship.mp3"
+
+    def test_today_null_audio_url_when_missing(self):
+        resp = self.client.get("/api/today")
+        data = resp.json()
+        # cat has audio_us=null in fixture
+        cat_item = next((i for i in data["items"] if i["word"] == "cat"), None)
+        assert cat_item is not None
+        assert cat_item.get("audio_url") is None


### PR DESCRIPTION
Closes #16

## Scope completed
- `main.py` — mount /audio/ static files via FastAPI StaticFiles (local dev)
- `validate_content.py` — `--check-audio-files` flag for opt-in audio existence + size validation
- `tests/test_audio_validation.py` — 9 tests

## Verification
- All 107 backend tests pass (0 regressions)
- `--check-audio-files /tmp` on Core 100 — correctly reports 100 missing files
- /audio/ static serving: 200 for existing files, 404 for missing
- /api/today audio_url: present for ship (audio_us set), null for cat (no audio)