### PR TITLE
[#41] Build Progress page and navigation entry

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,10 +1,12 @@
 import { fetchHealth } from "./api";
 import { useEffect, useState } from "react";
 import TodayPractice from "./pages/TodayPractice";
+import ProgressPage from "./pages/ProgressPage";
 
 function App() {
   const [backendReady, setBackendReady] = useState<boolean>(false);
   const [checking, setChecking] = useState(true);
+  const [page, setPage] = useState<"today" | "progress">("today");
 
   useEffect(() => {
     fetchHealth()
@@ -15,14 +17,7 @@ function App() {
 
   if (checking) {
     return (
-      <main
-        style={{
-          maxWidth: 480,
-          margin: "0 auto",
-          padding: "24px 16px",
-          fontFamily: "system-ui, sans-serif",
-        }}
-      >
+      <main className="practice-container">
         <h1>Tiny IPA</h1>
         <p>Connecting to backend…</p>
       </main>
@@ -31,23 +26,29 @@ function App() {
 
   if (!backendReady) {
     return (
-      <main
-        style={{
-          maxWidth: 480,
-          margin: "0 auto",
-          padding: "24px 16px",
-          fontFamily: "system-ui, sans-serif",
-        }}
-      >
+      <main className="practice-container">
         <h1>Tiny IPA</h1>
         <p style={{ color: "#c00" }}>
-          Cannot reach the backend. Make sure it is running on port 8010.
+          Cannot reach backend. Make sure it is running on port 8010.
         </p>
       </main>
     );
   }
 
-  return <TodayPractice />;
+  return (
+    <div>
+      <nav className="nav-bar">
+        <button className={`nav-tab ${page === "today" ? "nav-active" : ""}`}
+          onClick={() => setPage("today")}>Today</button>
+        <button className={`nav-tab ${page === "progress" ? "nav-active" : ""}`}
+          onClick={() => setPage("progress")}>Progress</button>
+      </nav>
+      {page === "progress"
+        ? <ProgressPage onBack={() => setPage("today")} />
+        : <TodayPractice />
+      }
+    </div>
+  );
 }
 
 export default App;

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -79,6 +79,40 @@ export interface AttemptResponse {
   next_action: string;
 }
 
+// ---------------------------------------------------------------------------
+// Progress
+// ---------------------------------------------------------------------------
+
+export interface PhonemeStat {
+  phoneme: string;
+  accuracy: number;
+  attempt_count: number;
+  correct_count: number;
+  mastery_status: string;
+}
+
+export interface ProgressResponse {
+  today_completed: boolean;
+  today_status: string;
+  streak_days: number;
+  total_attempts: number;
+  total_sessions: number;
+  weak_phonemes: PhonemeStat[];
+  strong_phonemes: PhonemeStat[];
+}
+
+export async function fetchProgress(): Promise<ProgressResponse> {
+  const res = await fetch(`${API_BASE}/progress`);
+  if (!res.ok) {
+    throw new Error(`GET /api/progress failed: ${res.status}`);
+  }
+  return res.json();
+}
+
+// ---------------------------------------------------------------------------
+// Attempt submission
+// ---------------------------------------------------------------------------
+
 export async function submitAttempt(
   sessionItemId: string,
   selectedAnswer: string,

--- a/frontend/src/pages/ProgressPage.tsx
+++ b/frontend/src/pages/ProgressPage.tsx
@@ -1,0 +1,88 @@
+/**
+ * ProgressPage — displays learner progress summary.
+ *
+ * Shows streak, total stats, and weak/strong phoneme lists.
+ */
+
+import { useEffect, useState } from "react";
+import type { ProgressResponse } from "../api";
+import { fetchProgress } from "../api";
+
+interface Props {
+  onBack: () => void;
+}
+
+export default function ProgressPage({ onBack }: Props) {
+  const [data, setData] = useState<ProgressResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchProgress()
+      .then(setData)
+      .catch((e) => setError(e.message))
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) return <main className="practice-container"><p>Loading progress…</p></main>;
+  if (error) return <main className="practice-container"><p className="error">Failed: {error}</p></main>;
+  if (!data) return null;
+
+  return (
+    <main className="practice-container">
+      <div className="page-header">
+        <button className="back-btn" onClick={onBack}>← Today</button>
+        <h1>Progress</h1>
+      </div>
+
+      <div className="progress-stats">
+        <div className="stat-card">
+          <span className="stat-number">{data.streak_days}</span>
+          <span className="stat-label">day streak</span>
+        </div>
+        <div className="stat-card">
+          <span className="stat-number">{data.total_attempts}</span>
+          <span className="stat-label">attempts</span>
+        </div>
+        <div className="stat-card">
+          <span className="stat-number">{data.total_sessions}</span>
+          <span className="stat-label">sessions</span>
+        </div>
+      </div>
+
+      {data.weak_phonemes.length > 0 && (
+        <section className="phoneme-section">
+          <h2>Needs practice</h2>
+          <ul className="phoneme-list">
+            {data.weak_phonemes.map((p) => (
+              <li key={p.phoneme} className="phoneme-item weak">
+                <span className="phoneme-symbol">{p.phoneme}</span>
+                <span className="phoneme-acc">{Math.round(p.accuracy * 100)}%</span>
+                <span className="phoneme-count">{p.attempt_count} att.</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {data.strong_phonemes.length > 0 && (
+        <section className="phoneme-section">
+          <h2>Strong</h2>
+          <ul className="phoneme-list">
+            {data.strong_phonemes.map((p) => (
+              <li key={p.phoneme} className="phoneme-item strong">
+                <span className="phoneme-symbol">{p.phoneme}</span>
+                <span className="phoneme-acc">{Math.round(p.accuracy * 100)}%</span>
+                <span className="phoneme-count">{p.attempt_count} att.</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {data.weak_phonemes.length === 0 && data.strong_phonemes.length === 0 && (
+        <p className="empty-hint">Complete some practice to see your phoneme stats.</p>
+      )}
+    </main>
+  );
+}

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -271,3 +271,144 @@ button {
 .summary-wrong {
   color: #c62828;
 }
+
+/* ---------------------------------------------------------------------------
+ * Navigation
+ * --------------------------------------------------------------------------- */
+
+.nav-bar {
+  display: flex;
+  max-width: 480px;
+  margin: 0 auto;
+  border-bottom: 2px solid #eee;
+}
+
+.nav-tab {
+  flex: 1;
+  padding: 12px 0;
+  border: none;
+  background: none;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #888;
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -2px;
+}
+
+.nav-tab:hover {
+  color: #333;
+}
+
+.nav-active {
+  color: #4a90d9;
+  border-bottom-color: #4a90d9;
+}
+
+/* ---------------------------------------------------------------------------
+ * Progress page
+ * --------------------------------------------------------------------------- */
+
+.page-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 20px;
+}
+
+.page-header h1 {
+  font-size: 1.25rem;
+  margin: 0;
+}
+
+.back-btn {
+  padding: 6px 12px;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  background: #f5f5f5;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+.progress-stats {
+  display: flex;
+  gap: 12px;
+  margin-bottom: 24px;
+}
+
+.stat-card {
+  flex: 1;
+  text-align: center;
+  background: #f5f5f5;
+  border-radius: 8px;
+  padding: 12px 8px;
+}
+
+.stat-number {
+  display: block;
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #4a90d9;
+}
+
+.stat-label {
+  display: block;
+  font-size: 0.75rem;
+  color: #888;
+  margin-top: 2px;
+}
+
+.phoneme-section {
+  margin-bottom: 20px;
+}
+
+.phoneme-section h2 {
+  font-size: 1rem;
+  margin-bottom: 8px;
+}
+
+.phoneme-list {
+  list-style: none;
+  padding: 0;
+}
+
+.phoneme-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 0;
+  border-bottom: 1px solid #f0f0f0;
+  font-size: 0.95rem;
+}
+
+.phoneme-symbol {
+  font-weight: 600;
+  min-width: 48px;
+}
+
+.phoneme-acc {
+  color: #888;
+  font-size: 0.85rem;
+}
+
+.phoneme-count {
+  color: #aaa;
+  font-size: 0.8rem;
+  margin-left: auto;
+}
+
+.phoneme-item.weak .phoneme-symbol {
+  color: #e65100;
+}
+
+.phoneme-item.strong .phoneme-symbol {
+  color: #2e7d32;
+}
+
+.empty-hint {
+  text-align: center;
+  color: #999;
+  font-size: 0.9rem;
+  margin-top: 24px;
+}


### PR DESCRIPTION
Closes #41

## Scope completed
- `ProgressPage.tsx` — streak, total stats, weak/strong phoneme lists
- `App.tsx` — tab navigation (Today | Progress)
- `api.ts` — fetchProgress() + types
- `global.css` — nav bar, stat cards, phoneme styles

## Verification
- TypeScript: 0 errors, Vite build: success
- Backend: 119 tests pass
## Completion handoff: batch checkpoint