### PR TITLE
[#59] Add project-local role routing config

### DIFF
--- a/tools/agents/README.md
+++ b/tools/agents/README.md
@@ -16,16 +16,25 @@ jq
 ```bash
 tools/agents/agent-inbox architect
 tools/agents/agent-inbox implementer
+tools/agents/agent-inbox reviewer
+tools/agents/agent-role-config
 tools/agents/agent-ready-queue
 tools/agents/agent-audit
 ```
 
-`agent-inbox` reads `needs:*` labels only. It deliberately avoids Project v2
+Role routing is configured by `tools/agents/role-routing.conf`, with a built-in
+fallback in `_lib.sh` so helpers still work if the config file is absent. The
+config is shell-readable and defines roles, each role's inbox label, and the
+primary next-action labels. Use `tools/agents/agent-role-config` to print the
+active config compactly. Future projects can adapt the role set by changing
+that one config file instead of editing every helper script.
+
+`agent-inbox` reads primary next-action labels only. It deliberately avoids Project v2
 queries because labels are faster and more reliable for agent pickup. It uses
 GitHub's REST API rather than `gh issue list` because the latter can hit
 GraphQL/TLS timeouts in our current network setup. `agent-inbox all` fetches
-open issues once and groups labels locally, instead of making one network call
-per label.
+open issues once and groups the configured primary labels locally, instead of
+making one network call per label.
 
 `agent-ready-queue` extracts `Execution Contract` lines so an Implementer can
 see which ready issues are immediately startable and which are waiting on
@@ -42,7 +51,7 @@ then reads comments only for the queued issues.
 `agent-audit` is a read-only consistency check. It looks for common workflow
 drift without touching GitHub Project v2:
 
-- open issues with multiple `needs:*` labels
+- open issues with multiple primary next-action labels
 - open task issues with no next-action label, annotated as `pickup confirmed`
   or `unrouted`
 - closed issues that still carry next-action labels
@@ -68,13 +77,15 @@ reliable than `gh pr view` in this project.
 ```bash
 tools/agents/agent-label 15 set-next needs:implementer
 tools/agents/agent-label 15 set-next needs:architect
+tools/agents/agent-label 15 set-next needs:reviewer
 tools/agents/agent-label 15 remove needs:implementer
 ```
 
 Use `agent-label` for role routing when GraphQL-backed `gh issue edit` is slow
-or flaky. `set-next` removes the other primary next-action labels before adding
-the requested label. It reads current labels first, so it avoids unnecessary
-delete/add calls when the issue is already in the requested route.
+or flaky. `set-next` accepts only configured primary next-action labels, removes
+the other configured primary labels before adding the requested label, and fails
+closed on unknown labels. It reads current labels first, so it avoids
+unnecessary delete/add calls when the issue is already in the requested route.
 
 ## Project Status
 

--- a/tools/agents/_lib.sh
+++ b/tools/agents/_lib.sh
@@ -5,6 +5,272 @@ repo_api_path() {
   printf 'repos/%s' "$repo"
 }
 
+agent_role_config_path() {
+  if [[ -n "${AGENT_ROLE_ROUTING_CONFIG:-}" ]]; then
+    printf '%s\n' "$AGENT_ROLE_ROUTING_CONFIG"
+    return
+  fi
+
+  local lib_dir
+  lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  printf '%s/role-routing.conf\n' "$lib_dir"
+}
+
+agent_set_default_role_config() {
+  AGENT_ROLES=(architect implementer reviewer user ci merge)
+  AGENT_ROLE_LABEL_architect="needs:architect"
+  AGENT_ROLE_LABEL_implementer="needs:implementer"
+  AGENT_ROLE_LABEL_reviewer="needs:reviewer"
+  AGENT_ROLE_LABEL_user="needs:user"
+  AGENT_ROLE_LABEL_ci="needs:ci"
+  AGENT_ROLE_LABEL_merge="needs:merge"
+  AGENT_PRIMARY_NEXT_LABELS=(
+    needs:architect
+    needs:implementer
+    needs:reviewer
+    needs:user
+    needs:ci
+    needs:merge
+    blocked
+  )
+  AGENT_ROLE_CONFIG_SOURCE="built-in fallback"
+}
+
+agent_fail_config() {
+  printf 'Invalid agent role routing config: %s\n' "$1" >&2
+  return 2
+}
+
+agent_contains_value() {
+  local needle="$1"
+  shift
+  local value
+
+  for value in "$@"; do
+    if [[ "$value" == "$needle" ]]; then
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+agent_join_lines() {
+  awk 'BEGIN { first = 1 } { if (!first) printf ", "; printf "%s", $0; first = 0 }'
+}
+
+agent_validate_role_config() {
+  local role label var_name primary seen matched
+
+  if ! declare -p AGENT_ROLES >/dev/null 2>&1; then
+    agent_fail_config "AGENT_ROLES must be defined"
+    return 2
+  fi
+  if ! declare -p AGENT_PRIMARY_NEXT_LABELS >/dev/null 2>&1; then
+    agent_fail_config "AGENT_PRIMARY_NEXT_LABELS must be defined"
+    return 2
+  fi
+  if (( ${#AGENT_ROLES[@]} == 0 )); then
+    agent_fail_config "AGENT_ROLES must not be empty"
+    return 2
+  fi
+  if (( ${#AGENT_PRIMARY_NEXT_LABELS[@]} == 0 )); then
+    agent_fail_config "AGENT_PRIMARY_NEXT_LABELS must not be empty"
+    return 2
+  fi
+
+  seen=""
+  for role in "${AGENT_ROLES[@]}"; do
+    if [[ ! "$role" =~ ^[a-z][a-z0-9_]*$ ]]; then
+      agent_fail_config "unsupported role name '$role'"
+      return 2
+    fi
+    if grep -Fxq "$role" <<< "$seen"; then
+      agent_fail_config "duplicate role '$role'"
+      return 2
+    fi
+    seen="${seen}${role}"$'\n'
+
+    var_name="AGENT_ROLE_LABEL_$role"
+    eval "label=\"\${$var_name:-}\""
+    if [[ -z "$label" ]]; then
+      agent_fail_config "missing $var_name"
+      return 2
+    fi
+    if [[ ! "$label" =~ ^needs:[a-z][a-z0-9_]*$ ]]; then
+      agent_fail_config "$var_name must be a needs:<role> label: $label"
+      return 2
+    fi
+    if ! agent_contains_value "$label" "${AGENT_PRIMARY_NEXT_LABELS[@]}"; then
+      agent_fail_config "$var_name is not listed in AGENT_PRIMARY_NEXT_LABELS: $label"
+      return 2
+    fi
+  done
+
+  seen=""
+  for primary in "${AGENT_PRIMARY_NEXT_LABELS[@]}"; do
+    if [[ "$primary" != "blocked" && ! "$primary" =~ ^needs:[a-z][a-z0-9_]*$ ]]; then
+      agent_fail_config "unsupported primary next-action label '$primary'"
+      return 2
+    fi
+    if grep -Fxq "$primary" <<< "$seen"; then
+      agent_fail_config "duplicate primary next-action label '$primary'"
+      return 2
+    fi
+    seen="${seen}${primary}"$'\n'
+
+    if [[ "$primary" == needs:* ]]; then
+      matched=0
+      for role in "${AGENT_ROLES[@]}"; do
+        var_name="AGENT_ROLE_LABEL_$role"
+        eval "label=\"\${$var_name:-}\""
+        if [[ "$label" == "$primary" ]]; then
+          matched=1
+          break
+        fi
+      done
+      if [[ "$matched" -eq 0 ]]; then
+        agent_fail_config "primary label has no configured role: $primary"
+        return 2
+      fi
+    fi
+  done
+}
+
+agent_load_role_config() {
+  if [[ "${AGENT_ROLE_CONFIG_LOADED:-0}" -eq 1 ]]; then
+    return
+  fi
+
+  local config_path
+  config_path="$(agent_role_config_path)"
+  if [[ -f "$config_path" ]]; then
+    unset AGENT_ROLES AGENT_PRIMARY_NEXT_LABELS
+    while IFS= read -r var_name; do
+      unset "$var_name"
+    done < <(compgen -A variable AGENT_ROLE_LABEL_ || true)
+
+    # shellcheck source=/dev/null
+    source "$config_path"
+    AGENT_ROLE_CONFIG_SOURCE="$config_path"
+  else
+    agent_set_default_role_config
+  fi
+
+  agent_validate_role_config || return 2
+  AGENT_ROLE_CONFIG_LOADED=1
+}
+
+agent_configured_roles() {
+  local role
+  agent_load_role_config || return 2
+  for role in "${AGENT_ROLES[@]}"; do
+    printf '%s\n' "$role"
+  done
+}
+
+agent_primary_next_labels() {
+  local label
+  agent_load_role_config || return 2
+  for label in "${AGENT_PRIMARY_NEXT_LABELS[@]}"; do
+    printf '%s\n' "$label"
+  done
+}
+
+agent_role_exists() {
+  local target="$1"
+  local role
+  agent_load_role_config || return 2
+  for role in "${AGENT_ROLES[@]}"; do
+    if [[ "$role" == "$target" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+agent_role_label_for_role() {
+  local role="$1"
+  local var_name label
+
+  agent_load_role_config || return 2
+  if ! agent_role_exists "$role"; then
+    printf 'Unknown agent role: %s\n' "$role" >&2
+    printf 'Configured roles: %s\n' "$(agent_configured_roles | agent_join_lines)" >&2
+    return 2
+  fi
+
+  var_name="AGENT_ROLE_LABEL_$role"
+  eval "label=\"\${$var_name:-}\""
+  printf '%s\n' "$label"
+}
+
+agent_is_primary_next_label() {
+  local target="$1"
+  local label
+
+  agent_load_role_config || return 2
+  for label in "${AGENT_PRIMARY_NEXT_LABELS[@]}"; do
+    if [[ "$label" == "$target" ]]; then
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+agent_require_primary_next_label() {
+  local label="$1"
+
+  agent_load_role_config || return 2
+  if ! agent_contains_value "$label" "${AGENT_PRIMARY_NEXT_LABELS[@]}"; then
+    printf 'Unsupported next-action label: %s\n' "$label" >&2
+    printf 'Configured primary next-action labels: %s\n' "$(agent_primary_next_labels | agent_join_lines)" >&2
+    return 2
+  fi
+}
+
+agent_label_for_inbox_target() {
+  local target="$1"
+
+  agent_load_role_config || return 2
+  if agent_role_exists "$target"; then
+    agent_role_label_for_role "$target"
+    return
+  fi
+  if agent_is_primary_next_label "$target"; then
+    printf '%s\n' "$target"
+    return
+  fi
+
+  printf 'Unknown inbox target: %s\n' "$target" >&2
+  printf 'Use a configured role, primary next-action label, or all.\n' >&2
+  return 2
+}
+
+agent_print_role_routing_config() {
+  local role label first=1
+
+  agent_load_role_config || return 2
+  printf 'Config: %s\n' "$AGENT_ROLE_CONFIG_SOURCE"
+  printf 'Roles:'
+  for role in "${AGENT_ROLES[@]}"; do
+    label="$(agent_role_label_for_role "$role")"
+    printf ' %s=%s' "$role" "$label"
+  done
+  printf '\n'
+  printf 'Primary next-action labels: '
+  for label in "${AGENT_PRIMARY_NEXT_LABELS[@]}"; do
+    if [[ "$first" -eq 1 ]]; then
+      first=0
+    else
+      printf ', '
+    fi
+    printf '%s' "$label"
+  done
+  printf '\n'
+}
+
 require_number() {
   local value="$1"
   local name="$2"

--- a/tools/agents/agent-audit
+++ b/tools/agents/agent-audit
@@ -23,7 +23,10 @@ if [[ "${1:-}" == "-h" || "${1:-}" == "--help" || $# -gt 0 ]]; then
   exit 0
 fi
 
-next_labels=(needs:architect needs:implementer needs:user needs:ci needs:merge blocked)
+next_labels=()
+while IFS= read -r label; do
+  next_labels+=("$label")
+done < <(agent_primary_next_labels)
 issues_json="$("$gh_retry" gh api -X GET "$(repo_api_path "$repo")/issues" \
   -f state=open \
   -f per_page="$limit")"

--- a/tools/agents/agent-inbox
+++ b/tools/agents/agent-inbox
@@ -10,7 +10,7 @@ source "$root/tools/agents/_lib.sh"
 usage() {
   cat <<'USAGE'
 Usage:
-  tools/agents/agent-inbox <architect|implementer|user|ci|merge|blocked|all>
+  tools/agents/agent-inbox <role|next-action-label|all>
 
 Lists the machine-readable agent inbox from issue labels.
 Project v2 status is intentionally not queried here.
@@ -18,18 +18,6 @@ Project v2 status is intentionally not queried here.
 Uses GitHub's REST API by default to avoid the GraphQL timeouts that can affect
 `gh issue list`.
 USAGE
-}
-
-label_for_role() {
-  case "$1" in
-    architect) echo "needs:architect" ;;
-    implementer) echo "needs:implementer" ;;
-    user) echo "needs:user" ;;
-    ci) echo "needs:ci" ;;
-    merge) echo "needs:merge" ;;
-    blocked) echo "blocked" ;;
-    *) return 1 ;;
-  esac
 }
 
 print_label() {
@@ -68,13 +56,13 @@ if [[ "$role" == "all" ]]; then
   issues_json="$("$gh_retry" gh api -X GET "$(repo_api_path "$repo")/issues" \
     -f state=open \
     -f per_page="$limit")"
-  for item in architect implementer user ci merge blocked; do
-    print_label_from_json "$(label_for_role "$item")" "$issues_json"
-  done
+  while IFS= read -r label; do
+    print_label_from_json "$label" "$issues_json"
+  done < <(agent_primary_next_labels)
   exit 0
 fi
 
-label="$(label_for_role "$role")" || {
+label="$(agent_label_for_inbox_target "$role")" || {
   usage >&2
   exit 2
 }

--- a/tools/agents/agent-label
+++ b/tools/agents/agent-label
@@ -11,7 +11,7 @@ usage() {
 Usage:
   tools/agents/agent-label <issue-number> add <label>
   tools/agents/agent-label <issue-number> remove <label>
-  tools/agents/agent-label <issue-number> set-next <needs:architect|needs:implementer|needs:user|needs:ci|needs:merge|blocked>
+  tools/agents/agent-label <issue-number> set-next <primary-next-action-label>
 
 Uses GitHub REST label endpoints to avoid `gh issue edit` GraphQL timeouts.
 `set-next` removes the primary next-action labels first, then adds the target.
@@ -59,19 +59,13 @@ case "$action" in
     remove_label "$label"
     ;;
   set-next)
-    case "$label" in
-      needs:architect|needs:implementer|needs:user|needs:ci|needs:merge|blocked) ;;
-      *)
-        printf 'Unsupported next-action label: %s\n' "$label" >&2
-        exit 2
-        ;;
-    esac
+    agent_require_primary_next_label "$label"
     labels_json="$(current_labels_json)"
-    for next_label in needs:architect needs:implementer needs:user needs:ci needs:merge blocked; do
+    while IFS= read -r next_label; do
       if [[ "$next_label" != "$label" ]] && has_label "$next_label" "$labels_json"; then
         remove_label "$next_label"
       fi
-    done
+    done < <(agent_primary_next_labels)
     if ! has_label "$label" "$labels_json"; then
       add_label "$label"
     fi

--- a/tools/agents/agent-role-config
+++ b/tools/agents/agent-role-config
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+source "$root/tools/agents/_lib.sh"
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  tools/agents/agent-role-config
+
+Prints the active role routing config in a compact form.
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" || $# -gt 0 ]]; then
+  usage
+  exit 0
+fi
+
+agent_print_role_routing_config

--- a/tools/agents/role-routing.conf
+++ b/tools/agents/role-routing.conf
@@ -1,0 +1,23 @@
+# Project-local role routing config for tools/agents helpers.
+#
+# This file is sourced by Bash. Keep values simple: arrays of role names and
+# labels, plus AGENT_ROLE_LABEL_<role> entries for each role.
+
+AGENT_ROLES=(architect implementer reviewer user ci merge)
+
+AGENT_ROLE_LABEL_architect="needs:architect"
+AGENT_ROLE_LABEL_implementer="needs:implementer"
+AGENT_ROLE_LABEL_reviewer="needs:reviewer"
+AGENT_ROLE_LABEL_user="needs:user"
+AGENT_ROLE_LABEL_ci="needs:ci"
+AGENT_ROLE_LABEL_merge="needs:merge"
+
+AGENT_PRIMARY_NEXT_LABELS=(
+  needs:architect
+  needs:implementer
+  needs:reviewer
+  needs:user
+  needs:ci
+  needs:merge
+  blocked
+)

--- a/tools/agents/test-role-routing-config
+++ b/tools/agents/test-role-routing-config
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+check() {
+  local name="$1"
+  shift
+
+  printf 'check: %s\n' "$name"
+  "$@"
+}
+
+check "built-in fallback includes reviewer" \
+  env AGENT_ROLE_ROUTING_CONFIG="$tmp_dir/missing.conf" ROOT="$root" bash -c '
+    set -euo pipefail
+    source "$ROOT/tools/agents/_lib.sh"
+    [[ "$(agent_role_label_for_role reviewer)" == "needs:reviewer" ]]
+    agent_require_primary_next_label needs:architect
+    agent_require_primary_next_label needs:implementer
+    agent_require_primary_next_label needs:reviewer
+  '
+
+cat > "$tmp_dir/custom.conf" <<'CONFIG'
+AGENT_ROLES=(architect reviewer)
+AGENT_ROLE_LABEL_architect="needs:architect"
+AGENT_ROLE_LABEL_reviewer="needs:reviewer"
+AGENT_PRIMARY_NEXT_LABELS=(needs:architect needs:reviewer blocked)
+CONFIG
+
+check "custom config maps configured roles" \
+  env AGENT_ROLE_ROUTING_CONFIG="$tmp_dir/custom.conf" ROOT="$root" bash -c '
+    set -euo pipefail
+    source "$ROOT/tools/agents/_lib.sh"
+    [[ "$(agent_role_label_for_role architect)" == "needs:architect" ]]
+    [[ "$(agent_role_label_for_role reviewer)" == "needs:reviewer" ]]
+    agent_require_primary_next_label blocked
+  '
+
+cat > "$tmp_dir/invalid.conf" <<'CONFIG'
+AGENT_ROLES=(architect reviewer)
+AGENT_ROLE_LABEL_architect="needs:architect"
+AGENT_ROLE_LABEL_reviewer="needs:reviewer"
+AGENT_PRIMARY_NEXT_LABELS=(needs:architect blocked)
+CONFIG
+
+check "invalid config fails closed" \
+  env AGENT_ROLE_ROUTING_CONFIG="$tmp_dir/invalid.conf" ROOT="$root" bash -c '
+    set -euo pipefail
+    if bash -c '"'"'
+      source "$ROOT/tools/agents/_lib.sh"
+      agent_primary_next_labels >/dev/null
+    '"'"' 2>/dev/null; then
+      exit 1
+    fi
+  '
+
+check "unknown next-action label fails closed" \
+  env AGENT_ROLE_ROUTING_CONFIG="$tmp_dir/custom.conf" ROOT="$root" bash -c '
+    set -euo pipefail
+    if bash -c '"'"'
+      source "$ROOT/tools/agents/_lib.sh"
+      agent_require_primary_next_label needs:unknown >/dev/null
+    '"'"' 2>/dev/null; then
+      exit 1
+    fi
+  '
+
+printf 'role routing config checks passed\n'


### PR DESCRIPTION
Closes #59

## Scope completed

- Added a project-local shell-readable role routing config at `tools/agents/role-routing.conf`.
- Added reusable `_lib.sh` helpers for loading, validating, introspecting, and querying configured roles and primary next-action labels.
- Added `reviewer` to the default/fallback role model without requiring per-helper hard-coding.
- Updated `agent-inbox`, `agent-label`, and `agent-audit` to consume shared primary next-action config.
- Added compact config introspection via `tools/agents/agent-role-config`.
- Added focused shell fixture checks in `tools/agents/test-role-routing-config`.
- Updated `tools/agents/README.md` with config usage and future project adaptation notes.

## Verification

- `tools/agents/test-role-routing-config`
- `bash -n tools/agents/_lib.sh tools/agents/agent-inbox tools/agents/agent-label tools/agents/agent-audit tools/agents/agent-ready-queue tools/agents/agent-role-config tools/agents/test-role-routing-config`
- `git diff --check`
- `tools/agents/agent-role-config`
- `AGENT_ROLE_ROUTING_CONFIG=/tmp/tiny-ipa-missing-role-config.conf tools/agents/agent-role-config`
- `tools/agents/agent-inbox all`
- `tools/agents/agent-audit`
- `tools/agents/agent-inbox architect && tools/agents/agent-inbox implementer && tools/agents/agent-inbox reviewer`
- `tools/agents/agent-label 59 set-next needs:unknown` confirmed fail-closed with configured-label message.

## Residual risks

- Config is Bash-sourceable by design, so future edits should keep it project-local and trusted.
- `agent-ready-queue` remains implementer-specific for #65; this PR only provides the shared routing foundation.
- Role-aware audit expansion is intentionally left to #61.