### PR TITLE
[#60] Verify role-generic inbox and label routing

### DIFF
--- a/tools/agents/test-role-routing-config
+++ b/tools/agents/test-role-routing-config
@@ -68,4 +68,84 @@ check "unknown next-action label fails closed" \
     fi
   '
 
+fixture_root="$tmp_dir/fixture-root"
+mkdir -p "$fixture_root/tools/agents"
+ln -s "$root/tools/agents/_lib.sh" "$fixture_root/tools/agents/_lib.sh"
+ln -s "$root/tools/agents/agent-inbox" "$fixture_root/tools/agents/agent-inbox"
+ln -s "$root/tools/agents/agent-label" "$fixture_root/tools/agents/agent-label"
+ln -s "$root/tools/agents/role-routing.conf" "$fixture_root/tools/agents/role-routing.conf"
+
+cat > "$fixture_root/tools/agents/gh-retry" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s\n' "$*" >> "$FAKE_GH_LOG"
+
+if [[ "$*" == *"-X GET"* && "$*" == *"/issues"* && "$*" == *"state=open"* ]]; then
+  if [[ "$*" == *"labels="* ]]; then
+    printf 'unexpected label-filtered inbox call\n' >&2
+    exit 20
+  fi
+  cat <<'JSON'
+[
+  {
+    "number": 1,
+    "title": "Architect task",
+    "html_url": "https://example.test/issues/1",
+    "updated_at": "2026-06-10T00:00:00Z",
+    "labels": [{"name": "needs:architect"}]
+  },
+  {
+    "number": 2,
+    "title": "Reviewer task",
+    "html_url": "https://example.test/issues/2",
+    "updated_at": "2026-06-10T00:00:00Z",
+    "labels": [{"name": "needs:reviewer"}]
+  }
+]
+JSON
+  exit 0
+fi
+
+if [[ "$*" == *"repos/farmerhunter/tiny-ipa/issues/60"* && "$*" == *"--jq [.labels[].name]"* ]]; then
+  printf '["needs:architect","needs:implementer","needs:reviewer","blocked","area:tooling"]\n'
+  exit 0
+fi
+
+if [[ "$*" == *"-X DELETE"* || "$*" == *"-X POST"* ]]; then
+  exit 0
+fi
+
+if [[ "$*" == *"repos/farmerhunter/tiny-ipa/issues/60"* && "$*" == *"--jq"* ]]; then
+  printf '#60 labels: needs:reviewer, area:tooling\n'
+  exit 0
+fi
+
+printf 'unexpected fake gh call: %s\n' "$*" >&2
+exit 21
+SH
+chmod +x "$fixture_root/tools/agents/gh-retry"
+
+check "agent-inbox all groups configured labels with one issue fetch" \
+  env FAKE_GH_LOG="$tmp_dir/inbox-gh.log" bash -c '
+    set -euo pipefail
+    output="$("$1/tools/agents/agent-inbox" all)"
+    grep -Fq "== needs:architect ==" <<< "$output"
+    grep -Fq "== needs:reviewer ==" <<< "$output"
+    grep -Fq "#1 Architect task" <<< "$output"
+    grep -Fq "#2 Reviewer task" <<< "$output"
+    [[ "$(wc -l < "$FAKE_GH_LOG" | tr -d " ")" == "1" ]]
+  ' bash "$fixture_root"
+
+check "agent-label set-next removes other configured primary labels" \
+  env FAKE_GH_LOG="$tmp_dir/label-gh.log" bash -c '
+    set -euo pipefail
+    "$1/tools/agents/agent-label" 60 set-next needs:reviewer >/dev/null
+    grep -Fq "/issues/60/labels/needs:architect" "$FAKE_GH_LOG"
+    grep -Fq "/issues/60/labels/needs:implementer" "$FAKE_GH_LOG"
+    grep -Fq "/issues/60/labels/blocked" "$FAKE_GH_LOG"
+    ! grep -Fq "/issues/60/labels/needs:reviewer" "$FAKE_GH_LOG"
+    ! grep -Fq "labels[]=needs:reviewer" "$FAKE_GH_LOG"
+  ' bash "$fixture_root"
+
 printf 'role routing config checks passed\n'


### PR DESCRIPTION
Closes #60

## Scope completed

- Added focused local fixture checks to `tools/agents/test-role-routing-config` for the #60 acceptance gaps left after #59.
- Verified `agent-inbox all` groups configured primary next-action labels, including `needs:reviewer`, from one unfiltered issue-list read.
- Verified `agent-label set-next` removes other configured primary labels before adding/keeping the requested route.
- Avoided live label mutation for the behavior check by using a fake `gh-retry` fixture around the real helper scripts.

## Verification

- `tools/agents/test-role-routing-config`
- `bash -n tools/agents/_lib.sh tools/agents/agent-inbox tools/agents/agent-label tools/agents/agent-audit tools/agents/agent-ready-queue tools/agents/agent-role-config tools/agents/test-role-routing-config`
- `git diff --check`
- `tools/agents/agent-inbox all`
- `tools/agents/agent-inbox architect && tools/agents/agent-inbox implementer && tools/agents/agent-inbox reviewer`
- `tools/agents/agent-audit`

## Residual risks

- Live GitHub helper verification hit intermittent TLS timeouts, but `gh-retry` retried and the commands completed.
- This PR intentionally does not broaden `agent-ready-queue`, `agent-audit`, pickup, or handoff behavior beyond #60.