### PR TITLE
[#39] Implement GET /api/progress with phoneme summary and streak

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -10,6 +10,7 @@ from fastapi.staticfiles import StaticFiles
 from app.routes.health import router as health_router
 from app.routes.practice import router as practice_router
 from app.routes.attempts import router as attempts_router
+from app.routes.progress import router as progress_router
 
 app = FastAPI(title="Tiny IPA", version="0.1.0")
 
@@ -23,6 +24,7 @@ app.add_middleware(
 app.include_router(health_router, prefix="/api")
 app.include_router(practice_router, prefix="/api")
 app.include_router(attempts_router, prefix="/api")
+app.include_router(progress_router, prefix="/api")
 
 # Mount static audio directory for local dev. In production Nginx serves /audio/.
 _AUDIO_DIR = os.getenv("TINY_IPA_AUDIO_DIR", str(Path(__file__).resolve().parent.parent.parent / "audio"))

--- a/backend/app/routes/progress.py
+++ b/backend/app/routes/progress.py
@@ -1,0 +1,19 @@
+"""Progress endpoint — GET /api/progress."""
+
+from fastapi import APIRouter
+
+from app.db import get_db
+from app.services.progress import build_progress_response
+
+router = APIRouter()
+
+
+@router.get("/progress")
+def progress():
+    """Return a domain summary of learner progress.
+
+    Includes today's status, streak, total attempts/sessions, and
+    weak/strong phoneme lists derived from phoneme_stats.
+    """
+    with get_db() as conn:
+        return build_progress_response(conn)

--- a/backend/app/services/progress.py
+++ b/backend/app/services/progress.py
@@ -1,13 +1,17 @@
-"""Phoneme-level statistics and mastery computation.
+"""Phoneme-level statistics, mastery computation, and progress summaries.
 
 Every attempt submission updates ``phoneme_stats`` for each target
 phoneme on the session item. Mastery status is derived from attempt
 count and accuracy with documented precedence rules.
+
+GET /api/progress reads ``phoneme_stats``, ``attempts``, and
+``daily_sessions`` to produce a domain summary for the frontend.
 """
 
 from __future__ import annotations
 
 import sqlite3
+from datetime import date, timedelta
 from typing import Dict, List, Optional, Tuple
 
 # ---------------------------------------------------------------------------
@@ -174,3 +178,157 @@ def update_phoneme_stats(
             }
         )
     return updated
+
+
+# ============================================================================
+# Progress summary for GET /api/progress
+# ============================================================================
+
+_MIN_ATTEMPTS_FOR_PHONEME_LIST = 2
+
+
+def build_progress_response(
+    conn: sqlite3.Connection,
+    user_id: str = "default",
+) -> dict:
+    """Build the GET /api/progress response dict from runtime data.
+
+    Returns zero/empty defaults when no data exists (no crash).
+    """
+    # ---- accent from settings ------------------------------------------------
+    primary_accent = "US"
+    row = conn.execute(
+        "SELECT primary_accent FROM settings WHERE user_id = ?", (user_id,)
+    ).fetchone()
+    if row:
+        primary_accent = row["primary_accent"]
+
+    # ---- total attempts ------------------------------------------------------
+    total_row = conn.execute(
+        "SELECT COUNT(*) AS cnt FROM attempts WHERE user_id = ?", (user_id,)
+    ).fetchone()
+    total_attempts = total_row["cnt"] if total_row else 0
+
+    # ---- total sessions ------------------------------------------------------
+    sess_row = conn.execute(
+        "SELECT COUNT(*) AS cnt FROM daily_sessions WHERE user_id = ?",
+        (user_id,),
+    ).fetchone()
+    total_sessions = sess_row["cnt"] if sess_row else 0
+
+    # ---- today ---------------------------------------------------------------
+    today_str = date.today().isoformat()
+    today_row = conn.execute(
+        """
+        SELECT status FROM daily_sessions
+        WHERE user_id = ? AND session_date = ?
+        """,
+        (user_id, today_str),
+    ).fetchone()
+    today_status = today_row["status"] if today_row else "none"
+    today_completed = today_status == "completed"
+
+    # ---- streak --------------------------------------------------------------
+    streak_days = _compute_streak(conn, user_id)
+
+    # ---- weak / strong phonemes ----------------------------------------------
+    weak_phonemes, strong_phonemes = _compute_phoneme_lists(
+        conn, user_id, primary_accent
+    )
+
+    return {
+        "today_completed": today_completed,
+        "today_status": today_status,
+        "streak_days": streak_days,
+        "total_attempts": total_attempts,
+        "total_sessions": total_sessions,
+        "weak_phonemes": weak_phonemes,
+        "strong_phonemes": strong_phonemes,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Streak
+# ---------------------------------------------------------------------------
+
+
+def _compute_streak(conn: sqlite3.Connection, user_id: str) -> int:
+    """Count consecutive completed daily sessions.
+
+    Walks backwards from yesterday; a gap or incomplete day breaks the streak.
+    Days that are not completed before the streak starts are skipped.
+    """
+    rows = conn.execute(
+        """
+        SELECT session_date FROM daily_sessions
+        WHERE user_id = ? AND status = 'completed'
+        ORDER BY session_date DESC
+        """,
+        (user_id,),
+    ).fetchall()
+    completed_dates = {r["session_date"] for r in rows}
+
+    if not completed_dates:
+        return 0
+
+    streak = 0
+    d = date.today() - timedelta(days=1)  # start from yesterday
+
+    for _ in range(366):  # safety limit
+        ds = d.isoformat()
+        if ds in completed_dates:
+            streak += 1
+            d = d - timedelta(days=1)
+        else:
+            # First miss after streak started (or no streak yet) — break
+            break
+
+    return streak
+
+
+# ---------------------------------------------------------------------------
+# Weak / strong phoneme lists
+# ---------------------------------------------------------------------------
+
+
+def _compute_phoneme_lists(
+    conn: sqlite3.Connection, user_id: str, primary_accent: str
+) -> Tuple[List[dict], List[dict]]:
+    """Return (weak_phonemes, strong_phonemes) sorted lists from phoneme_stats.
+
+    Only includes phonemes with attempt_count >= _MIN_ATTEMPTS_FOR_PHONEME_LIST.
+    """
+    rows = conn.execute(
+        """
+        SELECT phoneme_id, attempt_count, correct_count, mastery_status
+        FROM phoneme_stats
+        WHERE user_id = ? AND primary_accent = ?
+          AND attempt_count >= ?
+        """,
+        (user_id, primary_accent, _MIN_ATTEMPTS_FOR_PHONEME_LIST),
+    ).fetchall()
+
+    entries: List[dict] = []
+    for r in rows:
+        acc = r["correct_count"] / r["attempt_count"] if r["attempt_count"] > 0 else 0.0
+        entries.append({
+            "phoneme": r["phoneme_id"],
+            "accuracy": round(acc, 2),
+            "attempt_count": r["attempt_count"],
+            "correct_count": r["correct_count"],
+            "mastery_status": r["mastery_status"],
+        })
+
+    # Weak: sort by low accuracy then higher attempt count
+    weak = sorted(
+        [e for e in entries if e["accuracy"] < 0.70],
+        key=lambda e: (e["accuracy"], -e["attempt_count"]),
+    )
+
+    # Strong: sort by high accuracy then higher attempt count
+    strong = sorted(
+        [e for e in entries if e["accuracy"] >= 0.85],
+        key=lambda e: (-e["accuracy"], -e["attempt_count"]),
+    )
+
+    return weak, strong

--- a/backend/tests/test_progress_api.py
+++ b/backend/tests/test_progress_api.py
@@ -1,0 +1,268 @@
+"""Tests for GET /api/progress — phoneme summary and streak."""
+
+from __future__ import annotations
+
+import sys
+from datetime import date, timedelta
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+_SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+from import_words import import_words  # noqa: E402
+from app.main import app  # noqa: E402
+from app.db import get_connection, get_db  # noqa: E402
+from app.services.db_schema import init_db  # noqa: E402
+from app.services.progress import build_progress_response  # noqa: E402
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures"
+CONTENT_SAMPLE = FIXTURES / "content_sample.json"
+PHONEMES_PATH = Path(__file__).resolve().parent.parent.parent / "content" / "phonemes.json"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(name="seeded_db")
+def seeded_db_fixture(tmp_path: Path) -> str:
+    """Database with imported content and default settings."""
+    db_path = str(tmp_path / "test.sqlite")
+    import_words(source_path=CONTENT_SAMPLE, phonemes_path=PHONEMES_PATH, db_path=db_path)
+    import app.db as db_mod
+    orig = db_mod.DEFAULT_DB_PATH
+    db_mod.DEFAULT_DB_PATH = db_path
+    yield db_path
+    db_mod.DEFAULT_DB_PATH = orig
+
+
+@pytest.fixture(name="client")
+def client_fixture(seeded_db: str) -> TestClient:
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestProgressApi:
+    """Integration tests for GET /api/progress."""
+
+    def test_empty_progress_returns_defaults(self, client):
+        """No attempts yet — returns zeros and empty lists."""
+        resp = client.get("/api/progress")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total_attempts"] == 0
+        assert data["total_sessions"] == 0
+        assert data["today_completed"] is False
+        assert data["streak_days"] == 0
+        assert data["weak_phonemes"] == []
+        assert data["strong_phonemes"] == []
+
+    def test_today_status_reflects_session(self, client, seeded_db):
+        """After creating today's session, progress reflects it."""
+        # Create today's session
+        client.get("/api/today")
+        resp = client.get("/api/progress")
+        data = resp.json()
+        assert data["today_status"] == "in_progress"
+        assert data["today_completed"] is False
+
+    def test_total_attempts_counted(self, client, seeded_db):
+        """After submitting attempts, total_attempts increases."""
+        # Get a session item
+        today = client.get("/api/today").json()
+        item = today["items"][0]
+
+        # Submit one attempt
+        client.post("/api/attempt", json={
+            "session_item_id": item["session_item_id"],
+            "selected_answer": item["display_ipa"],
+        })
+
+        resp = client.get("/api/progress")
+        data = resp.json()
+        assert data["total_attempts"] == 1
+        assert data["total_sessions"] > 0
+
+    def test_phoneme_lists_after_attempts(self, client, seeded_db):
+        """After several attempts across phonemes, weak/strong lists appear."""
+        today = client.get("/api/today").json()
+
+        # Submit 3 wrong answers for first item
+        for _ in range(3):
+            client.post("/api/attempt", json={
+                "session_item_id": today["items"][0]["session_item_id"],
+                "selected_answer": "/wrong/",
+            })
+
+        resp = client.get("/api/progress")
+        data = resp.json()
+        # Should have weak phonemes (low accuracy)
+        assert len(data["weak_phonemes"]) > 0
+        for wp in data["weak_phonemes"]:
+            assert wp["accuracy"] < 0.70
+            assert wp["attempt_count"] >= 2
+            assert "phoneme" in wp
+            assert "correct_count" in wp
+            assert "mastery_status" in wp
+
+    def test_empty_db_no_crash(self, tmp_path, monkeypatch):
+        """Fresh database with no content returns safe defaults."""
+        db_path = str(tmp_path / "empty.sqlite")
+        conn = get_connection(db_path)
+        init_db(conn)
+        conn.close()
+
+        import app.db as db_mod
+        orig = db_mod.DEFAULT_DB_PATH
+        db_mod.DEFAULT_DB_PATH = db_path
+        try:
+            c = TestClient(app)
+            resp = c.get("/api/progress")
+            assert resp.status_code == 200
+            data = resp.json()
+            assert data["total_attempts"] == 0
+            assert data["weak_phonemes"] == []
+        finally:
+            db_mod.DEFAULT_DB_PATH = orig
+
+    def test_response_shape(self, client):
+        """Response contains all documented fields."""
+        resp = client.get("/api/progress")
+        data = resp.json()
+        for key in (
+            "today_completed", "today_status", "streak_days",
+            "total_attempts", "total_sessions",
+            "weak_phonemes", "strong_phonemes",
+        ):
+            assert key in data, f"missing key: {key}"
+
+
+# ---------------------------------------------------------------------------
+# Streak
+# ---------------------------------------------------------------------------
+
+
+class TestStreak:
+    def test_no_sessions_zero_streak(self, tmp_path):
+        db_path = str(tmp_path / "test.sqlite")
+        conn = get_connection(db_path)
+        init_db(conn)
+        # Insert settings so build_progress_response doesn't 500
+        conn.execute(
+            "INSERT INTO settings VALUES ('default','US',10,1,0,'ipa_first','normal','2026-01-01T00:00:00Z')"
+        )
+        conn.commit()
+        resp = build_progress_response(conn)
+        conn.close()
+        assert resp["streak_days"] == 0
+
+    def test_consecutive_streak(self, tmp_path):
+        db_path = str(tmp_path / "test.sqlite")
+        conn = get_connection(db_path)
+        init_db(conn)
+        conn.execute(
+            "INSERT INTO settings VALUES ('default','US',10,1,0,'ipa_first','normal','2026-01-01T00:00:00Z')"
+        )
+        today = date.today()
+        yesterday = today - timedelta(days=1)
+        two_days_ago = today - timedelta(days=2)
+
+        # Completed yesterday and two days ago
+        for d in [yesterday, two_days_ago]:
+            conn.execute(
+                "INSERT INTO daily_sessions VALUES (?, 'default', ?, 'US', 'completed', ?, NULL)",
+                (f"{d.isoformat()}-default", d.isoformat(), f"{d.isoformat()}T10:00:00Z"),
+            )
+        conn.commit()
+        resp = build_progress_response(conn)
+        conn.close()
+        assert resp["streak_days"] == 2
+
+    def test_gap_breaks_streak(self, tmp_path):
+        db_path = str(tmp_path / "test.sqlite")
+        conn = get_connection(db_path)
+        init_db(conn)
+        conn.execute(
+            "INSERT INTO settings VALUES ('default','US',10,1,0,'ipa_first','normal','2026-01-01T00:00:00Z')"
+        )
+        today = date.today()
+        two_days_ago = today - timedelta(days=2)
+        four_days_ago = today - timedelta(days=4)
+
+        # Completed 2 days ago and 4 days ago (gap at 3 days ago)
+        for d in [two_days_ago, four_days_ago]:
+            conn.execute(
+                "INSERT INTO daily_sessions VALUES (?, 'default', ?, 'US', 'completed', ?, NULL)",
+                (f"{d.isoformat()}-default", d.isoformat(), f"{d.isoformat()}T10:00:00Z"),
+            )
+        conn.commit()
+        resp = build_progress_response(conn)
+        conn.close()
+        # Streak counts consecutive completed days ending at yesterday.
+        # Yesterday not completed → no active streak.
+        assert resp["streak_days"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Phoneme list ordering
+# ---------------------------------------------------------------------------
+
+
+class TestPhonemeOrdering:
+    def test_ordering(self, tmp_path):
+        db_path = str(tmp_path / "test.sqlite")
+        conn = get_connection(db_path)
+        init_db(conn)
+        conn.execute(
+            "INSERT INTO settings VALUES ('default','US',10,1,0,'ipa_first','normal','2026-01-01T00:00:00Z')"
+        )
+        # Insert stats with varying accuracy
+        stats = [
+            ("/ʃ/", 10, 9),   # 90% — strong
+            ("/ɪ/", 10, 5),   # 50% — weak
+            ("/p/", 5, 2),    # 40% — very weak
+            ("/k/", 8, 8),    # 100% — strong
+            ("/æ/", 6, 4),    # 67% — weak
+            ("/t/", 3, 3),    # 100% but only 3 attempts — strong (>= 85%)
+            ("/n/", 5, 5),    # 100% — strong
+            ("/θ/", 4, 1),    # 25% — very weak
+            ("/d/", 1, 1),    # below threshold — excluded
+        ]
+        for phoneme_id, cnt, correct in stats:
+            conn.execute(
+                "INSERT INTO phoneme_stats VALUES ('default','US',?,?,?,'2026-01-01T00:00:00Z',NULL,'new')",
+                (phoneme_id, cnt, correct),
+            )
+        conn.commit()
+
+        resp = build_progress_response(conn)
+        conn.close()
+
+        weak = resp["weak_phonemes"]
+        strong = resp["strong_phonemes"]
+
+        # All stats with attempt_count >= 2 should appear
+        # /d/ (1 attempt) excluded
+        assert len(weak) + len(strong) == 8  # 9 entries - 1 below threshold
+        assert len(weak) == 4  # /ɪ/ (50%), /p/ (40%), /æ/ (67%), /θ/ (25%)
+
+        # Weak sorted by low accuracy: /θ/ (25%) < /p/ (40%) < /ɪ/ (50%) < /æ/ (67%)
+        assert weak[0]["phoneme"] == "/θ/"
+        assert weak[3]["phoneme"] == "/æ/"
+
+        # Strong sorted by high accuracy: /k/ (100%) = /n/ (100%) > /ʃ/ (90%) > /t/ (100% but 3 att)
+        # Within same accuracy, higher attempt_count first
+        # /k/ (8) before /n/ (5) before /t/ (3)
+        assert strong[0]["phoneme"] == "/k/"
+        assert strong[1]["phoneme"] == "/n/"
+        assert strong[2]["phoneme"] == "/t/"
+        assert strong[3]["phoneme"] == "/ʃ/"


### PR DESCRIPTION
Closes #39

## Scope completed
- `services/progress.py` — build_progress_response: today status, streak, totals, weak/strong phoneme lists
- `routes/progress.py` — GET /api/progress
- `main.py` — registered progress router
- `test_progress_api.py` — 10 tests

## Verification
- 119 backend tests pass (10 new, 0 regressions)
## Completion handoff: batch checkpoint