### PR TITLE
[#40] Implement GET/PUT /api/settings with validation

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -10,6 +10,7 @@ from fastapi.staticfiles import StaticFiles
 from app.routes.health import router as health_router
 from app.routes.practice import router as practice_router
 from app.routes.attempts import router as attempts_router
+from app.routes.settings import router as settings_router
 
 app = FastAPI(title="Tiny IPA", version="0.1.0")
 
@@ -23,6 +24,7 @@ app.add_middleware(
 app.include_router(health_router, prefix="/api")
 app.include_router(practice_router, prefix="/api")
 app.include_router(attempts_router, prefix="/api")
+app.include_router(settings_router, prefix="/api")
 
 # Mount static audio directory for local dev. In production Nginx serves /audio/.
 _AUDIO_DIR = os.getenv("TINY_IPA_AUDIO_DIR", str(Path(__file__).resolve().parent.parent.parent / "audio"))

--- a/backend/app/routes/settings.py
+++ b/backend/app/routes/settings.py
@@ -1,0 +1,119 @@
+"""Settings endpoint — GET/PUT /api/settings."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, HTTPException, Request
+
+from app.db import get_db
+from app.models import Settings
+from app.services.db_store import get_settings, upsert_settings
+
+router = APIRouter()
+
+_VALID_ACCENTS = {"US", "UK"}
+_VALID_MODES = {"ipa_first", "reveal_first"}
+_VALID_STRENGTHS = {"normal", "extra_review", "quick"}
+
+
+@router.get("/settings")
+def settings_get():
+    """Return current settings for the default user."""
+    with get_db() as conn:
+        s = get_settings(conn, "default")
+        if s is None:
+            # Return defaults if never initialised
+            return {
+                "primary_accent": "US",
+                "daily_word_count": 10,
+                "show_translation": True,
+                "show_accent_compare": False,
+                "practice_mode": "ipa_first",
+                "review_strength": "normal",
+            }
+        return {
+            "primary_accent": s.primary_accent,
+            "daily_word_count": s.daily_word_count,
+            "show_translation": s.show_translation,
+            "show_accent_compare": s.show_accent_compare,
+            "practice_mode": s.practice_mode,
+            "review_strength": s.review_strength,
+        }
+
+
+@router.put("/settings")
+async def settings_put(request: Request):
+    """Update settings for the default user.
+
+    Accepts a partial update — only provided fields are changed.
+    """
+    body = await request.json()
+
+    with get_db() as conn:
+        existing = get_settings(conn, "default")
+        if existing is None:
+            existing = Settings(user_id="default")
+
+        # Validate and apply each field
+        errors = []
+
+        if "primary_accent" in body:
+            v = body["primary_accent"]
+            if v not in _VALID_ACCENTS:
+                errors.append(f"primary_accent must be one of {_VALID_ACCENTS}")
+            else:
+                existing.primary_accent = v
+
+        if "daily_word_count" in body:
+            v = body["daily_word_count"]
+            if not isinstance(v, int) or v < 1 or v > 50:
+                errors.append("daily_word_count must be an integer between 1 and 50")
+            else:
+                existing.daily_word_count = v
+
+        if "show_translation" in body:
+            v = body["show_translation"]
+            if not isinstance(v, bool):
+                errors.append("show_translation must be a boolean")
+            else:
+                existing.show_translation = v
+
+        if "show_accent_compare" in body:
+            v = body["show_accent_compare"]
+            if not isinstance(v, bool):
+                errors.append("show_accent_compare must be a boolean")
+            else:
+                existing.show_accent_compare = v
+
+        if "practice_mode" in body:
+            v = body["practice_mode"]
+            if v not in _VALID_MODES:
+                errors.append(f"practice_mode must be one of {_VALID_MODES}")
+            else:
+                existing.practice_mode = v
+
+        if "review_strength" in body:
+            v = body["review_strength"]
+            if v not in _VALID_STRENGTHS:
+                errors.append(f"review_strength must be one of {_VALID_STRENGTHS}")
+            else:
+                existing.review_strength = v
+
+        if errors:
+            raise HTTPException(
+                status_code=400,
+                detail={"error": "SETTINGS_INVALID", "detail": "; ".join(errors)},
+            )
+
+        existing.updated_at = datetime.now(timezone.utc).isoformat()
+        upsert_settings(conn, existing)
+
+        return {
+            "primary_accent": existing.primary_accent,
+            "daily_word_count": existing.daily_word_count,
+            "show_translation": existing.show_translation,
+            "show_accent_compare": existing.show_accent_compare,
+            "practice_mode": existing.practice_mode,
+            "review_strength": existing.review_strength,
+        }

--- a/backend/tests/test_settings_api.py
+++ b/backend/tests/test_settings_api.py
@@ -1,0 +1,112 @@
+"""Tests for GET/PUT /api/settings."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+_SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+from import_words import import_words  # noqa: E402
+from app.main import app  # noqa: E402
+from app.db import get_connection  # noqa: E402
+from app.services.db_schema import init_db  # noqa: E402
+from app.services.db_store import get_settings  # noqa: E402
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures"
+CONTENT_SAMPLE = FIXTURES / "content_sample.json"
+PHONEMES_PATH = Path(__file__).resolve().parent.parent.parent / "content" / "phonemes.json"
+
+
+@pytest.fixture(name="seeded_db")
+def seeded_db_fixture(tmp_path: Path) -> str:
+    """Database with imported content and default settings."""
+    db_path = str(tmp_path / "test.sqlite")
+    import_words(source_path=CONTENT_SAMPLE, phonemes_path=PHONEMES_PATH, db_path=db_path)
+    import app.db as db_mod
+    orig = db_mod.DEFAULT_DB_PATH
+    db_mod.DEFAULT_DB_PATH = db_path
+    yield db_path
+    db_mod.DEFAULT_DB_PATH = orig
+
+
+@pytest.fixture(name="client")
+def client_fixture(seeded_db: str) -> TestClient:
+    return TestClient(app)
+
+
+class TestSettingsApi:
+    """Integration tests for GET/PUT /api/settings."""
+
+    def test_get_returns_defaults(self, client):
+        resp = client.get("/api/settings")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["primary_accent"] == "US"
+        assert data["daily_word_count"] == 10
+        assert data["show_translation"] is True
+
+    def test_put_updates_and_persists(self, client, seeded_db):
+        resp = client.put("/api/settings", json={
+            "daily_word_count": 5,
+            "show_translation": False,
+        })
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["daily_word_count"] == 5
+        assert data["show_translation"] is False
+        # Other fields unchanged
+        assert data["primary_accent"] == "US"
+
+        # Verify persistence
+        conn = get_connection(seeded_db)
+        s = get_settings(conn, "default")
+        conn.close()
+        assert s is not None
+        assert s.daily_word_count == 5
+        assert s.show_translation is False
+
+    def test_put_invalid_daily_word_count(self, client):
+        resp = client.put("/api/settings", json={"daily_word_count": 100})
+        assert resp.status_code == 400
+        data = resp.json()
+        assert data["detail"]["error"] == "SETTINGS_INVALID"
+
+    def test_put_invalid_accent(self, client):
+        resp = client.put("/api/settings", json={"primary_accent": "JP"})
+        assert resp.status_code == 400
+        assert resp.json()["detail"]["error"] == "SETTINGS_INVALID"
+
+    def test_put_invalid_practice_mode(self, client):
+        resp = client.put("/api/settings", json={"practice_mode": "random"})
+        assert resp.status_code == 400
+        assert resp.json()["detail"]["error"] == "SETTINGS_INVALID"
+
+    def test_put_empty_body_noop(self, client):
+        """Empty body is accepted — no fields changed."""
+        resp = client.put("/api/settings", json={})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["daily_word_count"] == 10
+
+    def test_get_empty_db(self, tmp_path, monkeypatch):
+        """Settings GET returns defaults even without import."""
+        db_path = str(tmp_path / "empty.sqlite")
+        conn = get_connection(db_path)
+        init_db(conn)
+        conn.close()
+        import app.db as db_mod
+        orig = db_mod.DEFAULT_DB_PATH
+        db_mod.DEFAULT_DB_PATH = db_path
+        try:
+            c = TestClient(app)
+            resp = c.get("/api/settings")
+            assert resp.status_code == 200
+            assert resp.json()["daily_word_count"] == 10
+        finally:
+            db_mod.DEFAULT_DB_PATH = orig


### PR DESCRIPTION
Closes #40

## Scope completed
- `routes/settings.py` — GET/PUT /api/settings with per-field validation
- `main.py` — registered settings router
- `test_settings_api.py` — 7 tests

## Verification
- 116 backend tests pass (7 new)
## Completion handoff: batch checkpoint