### PR TITLE
[#65] Make agent-ready-queue role-generic

### DIFF
--- a/tools/agents/README.md
+++ b/tools/agents/README.md
@@ -19,6 +19,7 @@ tools/agents/agent-inbox implementer
 tools/agents/agent-inbox reviewer
 tools/agents/agent-role-config
 tools/agents/agent-ready-queue
+tools/agents/agent-ready-queue --role reviewer
 tools/agents/agent-audit
 ```
 
@@ -36,9 +37,11 @@ GraphQL/TLS timeouts in our current network setup. `agent-inbox all` fetches
 open issues once and groups the configured primary labels locally, instead of
 making one network call per label.
 
-`agent-ready-queue` extracts `Execution Contract` lines so an Implementer can
-see which ready issues are immediately startable and which are waiting on
-`Depends on`. It reads both issue bodies and issue comments because many
+`agent-ready-queue` defaults to the configured `implementer` role and also
+accepts `--role <role>` for other configured role inboxes, such as `reviewer`.
+It extracts `Execution Contract` lines so an agent can see which ready issues
+are immediately startable and which are waiting on `Depends on`. It reads both
+issue bodies and issue comments because many
 contracts are added after issue creation. When multiple contracts exist, it
 uses the latest highest-priority contract: `Final Execution Contract`, then
 `Execution Contract`, then `Draft Execution Contract`. This prevents stale
@@ -48,8 +51,8 @@ It also prints a dependency gate hint, such as `Gate: startable` or
 manually before deciding what to pick up. It also prints role-related contract
 fields (`Owner role`, `Review role`, `Acceptance role`, and `Completion
 handoff`) when present, using the same line-oriented contract parsing helpers
-as other scripts. It fetches the issue list once and then reads comments only
-for the queued issues.
+as other scripts. It fetches the open issue list once, filters configured role
+labels locally, and then reads comments only for the queued issues.
 
 `agent-audit` is a read-only consistency check. It looks for common workflow
 drift without touching GitHub Project v2:

--- a/tools/agents/agent-ready-queue
+++ b/tools/agents/agent-ready-queue
@@ -11,28 +11,55 @@ source "$root/tools/agents/_lib.sh"
 usage() {
   cat <<'USAGE'
 Usage:
-  tools/agents/agent-ready-queue
+  tools/agents/agent-ready-queue [--role <role>]
 
-Lists needs:implementer issues and extracts the latest effective Execution
-Contract lines that determine queue order. A Ready issue may still be blocked
-by Depends on.
+Lists queued issues for a configured role and extracts the latest effective
+Execution Contract lines that determine queue order. A Ready issue may still be
+blocked by Depends on. Defaults to --role implementer.
 
 Uses REST API calls instead of `gh issue list/view` to avoid GraphQL timeouts.
 USAGE
 }
 
-if [[ "${1:-}" == "-h" || "${1:-}" == "--help" || $# -gt 0 ]]; then
+role="implementer"
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
   usage
   exit 0
 fi
 
-issues_json="$("$gh_retry" gh api -X GET "$(repo_api_path "$repo")/issues" \
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --role)
+      if [[ -z "${2:-}" ]]; then
+        printf '--role requires a role name\n' >&2
+        exit 2
+      fi
+      role="$2"
+      shift 2
+      ;;
+    *)
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+role_label="$(agent_role_label_for_role "$role")"
+
+all_issues_json="$("$gh_retry" gh api -X GET "$(repo_api_path "$repo")/issues" \
   -f state=open \
-  -f labels=needs:implementer \
   -f per_page="$limit")"
+issues_json="$(jq --arg label "$role_label" '
+  [
+    .[] |
+    select(has("pull_request") | not) |
+    select(any(.labels[].name; . == $label))
+  ]
+' <<< "$all_issues_json")"
 
 if [[ "$(jq 'length' <<< "$issues_json")" -eq 0 ]]; then
-  printf 'No open issues labeled needs:implementer.\n'
+  printf 'No open issues labeled %s.\n' "$role_label"
   exit 0
 fi
 

--- a/tools/agents/agent-ready-queue
+++ b/tools/agents/agent-ready-queue
@@ -32,7 +32,7 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     --role)
       if [[ -z "${2:-}" ]]; then
-        printf '--role requires a role name\n' >&2
+        printf '%s\n' '--role requires a role name' >&2
         exit 2
       fi
       role="$2"

--- a/tools/agents/test-ready-queue
+++ b/tools/agents/test-ready-queue
@@ -90,4 +90,10 @@ if "$fixture_root/tools/agents/agent-ready-queue" --role ghost >/dev/null 2>&1; 
   exit 1
 fi
 
+if "$fixture_root/tools/agents/agent-ready-queue" --role >/tmp/ready-queue-missing-role.out 2>"$tmp_dir/missing-role.err"; then
+  printf 'missing role unexpectedly succeeded\n' >&2
+  exit 1
+fi
+grep -Fq -- "--role requires a role name" "$tmp_dir/missing-role.err"
+
 printf 'ready-queue fixture checks passed\n'

--- a/tools/agents/test-ready-queue
+++ b/tools/agents/test-ready-queue
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+fixture_root="$tmp_dir/fixture-root"
+mkdir -p "$fixture_root/tools/agents"
+ln -s "$root/tools/agents/_lib.sh" "$fixture_root/tools/agents/_lib.sh"
+ln -s "$root/tools/agents/agent-ready-queue" "$fixture_root/tools/agents/agent-ready-queue"
+ln -s "$root/tools/agents/role-routing.conf" "$fixture_root/tools/agents/role-routing.conf"
+
+cat > "$fixture_root/tools/agents/gh-retry" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s\n' "$*" >> "$FAKE_GH_LOG"
+
+if [[ "$*" == *"/issues/9"* && "$*" == *"--jq .state"* ]]; then
+  printf 'closed\n'
+  exit 0
+fi
+
+if [[ "$*" == *"/issues/"* && "$*" == *"/comments"* ]]; then
+  printf '[]\n'
+  exit 0
+fi
+
+if [[ "$*" == *"-X GET"* && "$*" == *"/issues"* && "$*" == *"state=open"* ]]; then
+  if [[ "$*" == *"labels="* ]]; then
+    printf 'unexpected label-filtered ready-queue call\n' >&2
+    exit 20
+  fi
+  cat <<'JSON'
+[
+  {
+    "number": 1,
+    "title": "Implementer task",
+    "html_url": "https://example.test/issues/1",
+    "body": "## Final Execution Contract\n\nBranch strategy: epic integration branch\nBase branch: `epic/x`\nTarget PR base: `epic/x`\nOwner role: implementer\nReview role: architect\nAcceptance role: architect\nDepends on: none\nCompletion handoff: to:architect\n",
+    "labels": [{"name": "type:task"}, {"name": "needs:implementer"}]
+  },
+  {
+    "number": 2,
+    "title": "Reviewer task",
+    "html_url": "https://example.test/issues/2",
+    "body": "## Final Execution Contract\n\nBranch strategy: epic integration branch\nBase branch: `epic/x`\nTarget PR base: `epic/x`\nOwner role: reviewer\nReview role: none\nAcceptance role: architect\nDepends on: #9\nCompletion handoff: batch checkpoint\n",
+    "labels": [{"name": "type:task"}, {"name": "needs:reviewer"}]
+  },
+  {
+    "number": 3,
+    "title": "Architect task",
+    "html_url": "https://example.test/issues/3",
+    "body": "## Final Execution Contract\n\nDepends on: none\nCompletion handoff: to:architect\n",
+    "labels": [{"name": "type:task"}, {"name": "needs:architect"}]
+  }
+]
+JSON
+  exit 0
+fi
+
+printf 'unexpected fake gh call: %s\n' "$*" >&2
+exit 21
+SH
+chmod +x "$fixture_root/tools/agents/gh-retry"
+
+FAKE_GH_LOG="$tmp_dir/default-gh.log" output="$(
+  FAKE_GH_LOG="$tmp_dir/default-gh.log" "$fixture_root/tools/agents/agent-ready-queue"
+)"
+grep -Fq "#1 Implementer task" <<< "$output"
+! grep -Fq "#2 Reviewer task" <<< "$output"
+grep -Fq "Owner role: implementer" <<< "$output"
+grep -Fq "Gate: startable" <<< "$output"
+[[ "$(grep -c "/issues" "$tmp_dir/default-gh.log")" == "2" ]]
+! grep -Fq "labels=" "$tmp_dir/default-gh.log"
+
+FAKE_GH_LOG="$tmp_dir/reviewer-gh.log" reviewer_output="$(
+  FAKE_GH_LOG="$tmp_dir/reviewer-gh.log" "$fixture_root/tools/agents/agent-ready-queue" --role reviewer
+)"
+grep -Fq "#2 Reviewer task" <<< "$reviewer_output"
+! grep -Fq "#1 Implementer task" <<< "$reviewer_output"
+grep -Fq "Review role: none" <<< "$reviewer_output"
+grep -Fq "Gate: startable" <<< "$reviewer_output"
+grep -Fq "Completion handoff: batch checkpoint" <<< "$reviewer_output"
+! grep -Fq "labels=" "$tmp_dir/reviewer-gh.log"
+
+if "$fixture_root/tools/agents/agent-ready-queue" --role ghost >/dev/null 2>&1; then
+  printf 'unknown role unexpectedly succeeded\n' >&2
+  exit 1
+fi
+
+printf 'ready-queue fixture checks passed\n'


### PR DESCRIPTION
Closes #65

## Scope completed

- Added `tools/agents/agent-ready-queue [--role <role>]` with `implementer` as the default.
- Resolved queue role labels through the project-local role routing config.
- Changed ready-queue issue discovery to one open issue-list read plus local filtering by the configured role label.
- Preserved compact queue output with latest contract, branch/base target, role fields, dependency gate, and completion handoff.
- Preserved Project-v2-free and pickup/handoff-mutation-free behavior.
- Added `tools/agents/test-ready-queue` fixture checks for default implementer queue, reviewer queue, local filtering/no label-filtered issue call, dependency gate output, batch checkpoint visibility, and unknown role failure.
- Updated `tools/agents/README.md` with `--role` usage and queue behavior.

## Verification

- `tools/agents/test-ready-queue`
- `tools/agents/test-contract-role-fields`
- `tools/agents/test-role-routing-config`
- `bash -n tools/agents/_lib.sh tools/agents/agent-ready-queue tools/agents/test-ready-queue tools/agents/test-contract-role-fields tools/agents/test-role-routing-config`
- `git diff --check`
- `tools/agents/agent-ready-queue`
- `tools/agents/agent-ready-queue --role implementer && tools/agents/agent-ready-queue --role reviewer`
- `tools/agents/agent-audit`

## Residual risks

- Live ready queues were empty after pickup, so role-specific non-empty behavior is covered by fixture tests rather than live GitHub data.
- Dependency gate semantics still use issue state for dependency checks; this PR does not change dependency closure policy or infer merge state from PR history.
- This PR does not implement pickup/handoff mutation or Project v2 reads.