### PR TITLE
Improve agent helper routing audits

### DIFF
--- a/tools/agents/README.md
+++ b/tools/agents/README.md
@@ -17,6 +17,7 @@ jq
 tools/agents/agent-inbox architect
 tools/agents/agent-inbox implementer
 tools/agents/agent-ready-queue
+tools/agents/agent-audit
 ```
 
 `agent-inbox` reads `needs:*` labels only. It deliberately avoids Project v2
@@ -29,8 +30,24 @@ per label.
 `agent-ready-queue` extracts `Execution Contract` lines so an Implementer can
 see which ready issues are immediately startable and which are waiting on
 `Depends on`. It reads both issue bodies and issue comments because many
-contracts are added after issue creation. It fetches the issue list once and
+contracts are added after issue creation. When multiple contracts exist, it
+uses the latest highest-priority contract: `Final Execution Contract`, then
+`Execution Contract`, then `Draft Execution Contract`. This prevents stale
+draft contracts in issue bodies from overriding newer final handoffs.
+It also prints a dependency gate hint, such as `Gate: startable` or
+`Gate: waiting on #39`, so Implementers do not need to inspect every dependency
+manually before deciding what to pick up. It fetches the issue list once and
 then reads comments only for the queued issues.
+
+`agent-audit` is a read-only consistency check. It looks for common workflow
+drift without touching GitHub Project v2:
+
+- open issues with multiple `needs:*` labels
+- open task issues with no next-action label, annotated as `pickup confirmed`
+  or `unrouted`
+- closed issues that still carry next-action labels
+- `needs:implementer` issues with missing contract fields
+- open PRs whose base branch does not match the linked issue contract
 
 ## Context Pickup
 

--- a/tools/agents/_lib.sh
+++ b/tools/agents/_lib.sh
@@ -32,3 +32,75 @@ extract_contract_line() {
     }
   ' <<< "$text"
 }
+
+extract_latest_contract_block() {
+  local text="$1"
+
+  awk '
+    function priority(header) {
+      if (header == "Final Execution Contract") return 3
+      if (header == "Execution Contract") return 2
+      if (header == "Draft Execution Contract") return 1
+      return 0
+    }
+    function flush_current() {
+      if (!in_contract) return
+      if (current_priority > best_priority ||
+          (current_priority == best_priority && current_order > best_order)) {
+        best_priority = current_priority
+        best_order = current_order
+        best_block = current_block
+      }
+    }
+
+    /^## (Final Execution Contract|Execution Contract|Draft Execution Contract)[[:space:]]*$/ {
+      flush_current()
+      in_contract = 1
+      current_order += 1
+      current_header = $0
+      sub(/^## /, "", current_header)
+      current_priority = priority(current_header)
+      current_block = $0 "\n"
+      next
+    }
+
+    /^## / {
+      flush_current()
+      in_contract = 0
+      current_block = ""
+      current_priority = 0
+      next
+    }
+
+    {
+      if (in_contract) {
+        current_block = current_block $0 "\n"
+      }
+    }
+
+    END {
+      flush_current()
+      if (best_block != "") {
+        printf "%s", best_block
+      }
+    }
+  ' <<< "$text"
+}
+
+contract_header() {
+  local text="$1"
+
+  awk '
+    /^## (Final Execution Contract|Execution Contract|Draft Execution Contract)[[:space:]]*$/ {
+      sub(/^## /, "")
+      print
+      found = 1
+      exit
+    }
+    END {
+      if (!found) {
+        print "Execution Contract MISSING"
+      }
+    }
+  ' <<< "$text"
+}

--- a/tools/agents/agent-audit
+++ b/tools/agents/agent-audit
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo="${GH_REPO:-farmerhunter/tiny-ipa}"
+limit="${AGENT_AUDIT_LIMIT:-100}"
+comments_limit="${AGENT_COMMENTS_LIMIT:-100}"
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+gh_retry="$root/tools/agents/gh-retry"
+source "$root/tools/agents/_lib.sh"
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  tools/agents/agent-audit
+
+Runs a read-only consistency audit for the label/comment based agent workflow.
+This intentionally avoids GitHub Project v2 so it stays fast and robust.
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" || $# -gt 0 ]]; then
+  usage
+  exit 0
+fi
+
+next_labels=(needs:architect needs:implementer needs:user needs:ci needs:merge blocked)
+issues_json="$("$gh_retry" gh api -X GET "$(repo_api_path "$repo")/issues" \
+  -f state=open \
+  -f per_page="$limit")"
+prs_json="$("$gh_retry" gh api -X GET "$(repo_api_path "$repo")/pulls" \
+  -f state=open \
+  -f per_page="$limit")"
+
+printf '== Agent Workflow Audit ==\n'
+
+printf '\n== Open issues with multiple next-action labels ==\n'
+multi_count=0
+while IFS= read -r issue_json; do
+  [[ -z "$issue_json" ]] && continue
+  labels="$(jq -r '[.labels[].name] | join("\n")' <<< "$issue_json")"
+  matched=()
+  for label in "${next_labels[@]}"; do
+    if grep -Fxq "$label" <<< "$labels"; then
+      matched+=("$label")
+    fi
+  done
+  if (( ${#matched[@]} > 1 )); then
+    multi_count=$((multi_count + 1))
+    printf '#%s %s\n  labels: %s\n  %s\n' \
+      "$(jq -r '.number' <<< "$issue_json")" \
+      "$(jq -r '.title' <<< "$issue_json")" \
+      "$(IFS=,; echo "${matched[*]}")" \
+      "$(jq -r '.html_url' <<< "$issue_json")"
+  fi
+done < <(jq -c '.[] | select(has("pull_request") | not)' <<< "$issues_json")
+if [[ "$multi_count" -eq 0 ]]; then
+  printf 'none\n'
+fi
+
+printf '\n== Open task issues without next-action labels ==\n'
+unrouted_count=0
+while IFS= read -r issue_json; do
+  [[ -z "$issue_json" ]] && continue
+  labels="$(jq -r '[.labels[].name] | join("\n")' <<< "$issue_json")"
+  has_next=0
+  for label in "${next_labels[@]}"; do
+    if grep -Fxq "$label" <<< "$labels"; then
+      has_next=1
+    fi
+  done
+  if [[ "$has_next" -eq 0 ]] && grep -Fxq "type:task" <<< "$labels"; then
+    issue="$(jq -r '.number' <<< "$issue_json")"
+    comments="$("$gh_retry" gh api -X GET "$(repo_api_path "$repo")/issues/$issue/comments" \
+      -f per_page="$comments_limit" \
+      --jq '[.[].body] | join("\n")')"
+    if grep -Fq "Pickup confirmed" <<< "$comments"; then
+      state_hint="pickup confirmed"
+    else
+      state_hint="unrouted"
+    fi
+    unrouted_count=$((unrouted_count + 1))
+    printf '#%s %s\n  state hint: %s\n  %s\n' \
+      "$issue" \
+      "$(jq -r '.title' <<< "$issue_json")" \
+      "$state_hint" \
+      "$(jq -r '.html_url' <<< "$issue_json")"
+  fi
+done < <(jq -c '.[] | select(has("pull_request") | not)' <<< "$issues_json")
+if [[ "$unrouted_count" -eq 0 ]]; then
+  printf 'none\n'
+fi
+
+printf '\n== Closed issues still carrying next-action labels ==\n'
+closed_count=0
+for label in "${next_labels[@]}"; do
+  closed_json="$("$gh_retry" gh api -X GET "$(repo_api_path "$repo")/issues" \
+    -f state=closed \
+    -f labels="$label" \
+    -f per_page=30)"
+  while IFS= read -r issue_json; do
+    [[ -z "$issue_json" ]] && continue
+    closed_count=$((closed_count + 1))
+    printf '#%s %s\n  label: %s\n  %s\n' \
+      "$(jq -r '.number' <<< "$issue_json")" \
+      "$(jq -r '.title' <<< "$issue_json")" \
+      "$label" \
+      "$(jq -r '.html_url' <<< "$issue_json")"
+  done < <(jq -c '.[] | select(has("pull_request") | not)' <<< "$closed_json")
+done
+if [[ "$closed_count" -eq 0 ]]; then
+  printf 'none\n'
+fi
+
+printf '\n== needs:implementer contract gaps ==\n'
+gap_count=0
+while IFS= read -r issue_json; do
+  [[ -z "$issue_json" ]] && continue
+  issue="$(jq -r '.number' <<< "$issue_json")"
+  title="$(jq -r '.title' <<< "$issue_json")"
+  body="$(jq -r '.body // ""' <<< "$issue_json")"
+  comments="$("$gh_retry" gh api -X GET "$(repo_api_path "$repo")/issues/$issue/comments" \
+    -f per_page="$comments_limit" \
+    --jq '[.[].body] | join("\n")')"
+  contract="$(extract_latest_contract_block "$body"$'\n'"$comments")"
+  missing=()
+  for prefix in "Branch strategy:" "Base branch:" "Target PR base:" "Depends on:" "Completion handoff:"; do
+    line="$(extract_contract_line "$prefix" "$contract")"
+    if [[ "$line" == "$prefix MISSING" ]]; then
+      missing+=("$prefix")
+    fi
+  done
+  if (( ${#missing[@]} > 0 )); then
+    gap_count=$((gap_count + 1))
+    printf '#%s %s\n  missing: %s\n  contract: %s\n  %s\n' \
+      "$issue" "$title" "$(IFS=,; echo "${missing[*]}")" \
+      "$(contract_header "$contract")" "$(jq -r '.html_url' <<< "$issue_json")"
+  fi
+done < <(jq -c '.[] |
+  select(has("pull_request") | not) |
+  select(any(.labels[].name; . == "needs:implementer"))' <<< "$issues_json")
+if [[ "$gap_count" -eq 0 ]]; then
+  printf 'none\n'
+fi
+
+printf '\n== Open PRs with suspicious base branch ==\n'
+base_count=0
+while IFS= read -r pr_json; do
+  [[ -z "$pr_json" ]] && continue
+  pr="$(jq -r '.number' <<< "$pr_json")"
+  base="$(jq -r '.base.ref' <<< "$pr_json")"
+  title="$(jq -r '.title' <<< "$pr_json")"
+  body="$(jq -r '.body // ""' <<< "$pr_json")"
+  issue="$(
+    printf '%s\n%s\n' "$title" "$body" |
+      sed -nE 's/.*#([0-9]+).*/\1/p' |
+      head -n 1
+  )"
+  if [[ -z "$issue" ]]; then
+    continue
+  fi
+  issue_json="$("$gh_retry" gh api "$(repo_api_path "$repo")/issues/$issue" 2>/dev/null || true)"
+  if [[ -z "$issue_json" ]]; then
+    continue
+  fi
+  issue_body="$(jq -r '.body // ""' <<< "$issue_json")"
+  comments="$("$gh_retry" gh api -X GET "$(repo_api_path "$repo")/issues/$issue/comments" \
+    -f per_page="$comments_limit" \
+    --jq '[.[].body] | join("\n")')"
+  contract="$(extract_latest_contract_block "$issue_body"$'\n'"$comments")"
+  target_line="$(extract_contract_line "Target PR base:" "$contract")"
+  target="$(sed -nE 's/^Target PR base: `?([^` ]+)`?.*/\1/p' <<< "$target_line")"
+  if [[ -n "$target" && "$target" != "MISSING" && "$target" != "$base" ]]; then
+    base_count=$((base_count + 1))
+    printf '#%s %s\n  base: %s\n  contract target: %s\n  issue: #%s\n  %s\n' \
+      "$pr" "$title" "$base" "$target" "$issue" "$(jq -r '.html_url' <<< "$pr_json")"
+  fi
+done < <(jq -c '.[]' <<< "$prs_json")
+if [[ "$base_count" -eq 0 ]]; then
+  printf 'none\n'
+fi

--- a/tools/agents/agent-ready-queue
+++ b/tools/agents/agent-ready-queue
@@ -13,8 +13,9 @@ usage() {
 Usage:
   tools/agents/agent-ready-queue
 
-Lists needs:implementer issues and extracts the Execution Contract lines
-that determine queue order. A Ready issue may still be blocked by Depends on.
+Lists needs:implementer issues and extracts the latest effective Execution
+Contract lines that determine queue order. A Ready issue may still be blocked
+by Depends on.
 
 Uses REST API calls instead of `gh issue list/view` to avoid GraphQL timeouts.
 USAGE
@@ -35,6 +36,38 @@ if [[ "$(jq 'length' <<< "$issues_json")" -eq 0 ]]; then
   exit 0
 fi
 
+dependency_gate() {
+  local depends_line="$1"
+  local deps
+  local waiting=()
+  local dep state
+
+  if [[ "$depends_line" == *"none;"* || "$depends_line" == *"none"* ]]; then
+    printf 'Gate: startable'
+    return
+  fi
+
+  deps="$(grep -Eo '#[0-9]+' <<< "$depends_line" | tr -d '#')"
+  if [[ -z "$deps" ]]; then
+    printf 'Gate: manual check'
+    return
+  fi
+
+  while IFS= read -r dep; do
+    [[ -z "$dep" ]] && continue
+    state="$("$gh_retry" gh api "$(repo_api_path "$repo")/issues/$dep" --jq '.state')"
+    if [[ "$state" != "closed" ]]; then
+      waiting+=("#$dep")
+    fi
+  done <<< "$deps"
+
+  if (( ${#waiting[@]} == 0 )); then
+    printf 'Gate: startable'
+  else
+    printf 'Gate: waiting on %s' "$(IFS=,; echo "${waiting[*]}")"
+  fi
+}
+
 while IFS= read -r issue_json; do
   [[ -z "$issue_json" ]] && continue
   issue="$(jq -r '.number' <<< "$issue_json")"
@@ -45,10 +78,18 @@ while IFS= read -r issue_json; do
     -f per_page="$comments_limit" \
     --jq '[.[].body] | join("\n")')"
   text="$body"$'\n'"$comments"
+  contract="$(extract_latest_contract_block "$text")"
+  if [[ -z "$contract" ]]; then
+    contract=""
+  fi
 
   printf '#%s %s\n  %s\n' "$issue" "$title" "$url"
-  printf '  %s\n' "$(extract_contract_line "Branch strategy:" "$text")"
-  printf '  %s\n' "$(extract_contract_line "Base branch:" "$text")"
-  printf '  %s\n' "$(extract_contract_line "Target PR base:" "$text")"
-  printf '  %s\n' "$(extract_contract_line "Depends on:" "$text")"
+  printf '  Contract: %s\n' "$(contract_header "$contract")"
+  printf '  %s\n' "$(extract_contract_line "Branch strategy:" "$contract")"
+  printf '  %s\n' "$(extract_contract_line "Base branch:" "$contract")"
+  printf '  %s\n' "$(extract_contract_line "Target PR base:" "$contract")"
+  depends_line="$(extract_contract_line "Depends on:" "$contract")"
+  printf '  %s\n' "$depends_line"
+  printf '  %s\n' "$(dependency_gate "$depends_line")"
+  printf '  %s\n' "$(extract_contract_line "Completion handoff:" "$contract")"
 done < <(jq -c '.[]' <<< "$issues_json")


### PR DESCRIPTION
## Scope

Improve the project-local agent helpers used for Tiny IPA's GitHub-based multi-agent workflow.

Changes:
- `agent-ready-queue` now selects the latest effective contract instead of the first stale draft it sees.
- `agent-ready-queue` prints contract type and `Completion handoff`.
- `agent-ready-queue` prints dependency gate hints such as `Gate: startable` or `Gate: waiting on #39`.
- New `agent-audit` read-only consistency checker for common label/comment workflow drift.
- README updated with the new behavior and audit command.

## Verification

- `bash -n tools/agents/_lib.sh tools/agents/agent-ready-queue tools/agents/agent-audit tools/agents/agent-inbox tools/agents/agent-label tools/agents/agent-pr-context tools/agents/agent-issue-context tools/agents/agent-project-status tools/agents/gh-retry`
- `tools/agents/agent-ready-queue`
- `tools/agents/agent-audit`

## Notes

This is a tooling-only PR. It does not change backend/frontend product behavior.
