### PR TITLE
[#42] Build Settings page wired to settings API

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,11 +2,12 @@ import { fetchHealth } from "./api";
 import { useEffect, useState } from "react";
 import TodayPractice from "./pages/TodayPractice";
 import ProgressPage from "./pages/ProgressPage";
+import SettingsPage from "./pages/SettingsPage";
 
 function App() {
   const [backendReady, setBackendReady] = useState<boolean>(false);
   const [checking, setChecking] = useState(true);
-  const [page, setPage] = useState<"today" | "progress">("today");
+  const [page, setPage] = useState<"today" | "progress" | "settings">("today");
 
   useEffect(() => {
     fetchHealth()
@@ -42,9 +43,13 @@ function App() {
           onClick={() => setPage("today")}>Today</button>
         <button className={`nav-tab ${page === "progress" ? "nav-active" : ""}`}
           onClick={() => setPage("progress")}>Progress</button>
+        <button className={`nav-tab ${page === "settings" ? "nav-active" : ""}`}
+          onClick={() => setPage("settings")}>Settings</button>
       </nav>
       {page === "progress"
         ? <ProgressPage onBack={() => setPage("today")} />
+        : page === "settings"
+        ? <SettingsPage onBack={() => setPage("today")} />
         : <TodayPractice />
       }
     </div>

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -147,3 +147,52 @@ export async function submitAttempt(
   }
   return res.json();
 }
+
+// ---------------------------------------------------------------------------
+// Settings
+// ---------------------------------------------------------------------------
+
+export interface SettingsData {
+  primary_accent: string;
+  daily_word_count: number;
+  show_translation: boolean;
+  show_accent_compare: boolean;
+  practice_mode: string;
+  review_strength: string;
+}
+
+export async function fetchSettings(): Promise<SettingsData> {
+  const res = await fetch(`${API_BASE}/settings`);
+  if (!res.ok) {
+    throw new Error(`GET /api/settings failed: ${res.status}`);
+  }
+  return res.json();
+}
+
+export async function saveSettings(
+  data: Partial<SettingsData>,
+): Promise<SettingsData> {
+  const res = await fetch(`${API_BASE}/settings`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) {
+    let message = `Request failed (HTTP ${res.status})`;
+    try {
+      const body = await res.json();
+      const inner = body.detail ?? body;
+      if (typeof inner === "object" && inner !== null) {
+        const code = inner.error ?? "";
+        const text = inner.detail ?? JSON.stringify(inner);
+        message = code ? `${code}: ${text}` : String(text);
+      } else if (typeof inner === "string") {
+        message = inner;
+      }
+    } catch {
+      // Fall through with the default message.
+    }
+    throw new Error(message);
+  }
+  return res.json();
+}

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,39 +1,17 @@
 /**
  * SettingsPage — display and edit user settings.
+ *
+ * Only exposes MVP-supported controls.  Future settings (UK accent,
+ * reveal_first, extra_review/quick, accent compare) are intentionally
+ * hidden until the practice flow supports them.
  */
 
 import { useEffect, useState } from "react";
-
-interface SettingsData {
-  primary_accent: string;
-  daily_word_count: number;
-  show_translation: boolean;
-  show_accent_compare: boolean;
-  practice_mode: string;
-  review_strength: string;
-}
-
-const API_BASE = import.meta.env.VITE_API_BASE ?? "/api";
-
-async function fetchSettings(): Promise<SettingsData> {
-  const res = await fetch(`${API_BASE}/settings`);
-  if (!res.ok) throw new Error("Failed to load settings");
-  return res.json();
-}
-
-async function saveSettings(data: Partial<SettingsData>): Promise<SettingsData> {
-  const res = await fetch(`${API_BASE}/settings`, {
-    method: "PUT",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(data),
-  });
-  if (!res.ok) {
-    const body = await res.json().catch(() => ({}));
-    const inner = body.detail ?? body;
-    throw new Error(typeof inner === "string" ? inner : inner.detail ?? "Save failed");
-  }
-  return res.json();
-}
+import {
+  type SettingsData,
+  fetchSettings,
+  saveSettings,
+} from "../api";
 
 interface Props {
   onBack: () => void;
@@ -46,7 +24,10 @@ export default function SettingsPage({ onBack }: Props) {
   const [saved, setSaved] = useState(false);
 
   useEffect(() => {
-    fetchSettings().then(setSettings).catch(e => setError(e.message)).finally(() => setLoading(false));
+    fetchSettings()
+      .then(setSettings)
+      .catch((e) => setError(e.message))
+      .finally(() => setLoading(false));
   }, []);
 
   if (loading) return <main className="practice-container"><p>Loading…</p></main>;
@@ -77,38 +58,12 @@ export default function SettingsPage({ onBack }: Props) {
       {error && <p className="save-error">⚠️ {error}</p>}
 
       <div className="settings-form">
+        {/* ---- MVP-supported controls ---- */}
+
         <label className="setting-row">
           <span>Words per day</span>
           <input type="number" min={1} max={50} value={settings.daily_word_count}
             onChange={e => update({ daily_word_count: Number(e.target.value) })} />
-        </label>
-
-        <label className="setting-row">
-          <span>Primary accent</span>
-          <select value={settings.primary_accent}
-            onChange={e => update({ primary_accent: e.target.value })}>
-            <option value="US">US</option>
-            <option value="UK">UK</option>
-          </select>
-        </label>
-
-        <label className="setting-row">
-          <span>Practice mode</span>
-          <select value={settings.practice_mode}
-            onChange={e => update({ practice_mode: e.target.value })}>
-            <option value="ipa_first">IPA first</option>
-            <option value="reveal_first">Reveal first</option>
-          </select>
-        </label>
-
-        <label className="setting-row">
-          <span>Review strength</span>
-          <select value={settings.review_strength}
-            onChange={e => update({ review_strength: e.target.value })}>
-            <option value="normal">Normal</option>
-            <option value="extra_review">Extra review</option>
-            <option value="quick">Quick</option>
-          </select>
         </label>
 
         <label className="setting-row">
@@ -117,11 +72,24 @@ export default function SettingsPage({ onBack }: Props) {
             onChange={e => update({ show_translation: e.target.checked })} />
         </label>
 
+        {/* ---- Future controls (hidden until practice flow supports them) ----
+        <label className="setting-row">
+          <span>Primary accent</span>
+          <select value={settings.primary_accent} … />
+        </label>
+        <label className="setting-row">
+          <span>Practice mode</span>
+          <select value={settings.practice_mode} … />
+        </label>
+        <label className="setting-row">
+          <span>Review strength</span>
+          <select value={settings.review_strength} … />
+        </label>
         <label className="setting-row">
           <span>Show accent compare</span>
-          <input type="checkbox" checked={settings.show_accent_compare}
-            onChange={e => update({ show_accent_compare: e.target.checked })} />
+          <input type="checkbox" checked={settings.show_accent_compare} … />
         </label>
+        ---- */}
       </div>
     </main>
   );

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,0 +1,128 @@
+/**
+ * SettingsPage — display and edit user settings.
+ */
+
+import { useEffect, useState } from "react";
+
+interface SettingsData {
+  primary_accent: string;
+  daily_word_count: number;
+  show_translation: boolean;
+  show_accent_compare: boolean;
+  practice_mode: string;
+  review_strength: string;
+}
+
+const API_BASE = import.meta.env.VITE_API_BASE ?? "/api";
+
+async function fetchSettings(): Promise<SettingsData> {
+  const res = await fetch(`${API_BASE}/settings`);
+  if (!res.ok) throw new Error("Failed to load settings");
+  return res.json();
+}
+
+async function saveSettings(data: Partial<SettingsData>): Promise<SettingsData> {
+  const res = await fetch(`${API_BASE}/settings`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    const inner = body.detail ?? body;
+    throw new Error(typeof inner === "string" ? inner : inner.detail ?? "Save failed");
+  }
+  return res.json();
+}
+
+interface Props {
+  onBack: () => void;
+}
+
+export default function SettingsPage({ onBack }: Props) {
+  const [settings, setSettings] = useState<SettingsData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [saved, setSaved] = useState(false);
+
+  useEffect(() => {
+    fetchSettings().then(setSettings).catch(e => setError(e.message)).finally(() => setLoading(false));
+  }, []);
+
+  if (loading) return <main className="practice-container"><p>Loading…</p></main>;
+  if (error) return <main className="practice-container"><p className="error">{error}</p></main>;
+  if (!settings) return null;
+
+  const update = async (patch: Partial<SettingsData>) => {
+    setError(null);
+    setSaved(false);
+    try {
+      const updated = await saveSettings(patch);
+      setSettings(updated);
+      setSaved(true);
+      setTimeout(() => setSaved(false), 2000);
+    } catch (e: any) {
+      setError(e.message);
+    }
+  };
+
+  return (
+    <main className="practice-container">
+      <div className="page-header">
+        <button className="back-btn" onClick={onBack}>← Today</button>
+        <h1>Settings</h1>
+      </div>
+
+      {saved && <p className="save-confirm">✅ Saved</p>}
+      {error && <p className="save-error">⚠️ {error}</p>}
+
+      <div className="settings-form">
+        <label className="setting-row">
+          <span>Words per day</span>
+          <input type="number" min={1} max={50} value={settings.daily_word_count}
+            onChange={e => update({ daily_word_count: Number(e.target.value) })} />
+        </label>
+
+        <label className="setting-row">
+          <span>Primary accent</span>
+          <select value={settings.primary_accent}
+            onChange={e => update({ primary_accent: e.target.value })}>
+            <option value="US">US</option>
+            <option value="UK">UK</option>
+          </select>
+        </label>
+
+        <label className="setting-row">
+          <span>Practice mode</span>
+          <select value={settings.practice_mode}
+            onChange={e => update({ practice_mode: e.target.value })}>
+            <option value="ipa_first">IPA first</option>
+            <option value="reveal_first">Reveal first</option>
+          </select>
+        </label>
+
+        <label className="setting-row">
+          <span>Review strength</span>
+          <select value={settings.review_strength}
+            onChange={e => update({ review_strength: e.target.value })}>
+            <option value="normal">Normal</option>
+            <option value="extra_review">Extra review</option>
+            <option value="quick">Quick</option>
+          </select>
+        </label>
+
+        <label className="setting-row">
+          <span>Show translation</span>
+          <input type="checkbox" checked={settings.show_translation}
+            onChange={e => update({ show_translation: e.target.checked })} />
+        </label>
+
+        <label className="setting-row">
+          <span>Show accent compare</span>
+          <input type="checkbox" checked={settings.show_accent_compare}
+            onChange={e => update({ show_accent_compare: e.target.checked })} />
+        </label>
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -412,3 +412,53 @@ button {
   font-size: 0.9rem;
   margin-top: 24px;
 }
+
+/* ---------------------------------------------------------------------------
+ * Settings page
+ * --------------------------------------------------------------------------- */
+
+.settings-form {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.setting-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px 0;
+  border-bottom: 1px solid #f0f0f0;
+  font-size: 0.95rem;
+  cursor: pointer;
+}
+
+.setting-row select,
+.setting-row input[type="number"] {
+  padding: 4px 8px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  font-size: 0.9rem;
+}
+
+.setting-row input[type="number"] {
+  width: 64px;
+  text-align: center;
+}
+
+.setting-row input[type="checkbox"] {
+  width: 20px;
+  height: 20px;
+}
+
+.save-confirm {
+  color: #2e7d32;
+  font-size: 0.85rem;
+  margin-bottom: 8px;
+}
+
+.save-error {
+  color: #c62828;
+  font-size: 0.85rem;
+  margin-bottom: 8px;
+}


### PR DESCRIPTION
Closes #42

## Scope completed
- `SettingsPage.tsx` — display/edit settings, auto-save on change via PUT /api/settings
- `App.tsx` — added Settings tab
- `global.css` — settings form styles

## Verification
- TypeScript: 0 errors, Vite build: success
- Backend: 126 tests pass
## Completion handoff: batch checkpoint