### PR TITLE
[M4] Progress and settings

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -10,6 +10,7 @@ from fastapi.staticfiles import StaticFiles
 from app.routes.health import router as health_router
 from app.routes.practice import router as practice_router
 from app.routes.attempts import router as attempts_router
+from app.routes.progress import router as progress_router
 
 app = FastAPI(title="Tiny IPA", version="0.1.0")
 
@@ -23,6 +24,7 @@ app.add_middleware(
 app.include_router(health_router, prefix="/api")
 app.include_router(practice_router, prefix="/api")
 app.include_router(attempts_router, prefix="/api")
+app.include_router(progress_router, prefix="/api")
 
 # Mount static audio directory for local dev. In production Nginx serves /audio/.
 _AUDIO_DIR = os.getenv("TINY_IPA_AUDIO_DIR", str(Path(__file__).resolve().parent.parent.parent / "audio"))

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -10,6 +10,7 @@ from fastapi.staticfiles import StaticFiles
 from app.routes.health import router as health_router
 from app.routes.practice import router as practice_router
 from app.routes.attempts import router as attempts_router
+from app.routes.settings import router as settings_router
 
 app = FastAPI(title="Tiny IPA", version="0.1.0")
 
@@ -23,6 +24,7 @@ app.add_middleware(
 app.include_router(health_router, prefix="/api")
 app.include_router(practice_router, prefix="/api")
 app.include_router(attempts_router, prefix="/api")
+app.include_router(settings_router, prefix="/api")
 
 # Mount static audio directory for local dev. In production Nginx serves /audio/.
 _AUDIO_DIR = os.getenv("TINY_IPA_AUDIO_DIR", str(Path(__file__).resolve().parent.parent.parent / "audio"))

--- a/backend/app/routes/progress.py
+++ b/backend/app/routes/progress.py
@@ -1,0 +1,19 @@
+"""Progress endpoint — GET /api/progress."""
+
+from fastapi import APIRouter
+
+from app.db import get_db
+from app.services.progress import build_progress_response
+
+router = APIRouter()
+
+
+@router.get("/progress")
+def progress():
+    """Return a domain summary of learner progress.
+
+    Includes today's status, streak, total attempts/sessions, and
+    weak/strong phoneme lists derived from phoneme_stats.
+    """
+    with get_db() as conn:
+        return build_progress_response(conn)

--- a/backend/app/routes/settings.py
+++ b/backend/app/routes/settings.py
@@ -1,0 +1,119 @@
+"""Settings endpoint — GET/PUT /api/settings."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, HTTPException, Request
+
+from app.db import get_db
+from app.models import Settings
+from app.services.db_store import get_settings, upsert_settings
+
+router = APIRouter()
+
+_VALID_ACCENTS = {"US", "UK"}
+_VALID_MODES = {"ipa_first", "reveal_first"}
+_VALID_STRENGTHS = {"normal", "extra_review", "quick"}
+
+
+@router.get("/settings")
+def settings_get():
+    """Return current settings for the default user."""
+    with get_db() as conn:
+        s = get_settings(conn, "default")
+        if s is None:
+            # Return defaults if never initialised
+            return {
+                "primary_accent": "US",
+                "daily_word_count": 10,
+                "show_translation": True,
+                "show_accent_compare": False,
+                "practice_mode": "ipa_first",
+                "review_strength": "normal",
+            }
+        return {
+            "primary_accent": s.primary_accent,
+            "daily_word_count": s.daily_word_count,
+            "show_translation": s.show_translation,
+            "show_accent_compare": s.show_accent_compare,
+            "practice_mode": s.practice_mode,
+            "review_strength": s.review_strength,
+        }
+
+
+@router.put("/settings")
+async def settings_put(request: Request):
+    """Update settings for the default user.
+
+    Accepts a partial update — only provided fields are changed.
+    """
+    body = await request.json()
+
+    with get_db() as conn:
+        existing = get_settings(conn, "default")
+        if existing is None:
+            existing = Settings(user_id="default")
+
+        # Validate and apply each field
+        errors = []
+
+        if "primary_accent" in body:
+            v = body["primary_accent"]
+            if v not in _VALID_ACCENTS:
+                errors.append(f"primary_accent must be one of {_VALID_ACCENTS}")
+            else:
+                existing.primary_accent = v
+
+        if "daily_word_count" in body:
+            v = body["daily_word_count"]
+            if not isinstance(v, int) or v < 1 or v > 50:
+                errors.append("daily_word_count must be an integer between 1 and 50")
+            else:
+                existing.daily_word_count = v
+
+        if "show_translation" in body:
+            v = body["show_translation"]
+            if not isinstance(v, bool):
+                errors.append("show_translation must be a boolean")
+            else:
+                existing.show_translation = v
+
+        if "show_accent_compare" in body:
+            v = body["show_accent_compare"]
+            if not isinstance(v, bool):
+                errors.append("show_accent_compare must be a boolean")
+            else:
+                existing.show_accent_compare = v
+
+        if "practice_mode" in body:
+            v = body["practice_mode"]
+            if v not in _VALID_MODES:
+                errors.append(f"practice_mode must be one of {_VALID_MODES}")
+            else:
+                existing.practice_mode = v
+
+        if "review_strength" in body:
+            v = body["review_strength"]
+            if v not in _VALID_STRENGTHS:
+                errors.append(f"review_strength must be one of {_VALID_STRENGTHS}")
+            else:
+                existing.review_strength = v
+
+        if errors:
+            raise HTTPException(
+                status_code=400,
+                detail={"error": "SETTINGS_INVALID", "detail": "; ".join(errors)},
+            )
+
+        existing.updated_at = datetime.now(timezone.utc).isoformat()
+        upsert_settings(conn, existing)
+
+        return {
+            "primary_accent": existing.primary_accent,
+            "daily_word_count": existing.daily_word_count,
+            "show_translation": existing.show_translation,
+            "show_accent_compare": existing.show_accent_compare,
+            "practice_mode": existing.practice_mode,
+            "review_strength": existing.review_strength,
+        }

--- a/backend/app/services/progress.py
+++ b/backend/app/services/progress.py
@@ -1,13 +1,17 @@
-"""Phoneme-level statistics and mastery computation.
+"""Phoneme-level statistics, mastery computation, and progress summaries.
 
 Every attempt submission updates ``phoneme_stats`` for each target
 phoneme on the session item. Mastery status is derived from attempt
 count and accuracy with documented precedence rules.
+
+GET /api/progress reads ``phoneme_stats``, ``attempts``, and
+``daily_sessions`` to produce a domain summary for the frontend.
 """
 
 from __future__ import annotations
 
 import sqlite3
+from datetime import date, timedelta
 from typing import Dict, List, Optional, Tuple
 
 # ---------------------------------------------------------------------------
@@ -174,3 +178,157 @@ def update_phoneme_stats(
             }
         )
     return updated
+
+
+# ============================================================================
+# Progress summary for GET /api/progress
+# ============================================================================
+
+_MIN_ATTEMPTS_FOR_PHONEME_LIST = 2
+
+
+def build_progress_response(
+    conn: sqlite3.Connection,
+    user_id: str = "default",
+) -> dict:
+    """Build the GET /api/progress response dict from runtime data.
+
+    Returns zero/empty defaults when no data exists (no crash).
+    """
+    # ---- accent from settings ------------------------------------------------
+    primary_accent = "US"
+    row = conn.execute(
+        "SELECT primary_accent FROM settings WHERE user_id = ?", (user_id,)
+    ).fetchone()
+    if row:
+        primary_accent = row["primary_accent"]
+
+    # ---- total attempts ------------------------------------------------------
+    total_row = conn.execute(
+        "SELECT COUNT(*) AS cnt FROM attempts WHERE user_id = ?", (user_id,)
+    ).fetchone()
+    total_attempts = total_row["cnt"] if total_row else 0
+
+    # ---- total sessions ------------------------------------------------------
+    sess_row = conn.execute(
+        "SELECT COUNT(*) AS cnt FROM daily_sessions WHERE user_id = ?",
+        (user_id,),
+    ).fetchone()
+    total_sessions = sess_row["cnt"] if sess_row else 0
+
+    # ---- today ---------------------------------------------------------------
+    today_str = date.today().isoformat()
+    today_row = conn.execute(
+        """
+        SELECT status FROM daily_sessions
+        WHERE user_id = ? AND session_date = ?
+        """,
+        (user_id, today_str),
+    ).fetchone()
+    today_status = today_row["status"] if today_row else "none"
+    today_completed = today_status == "completed"
+
+    # ---- streak --------------------------------------------------------------
+    streak_days = _compute_streak(conn, user_id)
+
+    # ---- weak / strong phonemes ----------------------------------------------
+    weak_phonemes, strong_phonemes = _compute_phoneme_lists(
+        conn, user_id, primary_accent
+    )
+
+    return {
+        "today_completed": today_completed,
+        "today_status": today_status,
+        "streak_days": streak_days,
+        "total_attempts": total_attempts,
+        "total_sessions": total_sessions,
+        "weak_phonemes": weak_phonemes,
+        "strong_phonemes": strong_phonemes,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Streak
+# ---------------------------------------------------------------------------
+
+
+def _compute_streak(conn: sqlite3.Connection, user_id: str) -> int:
+    """Count consecutive completed daily sessions.
+
+    Walks backwards from yesterday; a gap or incomplete day breaks the streak.
+    Days that are not completed before the streak starts are skipped.
+    """
+    rows = conn.execute(
+        """
+        SELECT session_date FROM daily_sessions
+        WHERE user_id = ? AND status = 'completed'
+        ORDER BY session_date DESC
+        """,
+        (user_id,),
+    ).fetchall()
+    completed_dates = {r["session_date"] for r in rows}
+
+    if not completed_dates:
+        return 0
+
+    streak = 0
+    d = date.today() - timedelta(days=1)  # start from yesterday
+
+    for _ in range(366):  # safety limit
+        ds = d.isoformat()
+        if ds in completed_dates:
+            streak += 1
+            d = d - timedelta(days=1)
+        else:
+            # First miss after streak started (or no streak yet) — break
+            break
+
+    return streak
+
+
+# ---------------------------------------------------------------------------
+# Weak / strong phoneme lists
+# ---------------------------------------------------------------------------
+
+
+def _compute_phoneme_lists(
+    conn: sqlite3.Connection, user_id: str, primary_accent: str
+) -> Tuple[List[dict], List[dict]]:
+    """Return (weak_phonemes, strong_phonemes) sorted lists from phoneme_stats.
+
+    Only includes phonemes with attempt_count >= _MIN_ATTEMPTS_FOR_PHONEME_LIST.
+    """
+    rows = conn.execute(
+        """
+        SELECT phoneme_id, attempt_count, correct_count, mastery_status
+        FROM phoneme_stats
+        WHERE user_id = ? AND primary_accent = ?
+          AND attempt_count >= ?
+        """,
+        (user_id, primary_accent, _MIN_ATTEMPTS_FOR_PHONEME_LIST),
+    ).fetchall()
+
+    entries: List[dict] = []
+    for r in rows:
+        acc = r["correct_count"] / r["attempt_count"] if r["attempt_count"] > 0 else 0.0
+        entries.append({
+            "phoneme": r["phoneme_id"],
+            "accuracy": round(acc, 2),
+            "attempt_count": r["attempt_count"],
+            "correct_count": r["correct_count"],
+            "mastery_status": r["mastery_status"],
+        })
+
+    # Weak: sort by low accuracy then higher attempt count
+    weak = sorted(
+        [e for e in entries if e["accuracy"] < 0.70],
+        key=lambda e: (e["accuracy"], -e["attempt_count"]),
+    )
+
+    # Strong: sort by high accuracy then higher attempt count
+    strong = sorted(
+        [e for e in entries if e["accuracy"] >= 0.85],
+        key=lambda e: (-e["accuracy"], -e["attempt_count"]),
+    )
+
+    return weak, strong

--- a/backend/tests/test_progress_api.py
+++ b/backend/tests/test_progress_api.py
@@ -1,0 +1,268 @@
+"""Tests for GET /api/progress — phoneme summary and streak."""
+
+from __future__ import annotations
+
+import sys
+from datetime import date, timedelta
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+_SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+from import_words import import_words  # noqa: E402
+from app.main import app  # noqa: E402
+from app.db import get_connection, get_db  # noqa: E402
+from app.services.db_schema import init_db  # noqa: E402
+from app.services.progress import build_progress_response  # noqa: E402
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures"
+CONTENT_SAMPLE = FIXTURES / "content_sample.json"
+PHONEMES_PATH = Path(__file__).resolve().parent.parent.parent / "content" / "phonemes.json"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(name="seeded_db")
+def seeded_db_fixture(tmp_path: Path) -> str:
+    """Database with imported content and default settings."""
+    db_path = str(tmp_path / "test.sqlite")
+    import_words(source_path=CONTENT_SAMPLE, phonemes_path=PHONEMES_PATH, db_path=db_path)
+    import app.db as db_mod
+    orig = db_mod.DEFAULT_DB_PATH
+    db_mod.DEFAULT_DB_PATH = db_path
+    yield db_path
+    db_mod.DEFAULT_DB_PATH = orig
+
+
+@pytest.fixture(name="client")
+def client_fixture(seeded_db: str) -> TestClient:
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestProgressApi:
+    """Integration tests for GET /api/progress."""
+
+    def test_empty_progress_returns_defaults(self, client):
+        """No attempts yet — returns zeros and empty lists."""
+        resp = client.get("/api/progress")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total_attempts"] == 0
+        assert data["total_sessions"] == 0
+        assert data["today_completed"] is False
+        assert data["streak_days"] == 0
+        assert data["weak_phonemes"] == []
+        assert data["strong_phonemes"] == []
+
+    def test_today_status_reflects_session(self, client, seeded_db):
+        """After creating today's session, progress reflects it."""
+        # Create today's session
+        client.get("/api/today")
+        resp = client.get("/api/progress")
+        data = resp.json()
+        assert data["today_status"] == "in_progress"
+        assert data["today_completed"] is False
+
+    def test_total_attempts_counted(self, client, seeded_db):
+        """After submitting attempts, total_attempts increases."""
+        # Get a session item
+        today = client.get("/api/today").json()
+        item = today["items"][0]
+
+        # Submit one attempt
+        client.post("/api/attempt", json={
+            "session_item_id": item["session_item_id"],
+            "selected_answer": item["display_ipa"],
+        })
+
+        resp = client.get("/api/progress")
+        data = resp.json()
+        assert data["total_attempts"] == 1
+        assert data["total_sessions"] > 0
+
+    def test_phoneme_lists_after_attempts(self, client, seeded_db):
+        """After several attempts across phonemes, weak/strong lists appear."""
+        today = client.get("/api/today").json()
+
+        # Submit 3 wrong answers for first item
+        for _ in range(3):
+            client.post("/api/attempt", json={
+                "session_item_id": today["items"][0]["session_item_id"],
+                "selected_answer": "/wrong/",
+            })
+
+        resp = client.get("/api/progress")
+        data = resp.json()
+        # Should have weak phonemes (low accuracy)
+        assert len(data["weak_phonemes"]) > 0
+        for wp in data["weak_phonemes"]:
+            assert wp["accuracy"] < 0.70
+            assert wp["attempt_count"] >= 2
+            assert "phoneme" in wp
+            assert "correct_count" in wp
+            assert "mastery_status" in wp
+
+    def test_empty_db_no_crash(self, tmp_path, monkeypatch):
+        """Fresh database with no content returns safe defaults."""
+        db_path = str(tmp_path / "empty.sqlite")
+        conn = get_connection(db_path)
+        init_db(conn)
+        conn.close()
+
+        import app.db as db_mod
+        orig = db_mod.DEFAULT_DB_PATH
+        db_mod.DEFAULT_DB_PATH = db_path
+        try:
+            c = TestClient(app)
+            resp = c.get("/api/progress")
+            assert resp.status_code == 200
+            data = resp.json()
+            assert data["total_attempts"] == 0
+            assert data["weak_phonemes"] == []
+        finally:
+            db_mod.DEFAULT_DB_PATH = orig
+
+    def test_response_shape(self, client):
+        """Response contains all documented fields."""
+        resp = client.get("/api/progress")
+        data = resp.json()
+        for key in (
+            "today_completed", "today_status", "streak_days",
+            "total_attempts", "total_sessions",
+            "weak_phonemes", "strong_phonemes",
+        ):
+            assert key in data, f"missing key: {key}"
+
+
+# ---------------------------------------------------------------------------
+# Streak
+# ---------------------------------------------------------------------------
+
+
+class TestStreak:
+    def test_no_sessions_zero_streak(self, tmp_path):
+        db_path = str(tmp_path / "test.sqlite")
+        conn = get_connection(db_path)
+        init_db(conn)
+        # Insert settings so build_progress_response doesn't 500
+        conn.execute(
+            "INSERT INTO settings VALUES ('default','US',10,1,0,'ipa_first','normal','2026-01-01T00:00:00Z')"
+        )
+        conn.commit()
+        resp = build_progress_response(conn)
+        conn.close()
+        assert resp["streak_days"] == 0
+
+    def test_consecutive_streak(self, tmp_path):
+        db_path = str(tmp_path / "test.sqlite")
+        conn = get_connection(db_path)
+        init_db(conn)
+        conn.execute(
+            "INSERT INTO settings VALUES ('default','US',10,1,0,'ipa_first','normal','2026-01-01T00:00:00Z')"
+        )
+        today = date.today()
+        yesterday = today - timedelta(days=1)
+        two_days_ago = today - timedelta(days=2)
+
+        # Completed yesterday and two days ago
+        for d in [yesterday, two_days_ago]:
+            conn.execute(
+                "INSERT INTO daily_sessions VALUES (?, 'default', ?, 'US', 'completed', ?, NULL)",
+                (f"{d.isoformat()}-default", d.isoformat(), f"{d.isoformat()}T10:00:00Z"),
+            )
+        conn.commit()
+        resp = build_progress_response(conn)
+        conn.close()
+        assert resp["streak_days"] == 2
+
+    def test_gap_breaks_streak(self, tmp_path):
+        db_path = str(tmp_path / "test.sqlite")
+        conn = get_connection(db_path)
+        init_db(conn)
+        conn.execute(
+            "INSERT INTO settings VALUES ('default','US',10,1,0,'ipa_first','normal','2026-01-01T00:00:00Z')"
+        )
+        today = date.today()
+        two_days_ago = today - timedelta(days=2)
+        four_days_ago = today - timedelta(days=4)
+
+        # Completed 2 days ago and 4 days ago (gap at 3 days ago)
+        for d in [two_days_ago, four_days_ago]:
+            conn.execute(
+                "INSERT INTO daily_sessions VALUES (?, 'default', ?, 'US', 'completed', ?, NULL)",
+                (f"{d.isoformat()}-default", d.isoformat(), f"{d.isoformat()}T10:00:00Z"),
+            )
+        conn.commit()
+        resp = build_progress_response(conn)
+        conn.close()
+        # Streak counts consecutive completed days ending at yesterday.
+        # Yesterday not completed → no active streak.
+        assert resp["streak_days"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Phoneme list ordering
+# ---------------------------------------------------------------------------
+
+
+class TestPhonemeOrdering:
+    def test_ordering(self, tmp_path):
+        db_path = str(tmp_path / "test.sqlite")
+        conn = get_connection(db_path)
+        init_db(conn)
+        conn.execute(
+            "INSERT INTO settings VALUES ('default','US',10,1,0,'ipa_first','normal','2026-01-01T00:00:00Z')"
+        )
+        # Insert stats with varying accuracy
+        stats = [
+            ("/ʃ/", 10, 9),   # 90% — strong
+            ("/ɪ/", 10, 5),   # 50% — weak
+            ("/p/", 5, 2),    # 40% — very weak
+            ("/k/", 8, 8),    # 100% — strong
+            ("/æ/", 6, 4),    # 67% — weak
+            ("/t/", 3, 3),    # 100% but only 3 attempts — strong (>= 85%)
+            ("/n/", 5, 5),    # 100% — strong
+            ("/θ/", 4, 1),    # 25% — very weak
+            ("/d/", 1, 1),    # below threshold — excluded
+        ]
+        for phoneme_id, cnt, correct in stats:
+            conn.execute(
+                "INSERT INTO phoneme_stats VALUES ('default','US',?,?,?,'2026-01-01T00:00:00Z',NULL,'new')",
+                (phoneme_id, cnt, correct),
+            )
+        conn.commit()
+
+        resp = build_progress_response(conn)
+        conn.close()
+
+        weak = resp["weak_phonemes"]
+        strong = resp["strong_phonemes"]
+
+        # All stats with attempt_count >= 2 should appear
+        # /d/ (1 attempt) excluded
+        assert len(weak) + len(strong) == 8  # 9 entries - 1 below threshold
+        assert len(weak) == 4  # /ɪ/ (50%), /p/ (40%), /æ/ (67%), /θ/ (25%)
+
+        # Weak sorted by low accuracy: /θ/ (25%) < /p/ (40%) < /ɪ/ (50%) < /æ/ (67%)
+        assert weak[0]["phoneme"] == "/θ/"
+        assert weak[3]["phoneme"] == "/æ/"
+
+        # Strong sorted by high accuracy: /k/ (100%) = /n/ (100%) > /ʃ/ (90%) > /t/ (100% but 3 att)
+        # Within same accuracy, higher attempt_count first
+        # /k/ (8) before /n/ (5) before /t/ (3)
+        assert strong[0]["phoneme"] == "/k/"
+        assert strong[1]["phoneme"] == "/n/"
+        assert strong[2]["phoneme"] == "/t/"
+        assert strong[3]["phoneme"] == "/ʃ/"

--- a/backend/tests/test_settings_api.py
+++ b/backend/tests/test_settings_api.py
@@ -1,0 +1,112 @@
+"""Tests for GET/PUT /api/settings."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+_SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+from import_words import import_words  # noqa: E402
+from app.main import app  # noqa: E402
+from app.db import get_connection  # noqa: E402
+from app.services.db_schema import init_db  # noqa: E402
+from app.services.db_store import get_settings  # noqa: E402
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures"
+CONTENT_SAMPLE = FIXTURES / "content_sample.json"
+PHONEMES_PATH = Path(__file__).resolve().parent.parent.parent / "content" / "phonemes.json"
+
+
+@pytest.fixture(name="seeded_db")
+def seeded_db_fixture(tmp_path: Path) -> str:
+    """Database with imported content and default settings."""
+    db_path = str(tmp_path / "test.sqlite")
+    import_words(source_path=CONTENT_SAMPLE, phonemes_path=PHONEMES_PATH, db_path=db_path)
+    import app.db as db_mod
+    orig = db_mod.DEFAULT_DB_PATH
+    db_mod.DEFAULT_DB_PATH = db_path
+    yield db_path
+    db_mod.DEFAULT_DB_PATH = orig
+
+
+@pytest.fixture(name="client")
+def client_fixture(seeded_db: str) -> TestClient:
+    return TestClient(app)
+
+
+class TestSettingsApi:
+    """Integration tests for GET/PUT /api/settings."""
+
+    def test_get_returns_defaults(self, client):
+        resp = client.get("/api/settings")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["primary_accent"] == "US"
+        assert data["daily_word_count"] == 10
+        assert data["show_translation"] is True
+
+    def test_put_updates_and_persists(self, client, seeded_db):
+        resp = client.put("/api/settings", json={
+            "daily_word_count": 5,
+            "show_translation": False,
+        })
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["daily_word_count"] == 5
+        assert data["show_translation"] is False
+        # Other fields unchanged
+        assert data["primary_accent"] == "US"
+
+        # Verify persistence
+        conn = get_connection(seeded_db)
+        s = get_settings(conn, "default")
+        conn.close()
+        assert s is not None
+        assert s.daily_word_count == 5
+        assert s.show_translation is False
+
+    def test_put_invalid_daily_word_count(self, client):
+        resp = client.put("/api/settings", json={"daily_word_count": 100})
+        assert resp.status_code == 400
+        data = resp.json()
+        assert data["detail"]["error"] == "SETTINGS_INVALID"
+
+    def test_put_invalid_accent(self, client):
+        resp = client.put("/api/settings", json={"primary_accent": "JP"})
+        assert resp.status_code == 400
+        assert resp.json()["detail"]["error"] == "SETTINGS_INVALID"
+
+    def test_put_invalid_practice_mode(self, client):
+        resp = client.put("/api/settings", json={"practice_mode": "random"})
+        assert resp.status_code == 400
+        assert resp.json()["detail"]["error"] == "SETTINGS_INVALID"
+
+    def test_put_empty_body_noop(self, client):
+        """Empty body is accepted — no fields changed."""
+        resp = client.put("/api/settings", json={})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["daily_word_count"] == 10
+
+    def test_get_empty_db(self, tmp_path, monkeypatch):
+        """Settings GET returns defaults even without import."""
+        db_path = str(tmp_path / "empty.sqlite")
+        conn = get_connection(db_path)
+        init_db(conn)
+        conn.close()
+        import app.db as db_mod
+        orig = db_mod.DEFAULT_DB_PATH
+        db_mod.DEFAULT_DB_PATH = db_path
+        try:
+            c = TestClient(app)
+            resp = c.get("/api/settings")
+            assert resp.status_code == 200
+            assert resp.json()["daily_word_count"] == 10
+        finally:
+            db_mod.DEFAULT_DB_PATH = orig

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,11 +2,12 @@ import { fetchHealth } from "./api";
 import { useEffect, useState } from "react";
 import TodayPractice from "./pages/TodayPractice";
 import ProgressPage from "./pages/ProgressPage";
+import SettingsPage from "./pages/SettingsPage";
 
 function App() {
   const [backendReady, setBackendReady] = useState<boolean>(false);
   const [checking, setChecking] = useState(true);
-  const [page, setPage] = useState<"today" | "progress">("today");
+  const [page, setPage] = useState<"today" | "progress" | "settings">("today");
 
   useEffect(() => {
     fetchHealth()
@@ -42,9 +43,13 @@ function App() {
           onClick={() => setPage("today")}>Today</button>
         <button className={`nav-tab ${page === "progress" ? "nav-active" : ""}`}
           onClick={() => setPage("progress")}>Progress</button>
+        <button className={`nav-tab ${page === "settings" ? "nav-active" : ""}`}
+          onClick={() => setPage("settings")}>Settings</button>
       </nav>
       {page === "progress"
         ? <ProgressPage onBack={() => setPage("today")} />
+        : page === "settings"
+        ? <SettingsPage onBack={() => setPage("today")} />
         : <TodayPractice />
       }
     </div>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,10 +1,12 @@
 import { fetchHealth } from "./api";
 import { useEffect, useState } from "react";
 import TodayPractice from "./pages/TodayPractice";
+import ProgressPage from "./pages/ProgressPage";
 
 function App() {
   const [backendReady, setBackendReady] = useState<boolean>(false);
   const [checking, setChecking] = useState(true);
+  const [page, setPage] = useState<"today" | "progress">("today");
 
   useEffect(() => {
     fetchHealth()
@@ -15,14 +17,7 @@ function App() {
 
   if (checking) {
     return (
-      <main
-        style={{
-          maxWidth: 480,
-          margin: "0 auto",
-          padding: "24px 16px",
-          fontFamily: "system-ui, sans-serif",
-        }}
-      >
+      <main className="practice-container">
         <h1>Tiny IPA</h1>
         <p>Connecting to backend…</p>
       </main>
@@ -31,23 +26,29 @@ function App() {
 
   if (!backendReady) {
     return (
-      <main
-        style={{
-          maxWidth: 480,
-          margin: "0 auto",
-          padding: "24px 16px",
-          fontFamily: "system-ui, sans-serif",
-        }}
-      >
+      <main className="practice-container">
         <h1>Tiny IPA</h1>
         <p style={{ color: "#c00" }}>
-          Cannot reach the backend. Make sure it is running on port 8010.
+          Cannot reach backend. Make sure it is running on port 8010.
         </p>
       </main>
     );
   }
 
-  return <TodayPractice />;
+  return (
+    <div>
+      <nav className="nav-bar">
+        <button className={`nav-tab ${page === "today" ? "nav-active" : ""}`}
+          onClick={() => setPage("today")}>Today</button>
+        <button className={`nav-tab ${page === "progress" ? "nav-active" : ""}`}
+          onClick={() => setPage("progress")}>Progress</button>
+      </nav>
+      {page === "progress"
+        ? <ProgressPage onBack={() => setPage("today")} />
+        : <TodayPractice />
+      }
+    </div>
+  );
 }
 
 export default App;

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -79,6 +79,40 @@ export interface AttemptResponse {
   next_action: string;
 }
 
+// ---------------------------------------------------------------------------
+// Progress
+// ---------------------------------------------------------------------------
+
+export interface PhonemeStat {
+  phoneme: string;
+  accuracy: number;
+  attempt_count: number;
+  correct_count: number;
+  mastery_status: string;
+}
+
+export interface ProgressResponse {
+  today_completed: boolean;
+  today_status: string;
+  streak_days: number;
+  total_attempts: number;
+  total_sessions: number;
+  weak_phonemes: PhonemeStat[];
+  strong_phonemes: PhonemeStat[];
+}
+
+export async function fetchProgress(): Promise<ProgressResponse> {
+  const res = await fetch(`${API_BASE}/progress`);
+  if (!res.ok) {
+    throw new Error(`GET /api/progress failed: ${res.status}`);
+  }
+  return res.json();
+}
+
+// ---------------------------------------------------------------------------
+// Attempt submission
+// ---------------------------------------------------------------------------
+
 export async function submitAttempt(
   sessionItemId: string,
   selectedAnswer: string,

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -147,3 +147,52 @@ export async function submitAttempt(
   }
   return res.json();
 }
+
+// ---------------------------------------------------------------------------
+// Settings
+// ---------------------------------------------------------------------------
+
+export interface SettingsData {
+  primary_accent: string;
+  daily_word_count: number;
+  show_translation: boolean;
+  show_accent_compare: boolean;
+  practice_mode: string;
+  review_strength: string;
+}
+
+export async function fetchSettings(): Promise<SettingsData> {
+  const res = await fetch(`${API_BASE}/settings`);
+  if (!res.ok) {
+    throw new Error(`GET /api/settings failed: ${res.status}`);
+  }
+  return res.json();
+}
+
+export async function saveSettings(
+  data: Partial<SettingsData>,
+): Promise<SettingsData> {
+  const res = await fetch(`${API_BASE}/settings`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) {
+    let message = `Request failed (HTTP ${res.status})`;
+    try {
+      const body = await res.json();
+      const inner = body.detail ?? body;
+      if (typeof inner === "object" && inner !== null) {
+        const code = inner.error ?? "";
+        const text = inner.detail ?? JSON.stringify(inner);
+        message = code ? `${code}: ${text}` : String(text);
+      } else if (typeof inner === "string") {
+        message = inner;
+      }
+    } catch {
+      // Fall through with the default message.
+    }
+    throw new Error(message);
+  }
+  return res.json();
+}

--- a/frontend/src/pages/ProgressPage.tsx
+++ b/frontend/src/pages/ProgressPage.tsx
@@ -1,0 +1,88 @@
+/**
+ * ProgressPage — displays learner progress summary.
+ *
+ * Shows streak, total stats, and weak/strong phoneme lists.
+ */
+
+import { useEffect, useState } from "react";
+import type { ProgressResponse } from "../api";
+import { fetchProgress } from "../api";
+
+interface Props {
+  onBack: () => void;
+}
+
+export default function ProgressPage({ onBack }: Props) {
+  const [data, setData] = useState<ProgressResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchProgress()
+      .then(setData)
+      .catch((e) => setError(e.message))
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) return <main className="practice-container"><p>Loading progress…</p></main>;
+  if (error) return <main className="practice-container"><p className="error">Failed: {error}</p></main>;
+  if (!data) return null;
+
+  return (
+    <main className="practice-container">
+      <div className="page-header">
+        <button className="back-btn" onClick={onBack}>← Today</button>
+        <h1>Progress</h1>
+      </div>
+
+      <div className="progress-stats">
+        <div className="stat-card">
+          <span className="stat-number">{data.streak_days}</span>
+          <span className="stat-label">day streak</span>
+        </div>
+        <div className="stat-card">
+          <span className="stat-number">{data.total_attempts}</span>
+          <span className="stat-label">attempts</span>
+        </div>
+        <div className="stat-card">
+          <span className="stat-number">{data.total_sessions}</span>
+          <span className="stat-label">sessions</span>
+        </div>
+      </div>
+
+      {data.weak_phonemes.length > 0 && (
+        <section className="phoneme-section">
+          <h2>Needs practice</h2>
+          <ul className="phoneme-list">
+            {data.weak_phonemes.map((p) => (
+              <li key={p.phoneme} className="phoneme-item weak">
+                <span className="phoneme-symbol">{p.phoneme}</span>
+                <span className="phoneme-acc">{Math.round(p.accuracy * 100)}%</span>
+                <span className="phoneme-count">{p.attempt_count} att.</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {data.strong_phonemes.length > 0 && (
+        <section className="phoneme-section">
+          <h2>Strong</h2>
+          <ul className="phoneme-list">
+            {data.strong_phonemes.map((p) => (
+              <li key={p.phoneme} className="phoneme-item strong">
+                <span className="phoneme-symbol">{p.phoneme}</span>
+                <span className="phoneme-acc">{Math.round(p.accuracy * 100)}%</span>
+                <span className="phoneme-count">{p.attempt_count} att.</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {data.weak_phonemes.length === 0 && data.strong_phonemes.length === 0 && (
+        <p className="empty-hint">Complete some practice to see your phoneme stats.</p>
+      )}
+    </main>
+  );
+}

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,39 +1,17 @@
 /**
  * SettingsPage — display and edit user settings.
+ *
+ * Only exposes MVP-supported controls.  Future settings (UK accent,
+ * reveal_first, extra_review/quick, accent compare) are intentionally
+ * hidden until the practice flow supports them.
  */
 
 import { useEffect, useState } from "react";
-
-interface SettingsData {
-  primary_accent: string;
-  daily_word_count: number;
-  show_translation: boolean;
-  show_accent_compare: boolean;
-  practice_mode: string;
-  review_strength: string;
-}
-
-const API_BASE = import.meta.env.VITE_API_BASE ?? "/api";
-
-async function fetchSettings(): Promise<SettingsData> {
-  const res = await fetch(`${API_BASE}/settings`);
-  if (!res.ok) throw new Error("Failed to load settings");
-  return res.json();
-}
-
-async function saveSettings(data: Partial<SettingsData>): Promise<SettingsData> {
-  const res = await fetch(`${API_BASE}/settings`, {
-    method: "PUT",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(data),
-  });
-  if (!res.ok) {
-    const body = await res.json().catch(() => ({}));
-    const inner = body.detail ?? body;
-    throw new Error(typeof inner === "string" ? inner : inner.detail ?? "Save failed");
-  }
-  return res.json();
-}
+import {
+  type SettingsData,
+  fetchSettings,
+  saveSettings,
+} from "../api";
 
 interface Props {
   onBack: () => void;
@@ -46,7 +24,10 @@ export default function SettingsPage({ onBack }: Props) {
   const [saved, setSaved] = useState(false);
 
   useEffect(() => {
-    fetchSettings().then(setSettings).catch(e => setError(e.message)).finally(() => setLoading(false));
+    fetchSettings()
+      .then(setSettings)
+      .catch((e) => setError(e.message))
+      .finally(() => setLoading(false));
   }, []);
 
   if (loading) return <main className="practice-container"><p>Loading…</p></main>;
@@ -77,38 +58,12 @@ export default function SettingsPage({ onBack }: Props) {
       {error && <p className="save-error">⚠️ {error}</p>}
 
       <div className="settings-form">
+        {/* ---- MVP-supported controls ---- */}
+
         <label className="setting-row">
           <span>Words per day</span>
           <input type="number" min={1} max={50} value={settings.daily_word_count}
             onChange={e => update({ daily_word_count: Number(e.target.value) })} />
-        </label>
-
-        <label className="setting-row">
-          <span>Primary accent</span>
-          <select value={settings.primary_accent}
-            onChange={e => update({ primary_accent: e.target.value })}>
-            <option value="US">US</option>
-            <option value="UK">UK</option>
-          </select>
-        </label>
-
-        <label className="setting-row">
-          <span>Practice mode</span>
-          <select value={settings.practice_mode}
-            onChange={e => update({ practice_mode: e.target.value })}>
-            <option value="ipa_first">IPA first</option>
-            <option value="reveal_first">Reveal first</option>
-          </select>
-        </label>
-
-        <label className="setting-row">
-          <span>Review strength</span>
-          <select value={settings.review_strength}
-            onChange={e => update({ review_strength: e.target.value })}>
-            <option value="normal">Normal</option>
-            <option value="extra_review">Extra review</option>
-            <option value="quick">Quick</option>
-          </select>
         </label>
 
         <label className="setting-row">
@@ -117,11 +72,24 @@ export default function SettingsPage({ onBack }: Props) {
             onChange={e => update({ show_translation: e.target.checked })} />
         </label>
 
+        {/* ---- Future controls (hidden until practice flow supports them) ----
+        <label className="setting-row">
+          <span>Primary accent</span>
+          <select value={settings.primary_accent} … />
+        </label>
+        <label className="setting-row">
+          <span>Practice mode</span>
+          <select value={settings.practice_mode} … />
+        </label>
+        <label className="setting-row">
+          <span>Review strength</span>
+          <select value={settings.review_strength} … />
+        </label>
         <label className="setting-row">
           <span>Show accent compare</span>
-          <input type="checkbox" checked={settings.show_accent_compare}
-            onChange={e => update({ show_accent_compare: e.target.checked })} />
+          <input type="checkbox" checked={settings.show_accent_compare} … />
         </label>
+        ---- */}
       </div>
     </main>
   );

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,0 +1,128 @@
+/**
+ * SettingsPage — display and edit user settings.
+ */
+
+import { useEffect, useState } from "react";
+
+interface SettingsData {
+  primary_accent: string;
+  daily_word_count: number;
+  show_translation: boolean;
+  show_accent_compare: boolean;
+  practice_mode: string;
+  review_strength: string;
+}
+
+const API_BASE = import.meta.env.VITE_API_BASE ?? "/api";
+
+async function fetchSettings(): Promise<SettingsData> {
+  const res = await fetch(`${API_BASE}/settings`);
+  if (!res.ok) throw new Error("Failed to load settings");
+  return res.json();
+}
+
+async function saveSettings(data: Partial<SettingsData>): Promise<SettingsData> {
+  const res = await fetch(`${API_BASE}/settings`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    const inner = body.detail ?? body;
+    throw new Error(typeof inner === "string" ? inner : inner.detail ?? "Save failed");
+  }
+  return res.json();
+}
+
+interface Props {
+  onBack: () => void;
+}
+
+export default function SettingsPage({ onBack }: Props) {
+  const [settings, setSettings] = useState<SettingsData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [saved, setSaved] = useState(false);
+
+  useEffect(() => {
+    fetchSettings().then(setSettings).catch(e => setError(e.message)).finally(() => setLoading(false));
+  }, []);
+
+  if (loading) return <main className="practice-container"><p>Loading…</p></main>;
+  if (error) return <main className="practice-container"><p className="error">{error}</p></main>;
+  if (!settings) return null;
+
+  const update = async (patch: Partial<SettingsData>) => {
+    setError(null);
+    setSaved(false);
+    try {
+      const updated = await saveSettings(patch);
+      setSettings(updated);
+      setSaved(true);
+      setTimeout(() => setSaved(false), 2000);
+    } catch (e: any) {
+      setError(e.message);
+    }
+  };
+
+  return (
+    <main className="practice-container">
+      <div className="page-header">
+        <button className="back-btn" onClick={onBack}>← Today</button>
+        <h1>Settings</h1>
+      </div>
+
+      {saved && <p className="save-confirm">✅ Saved</p>}
+      {error && <p className="save-error">⚠️ {error}</p>}
+
+      <div className="settings-form">
+        <label className="setting-row">
+          <span>Words per day</span>
+          <input type="number" min={1} max={50} value={settings.daily_word_count}
+            onChange={e => update({ daily_word_count: Number(e.target.value) })} />
+        </label>
+
+        <label className="setting-row">
+          <span>Primary accent</span>
+          <select value={settings.primary_accent}
+            onChange={e => update({ primary_accent: e.target.value })}>
+            <option value="US">US</option>
+            <option value="UK">UK</option>
+          </select>
+        </label>
+
+        <label className="setting-row">
+          <span>Practice mode</span>
+          <select value={settings.practice_mode}
+            onChange={e => update({ practice_mode: e.target.value })}>
+            <option value="ipa_first">IPA first</option>
+            <option value="reveal_first">Reveal first</option>
+          </select>
+        </label>
+
+        <label className="setting-row">
+          <span>Review strength</span>
+          <select value={settings.review_strength}
+            onChange={e => update({ review_strength: e.target.value })}>
+            <option value="normal">Normal</option>
+            <option value="extra_review">Extra review</option>
+            <option value="quick">Quick</option>
+          </select>
+        </label>
+
+        <label className="setting-row">
+          <span>Show translation</span>
+          <input type="checkbox" checked={settings.show_translation}
+            onChange={e => update({ show_translation: e.target.checked })} />
+        </label>
+
+        <label className="setting-row">
+          <span>Show accent compare</span>
+          <input type="checkbox" checked={settings.show_accent_compare}
+            onChange={e => update({ show_accent_compare: e.target.checked })} />
+        </label>
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -271,3 +271,144 @@ button {
 .summary-wrong {
   color: #c62828;
 }
+
+/* ---------------------------------------------------------------------------
+ * Navigation
+ * --------------------------------------------------------------------------- */
+
+.nav-bar {
+  display: flex;
+  max-width: 480px;
+  margin: 0 auto;
+  border-bottom: 2px solid #eee;
+}
+
+.nav-tab {
+  flex: 1;
+  padding: 12px 0;
+  border: none;
+  background: none;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #888;
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -2px;
+}
+
+.nav-tab:hover {
+  color: #333;
+}
+
+.nav-active {
+  color: #4a90d9;
+  border-bottom-color: #4a90d9;
+}
+
+/* ---------------------------------------------------------------------------
+ * Progress page
+ * --------------------------------------------------------------------------- */
+
+.page-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 20px;
+}
+
+.page-header h1 {
+  font-size: 1.25rem;
+  margin: 0;
+}
+
+.back-btn {
+  padding: 6px 12px;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  background: #f5f5f5;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+.progress-stats {
+  display: flex;
+  gap: 12px;
+  margin-bottom: 24px;
+}
+
+.stat-card {
+  flex: 1;
+  text-align: center;
+  background: #f5f5f5;
+  border-radius: 8px;
+  padding: 12px 8px;
+}
+
+.stat-number {
+  display: block;
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #4a90d9;
+}
+
+.stat-label {
+  display: block;
+  font-size: 0.75rem;
+  color: #888;
+  margin-top: 2px;
+}
+
+.phoneme-section {
+  margin-bottom: 20px;
+}
+
+.phoneme-section h2 {
+  font-size: 1rem;
+  margin-bottom: 8px;
+}
+
+.phoneme-list {
+  list-style: none;
+  padding: 0;
+}
+
+.phoneme-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 0;
+  border-bottom: 1px solid #f0f0f0;
+  font-size: 0.95rem;
+}
+
+.phoneme-symbol {
+  font-weight: 600;
+  min-width: 48px;
+}
+
+.phoneme-acc {
+  color: #888;
+  font-size: 0.85rem;
+}
+
+.phoneme-count {
+  color: #aaa;
+  font-size: 0.8rem;
+  margin-left: auto;
+}
+
+.phoneme-item.weak .phoneme-symbol {
+  color: #e65100;
+}
+
+.phoneme-item.strong .phoneme-symbol {
+  color: #2e7d32;
+}
+
+.empty-hint {
+  text-align: center;
+  color: #999;
+  font-size: 0.9rem;
+  margin-top: 24px;
+}

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -412,3 +412,53 @@ button {
   font-size: 0.9rem;
   margin-top: 24px;
 }
+
+/* ---------------------------------------------------------------------------
+ * Settings page
+ * --------------------------------------------------------------------------- */
+
+.settings-form {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.setting-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px 0;
+  border-bottom: 1px solid #f0f0f0;
+  font-size: 0.95rem;
+  cursor: pointer;
+}
+
+.setting-row select,
+.setting-row input[type="number"] {
+  padding: 4px 8px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  font-size: 0.9rem;
+}
+
+.setting-row input[type="number"] {
+  width: 64px;
+  text-align: center;
+}
+
+.setting-row input[type="checkbox"] {
+  width: 20px;
+  height: 20px;
+}
+
+.save-confirm {
+  color: #2e7d32;
+  font-size: 0.85rem;
+  margin-bottom: 8px;
+}
+
+.save-error {
+  color: #c62828;
+  font-size: 0.85rem;
+  margin-bottom: 8px;
+}


### PR DESCRIPTION
Closes #24

## Scope

M4 completes the personal learning loop around progress and settings:

- `GET /api/progress` backend summary endpoint
- `GET/PUT /api/settings` backend endpoint with validation
- Progress page and Today/Progress navigation
- Settings page wired to supported MVP settings
- Integration QA across backend APIs, frontend pages, settings persistence, and existing Today practice behavior

## Architect QA

- `cd backend && pytest tests -q` -> 126 passed
- `cd frontend && npm run build` -> success
- Local API smoke against temporary SQLite DB and FastAPI on port 8012:
  - `GET /api/health` -> ok, db_ready true
  - `GET /api/progress` -> no-attempts summary returns sane empty state
  - `GET /api/settings` -> defaults returned
  - `PUT /api/settings` -> valid update persisted
  - `GET /api/today` after `daily_word_count=5` -> 5 items

## Residual risks

- Manual browser/mobile QA should continue during normal use, especially around compact Settings/Progress layout.
- M4 intentionally keeps unsupported future settings hidden in the UI; backend still accepts broader settings values for future compatibility.
