### PR TITLE
Add REST PR and label agent helpers

### DIFF
--- a/docs/08-multi-agent-epic-workflow.md
+++ b/docs/08-multi-agent-epic-workflow.md
@@ -425,12 +425,13 @@ tools/agents/agent-inbox architect
 tools/agents/agent-inbox implementer
 tools/agents/agent-ready-queue
 tools/agents/agent-issue-context <issue-number>
+tools/agents/agent-pr-context <pr-number>
 tools/agents/agent-project-status <issue-number> "In Review"
 ```
 
 Use these helpers first in daily agent work. They standardize retries, avoid unnecessary Project v2 reads, and cache Project item IDs in `.agent-cache/` when a Project status update is needed.
 
-Inbox and issue-context helpers should prefer GitHub REST API reads over `gh issue list/view`, because `gh issue list/view` can use GraphQL and has repeatedly hit TLS timeouts in this project. Project v2 remains separate and low-frequency.
+Inbox, issue-context, PR-context, and label-routing helpers should prefer GitHub REST API reads/writes over `gh issue list/view/edit` and `gh pr view`, because those commands can use GraphQL and have repeatedly hit TLS timeouts in this project. Project v2 remains separate and low-frequency.
 
 Operational rule:
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -54,7 +54,7 @@ When an issue returns from Architect review, read both the issue handoff comment
 
 ```bash
 tools/agents/agent-issue-context <issue-number>
-gh pr view <pr-number> -R farmerhunter/tiny-ipa --comments
+tools/agents/agent-pr-context <pr-number>
 ```
 
 Architect must not rely on only one comment surface when moving an issue back to `needs:implementer`. The issue comment should point to the PR review, name the fix branch, and summarize the blocker. The PR conversation should also include the latest handoff or a pointer to it, especially for stacked-branch refresh requests.
@@ -187,6 +187,13 @@ needs:user        -> user decision is needed
 needs:ci          -> checks are still running
 needs:merge       -> reviewed and ready to merge
 blocked           -> latest comment explains the blocker
+```
+
+Prefer the REST-backed helper for next-action label routing:
+
+```bash
+tools/agents/agent-label <issue-number> set-next needs:implementer
+tools/agents/agent-label <issue-number> set-next needs:architect
 ```
 
 Allowed Epic handoff labels are `needs:architect`, `needs:user`, and `blocked`. `needs:implementer`, `needs:ci`, and `needs:merge` belong on child issues or PRs.

--- a/tools/agents/README.md
+++ b/tools/agents/README.md
@@ -36,10 +36,28 @@ then reads comments only for the queued issues.
 
 ```bash
 tools/agents/agent-issue-context 15
+tools/agents/agent-pr-context 44
 ```
 
 Use this before pickup, review, or re-review. The command prints the issue,
 comments, and likely open PRs. It also uses REST for issue/comment reads.
+
+Use `agent-pr-context` before PR review. It reads PR metadata, commits, files,
+comments, and review comments through REST, which is often faster and more
+reliable than `gh pr view` in this project.
+
+## Labels
+
+```bash
+tools/agents/agent-label 15 set-next needs:implementer
+tools/agents/agent-label 15 set-next needs:architect
+tools/agents/agent-label 15 remove needs:implementer
+```
+
+Use `agent-label` for role routing when GraphQL-backed `gh issue edit` is slow
+or flaky. `set-next` removes the other primary next-action labels before adding
+the requested label. It reads current labels first, so it avoids unnecessary
+delete/add calls when the issue is already in the requested route.
 
 ## Project Status
 

--- a/tools/agents/_lib.sh
+++ b/tools/agents/_lib.sh
@@ -5,6 +5,16 @@ repo_api_path() {
   printf 'repos/%s' "$repo"
 }
 
+require_number() {
+  local value="$1"
+  local name="$2"
+
+  if [[ ! "$value" =~ ^[0-9]+$ ]]; then
+    printf '%s must be a number: %s\n' "$name" "$value" >&2
+    return 2
+  fi
+}
+
 extract_contract_line() {
   local prefix="$1"
   local text="$2"

--- a/tools/agents/agent-label
+++ b/tools/agents/agent-label
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo="${GH_REPO:-farmerhunter/tiny-ipa}"
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+gh_retry="$root/tools/agents/gh-retry"
+source "$root/tools/agents/_lib.sh"
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  tools/agents/agent-label <issue-number> add <label>
+  tools/agents/agent-label <issue-number> remove <label>
+  tools/agents/agent-label <issue-number> set-next <needs:architect|needs:implementer|needs:user|needs:ci|needs:merge|blocked>
+
+Uses GitHub REST label endpoints to avoid `gh issue edit` GraphQL timeouts.
+`set-next` removes the primary next-action labels first, then adds the target.
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" || $# -lt 3 ]]; then
+  usage
+  exit 0
+fi
+
+issue="$1"
+action="$2"
+label="$3"
+require_number "$issue" "Issue number"
+
+add_label() {
+  local target_label="$1"
+  "$gh_retry" gh api -X POST "$(repo_api_path "$repo")/issues/$issue/labels" \
+    -f "labels[]=$target_label" >/dev/null
+}
+
+remove_label() {
+  local target_label="$1"
+  "$gh_retry" gh api -X DELETE "$(repo_api_path "$repo")/issues/$issue/labels/$target_label" >/dev/null 2>&1 || true
+}
+
+current_labels_json() {
+  "$gh_retry" gh api "$(repo_api_path "$repo")/issues/$issue" \
+    --jq '[.labels[].name]'
+}
+
+has_label() {
+  local target_label="$1"
+  local labels_json="$2"
+
+  jq -e --arg label "$target_label" 'index($label) != null' <<< "$labels_json" >/dev/null
+}
+
+case "$action" in
+  add)
+    add_label "$label"
+    ;;
+  remove)
+    remove_label "$label"
+    ;;
+  set-next)
+    case "$label" in
+      needs:architect|needs:implementer|needs:user|needs:ci|needs:merge|blocked) ;;
+      *)
+        printf 'Unsupported next-action label: %s\n' "$label" >&2
+        exit 2
+        ;;
+    esac
+    labels_json="$(current_labels_json)"
+    for next_label in needs:architect needs:implementer needs:user needs:ci needs:merge blocked; do
+      if [[ "$next_label" != "$label" ]] && has_label "$next_label" "$labels_json"; then
+        remove_label "$next_label"
+      fi
+    done
+    if ! has_label "$label" "$labels_json"; then
+      add_label "$label"
+    fi
+    ;;
+  *)
+    usage >&2
+    exit 2
+    ;;
+esac
+
+"$gh_retry" gh api "$(repo_api_path "$repo")/issues/$issue" \
+  --jq '"#\(.number) labels: " + ([.labels[].name] | join(", "))'

--- a/tools/agents/agent-pr-context
+++ b/tools/agents/agent-pr-context
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo="${GH_REPO:-farmerhunter/tiny-ipa}"
+comments_limit="${AGENT_COMMENTS_LIMIT:-100}"
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+gh_retry="$root/tools/agents/gh-retry"
+source "$root/tools/agents/_lib.sh"
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  tools/agents/agent-pr-context <pr-number>
+
+Prints PR metadata, commits, files, comments, and linked issue hints using
+GitHub REST API calls. Use this for review before falling back to GraphQL
+commands such as `gh pr view`.
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" || $# -ne 1 ]]; then
+  usage
+  exit 0
+fi
+
+pr="$1"
+require_number "$pr" "PR number"
+
+printf '== PR #%s ==\n' "$pr"
+"$gh_retry" gh api "$(repo_api_path "$repo")/pulls/$pr" \
+  --jq '"#\(.number) \(.title)\nstate: \(.state)\nmergeable: \(.mergeable // "unknown")\ndraft: \(.draft)\nurl: \(.html_url)\nbase: \(.base.ref)\nhead: \(.head.ref)\nupdated: \(.updated_at)\n\n" + (.body // "")'
+
+printf '\n== Commits ==\n'
+"$gh_retry" gh api -X GET "$(repo_api_path "$repo")/pulls/$pr/commits" \
+  -f per_page=100 \
+  --jq '.[] | "\(.sha[0:7]) \(.commit.message | split("\n")[0])"'
+
+printf '\n== Files ==\n'
+"$gh_retry" gh api -X GET "$(repo_api_path "$repo")/pulls/$pr/files" \
+  -f per_page=100 \
+  --jq '.[] | "\(.status)\t\(.filename)\t+\(.additions)/-\(.deletions)"'
+
+printf '\n== Issue Hints ==\n'
+"$gh_retry" gh api "$(repo_api_path "$repo")/pulls/$pr" \
+  --jq '(.body // "" + "\n" + .title) |
+    [match("(close[sd]?|fix(e[sd])?|resolve[sd]?) +#([0-9]+)"; "ig")?.captures[2].string,
+     match("#([0-9]+)"; "g")?.captures[0].string] |
+    unique |
+    map(select(. != null)) |
+    if length == 0 then "No issue references found." else map("#" + .) | join("\n") end'
+
+printf '\n== PR Comments ==\n'
+"$gh_retry" gh api -X GET "$(repo_api_path "$repo")/issues/$pr/comments" \
+  -f per_page="$comments_limit" \
+  --jq '.[] |
+    "author: \(.user.login)\ncreated: \(.created_at)\nurl: \(.html_url)\n--\n\(.body)\n"'
+
+printf '\n== Review Comments ==\n'
+"$gh_retry" gh api -X GET "$(repo_api_path "$repo")/pulls/$pr/comments" \
+  -f per_page="$comments_limit" \
+  --jq '.[] |
+    "author: \(.user.login)\ncreated: \(.created_at)\npath: \(.path):\(.line // .original_line // 0)\nurl: \(.html_url)\n--\n\(.body)\n"'


### PR DESCRIPTION
## Summary

- add `tools/agents/agent-pr-context` for REST-backed PR metadata, commits, files, comments, review comments, and linked issue hints
- add `tools/agents/agent-label` for REST-backed next-action label routing without `gh issue edit` GraphQL calls
- optimize `agent-label set-next` to read current labels first and avoid unnecessary delete/add calls when the route is already correct
- document PR context and label helpers in development workflow docs

## Verification

- `bash -n tools/agents/agent-label tools/agents/agent-pr-context tools/agents/_lib.sh`
- `tools/agents/agent-pr-context 44` -> returned PR metadata, commits, files, issue hint #15, and PR comments
- `tools/agents/agent-label 16 set-next needs:implementer` -> kept #16 on needs:implementer and avoided contradictory next-action labels
- `tools/agents/agent-inbox all` -> confirmed needs:architect empty and #16/#17 in needs:implementer
- `git diff --check`

## Trial feedback

`agent-pr-context` avoids the GraphQL-heavy `gh pr view` path that has been flaky during M3 review. `agent-label set-next` initially took about 53s when it attempted unnecessary label deletes; after reading current labels first, the same no-op routing check took about 8s.
