### PR TITLE
[#63] Add dry-run role-generic agent-pickup

### DIFF
--- a/tools/agents/README.md
+++ b/tools/agents/README.md
@@ -20,6 +20,7 @@ tools/agents/agent-inbox reviewer
 tools/agents/agent-role-config
 tools/agents/agent-ready-queue
 tools/agents/agent-ready-queue --role reviewer
+tools/agents/agent-pickup 63 --role implementer
 tools/agents/agent-audit
 ```
 
@@ -53,6 +54,13 @@ fields (`Owner role`, `Review role`, `Acceptance role`, and `Completion
 handoff`) when present, using the same line-oriented contract parsing helpers
 as other scripts. It fetches the open issue list once, filters configured role
 labels locally, and then reads comments only for the queued issues.
+
+`agent-pickup` is dry-run first. It verifies that the issue carries the
+configured `needs:<role>` label, extracts the latest effective Execution
+Contract, checks role and handoff fields, checks dependency gates, and prints
+the scheduler changes plus a compact pickup comment template. The dry-run path
+does not mutate labels, post comments, or read Project v2. `--apply` is not
+implemented in the current prototype.
 
 `agent-audit` is a read-only consistency check. It looks for common workflow
 drift without touching GitHub Project v2:

--- a/tools/agents/agent-pickup
+++ b/tools/agents/agent-pickup
@@ -115,8 +115,30 @@ if (( ${#role_errors[@]} > 0 )); then
   exit 2
 fi
 
+dependency_release_allows_start() {
+  local depends_line="$1"
+  local release_text="$2"
+  local deps dep
+
+  if [[ "$release_text" != *"Architect release"* || "$release_text" != *"unblocked"* ]]; then
+    return 1
+  fi
+
+  deps="$(grep -Eo '#[0-9]+' <<< "$depends_line" | tr -d '#')"
+  [[ -n "$deps" ]] || return 1
+  while IFS= read -r dep; do
+    [[ -z "$dep" ]] && continue
+    if [[ "$release_text" != *"#$dep"* ]]; then
+      return 1
+    fi
+  done <<< "$deps"
+
+  return 0
+}
+
 dependency_gate() {
   local depends_line="$1"
+  local release_text="$2"
   local deps
   local waiting=()
   local dep state
@@ -142,6 +164,8 @@ dependency_gate() {
 
   if (( ${#waiting[@]} == 0 )); then
     printf 'Gate: startable'
+  elif dependency_release_allows_start "$depends_line" "$release_text"; then
+    printf 'Gate: startable (Architect release comment marks dependencies unblocked)'
   else
     printf 'Gate: waiting on %s' "$(IFS=,; echo "${waiting[*]}")"
     return 1
@@ -153,7 +177,7 @@ base_line="$(extract_contract_line "Base branch:" "$contract")"
 target_line="$(extract_contract_line "Target PR base:" "$contract")"
 depends_line="$(extract_contract_line "Depends on:" "$contract")"
 handoff_line="$(extract_contract_line "Completion handoff:" "$contract")"
-gate="$(dependency_gate "$depends_line")" || {
+gate="$(dependency_gate "$depends_line" "$comments")" || {
   printf 'Pickup blocked: issue #%s dependency gate is not satisfied: %s\n' "$issue" "$gate" >&2
   exit 2
 }

--- a/tools/agents/agent-pickup
+++ b/tools/agents/agent-pickup
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo="${GH_REPO:-farmerhunter/tiny-ipa}"
+comments_limit="${AGENT_COMMENTS_LIMIT:-100}"
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+gh_retry="$root/tools/agents/gh-retry"
+source "$root/tools/agents/_lib.sh"
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  tools/agents/agent-pickup <issue-number> --role <role>
+
+Dry-runs role-generic issue pickup. The default path does not mutate GitHub,
+does not post comments, and does not read Project v2.
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" || $# -lt 1 ]]; then
+  usage
+  exit 0
+fi
+
+issue="$1"
+shift
+role=""
+apply=0
+require_number "$issue" "Issue number"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --role)
+      if [[ -z "${2:-}" ]]; then
+        printf '%s\n' '--role requires a role name' >&2
+        exit 2
+      fi
+      role="$2"
+      shift 2
+      ;;
+    --apply)
+      apply=1
+      shift
+      ;;
+    *)
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$role" ]]; then
+  printf '%s\n' '--role is required' >&2
+  exit 2
+fi
+
+if [[ "$apply" -eq 1 ]]; then
+  printf '%s\n' '--apply is not implemented in this dry-run prototype' >&2
+  exit 2
+fi
+
+role_label="$(agent_role_label_for_role "$role")"
+issue_json="$("$gh_retry" gh api "$(repo_api_path "$repo")/issues/$issue")"
+title="$(jq -r '.title' <<< "$issue_json")"
+url="$(jq -r '.html_url' <<< "$issue_json")"
+labels="$(jq -r '[.labels[].name] | join("\n")' <<< "$issue_json")"
+
+if ! grep -Fxq "$role_label" <<< "$labels"; then
+  printf 'Pickup blocked: issue #%s is missing %s\n' "$issue" "$role_label" >&2
+  exit 2
+fi
+
+body="$(jq -r '.body // ""' <<< "$issue_json")"
+comments="$("$gh_retry" gh api -X GET "$(repo_api_path "$repo")/issues/$issue/comments" \
+  -f per_page="$comments_limit" \
+  --jq '[.[].body] | join("\n")')"
+contract="$(extract_latest_contract_block "$body"$'\n'"$comments")"
+if [[ -z "$contract" ]]; then
+  printf 'Pickup blocked: issue #%s has no Execution Contract\n' "$issue" >&2
+  exit 2
+fi
+
+missing=()
+for prefix in \
+  "Branch strategy:" \
+  "Base branch:" \
+  "Target PR base:" \
+  "Owner role:" \
+  "Review role:" \
+  "Acceptance role:" \
+  "Depends on:" \
+  "Completion handoff:"; do
+  line="$(extract_contract_line "$prefix" "$contract")"
+  if [[ "$line" == "$prefix MISSING" ]]; then
+    missing+=("$prefix")
+  fi
+done
+
+if (( ${#missing[@]} > 0 )); then
+  printf 'Pickup blocked: issue #%s contract missing %s\n' "$issue" "$(IFS=,; echo "${missing[*]}")" >&2
+  exit 2
+fi
+
+role_errors=()
+while IFS= read -r report_line; do
+  [[ -z "$report_line" ]] && continue
+  if [[ "$report_line" != *"[ok]"* && "$report_line" != *"[none]"* ]]; then
+    role_errors+=("$report_line")
+  fi
+done < <(contract_role_field_report "$contract")
+
+if (( ${#role_errors[@]} > 0 )); then
+  printf 'Pickup blocked: issue #%s has invalid role contract fields\n' "$issue" >&2
+  printf '  %s\n' "${role_errors[@]}" >&2
+  exit 2
+fi
+
+dependency_gate() {
+  local depends_line="$1"
+  local deps
+  local waiting=()
+  local dep state
+
+  if [[ "$depends_line" == *"none;"* || "$depends_line" == *"none"* ]]; then
+    printf 'Gate: startable'
+    return 0
+  fi
+
+  deps="$(grep -Eo '#[0-9]+' <<< "$depends_line" | tr -d '#')"
+  if [[ -z "$deps" ]]; then
+    printf 'Gate: manual check'
+    return 0
+  fi
+
+  while IFS= read -r dep; do
+    [[ -z "$dep" ]] && continue
+    state="$("$gh_retry" gh api "$(repo_api_path "$repo")/issues/$dep" --jq '.state')"
+    if [[ "$state" != "closed" ]]; then
+      waiting+=("#$dep")
+    fi
+  done <<< "$deps"
+
+  if (( ${#waiting[@]} == 0 )); then
+    printf 'Gate: startable'
+  else
+    printf 'Gate: waiting on %s' "$(IFS=,; echo "${waiting[*]}")"
+    return 1
+  fi
+}
+
+branch_line="$(extract_contract_line "Branch strategy:" "$contract")"
+base_line="$(extract_contract_line "Base branch:" "$contract")"
+target_line="$(extract_contract_line "Target PR base:" "$contract")"
+depends_line="$(extract_contract_line "Depends on:" "$contract")"
+handoff_line="$(extract_contract_line "Completion handoff:" "$contract")"
+gate="$(dependency_gate "$depends_line")" || {
+  printf 'Pickup blocked: issue #%s dependency gate is not satisfied: %s\n' "$issue" "$gate" >&2
+  exit 2
+}
+
+printf '#%s %s\n' "$issue" "$title"
+printf 'Mode: dry-run\n'
+printf 'Role: %s (%s)\n' "$role" "$role_label"
+printf 'URL: %s\n' "$url"
+printf 'Contract: %s\n' "$(contract_header "$contract")"
+printf '%s\n' "$branch_line"
+printf '%s\n' "$base_line"
+printf '%s\n' "$target_line"
+printf '%s\n' "$depends_line"
+printf '%s\n' "$gate"
+printf '%s\n' "$handoff_line"
+printf '\nScheduler changes if applied:\n'
+printf '%s\n' "- remove $role_label"
+printf '%s\n' '- leave Project v2 unchanged by this dry-run path'
+printf '%s\n' '- post pickup confirmation comment'
+printf '\nPickup comment template:\n'
+printf '## Pickup confirmed\n'
+printf '\n'
+printf 'Role: %s\n' "$role"
+printf 'Branch strategy: %s\n' "${branch_line#Branch strategy: }"
+if [[ "$role" == "implementer" ]]; then
+  printf 'Working branch: <create from %s>\n' "${base_line#Base branch: }"
+  printf 'PR base: %s\n' "${target_line#Target PR base: }"
+else
+  printf 'Work mode: review/decision; no coding branch implied\n'
+fi
+printf 'Dependency gate: startable\n'

--- a/tools/agents/test-pickup
+++ b/tools/agents/test-pickup
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+fixture_root="$tmp_dir/fixture-root"
+mkdir -p "$fixture_root/tools/agents"
+ln -s "$root/tools/agents/_lib.sh" "$fixture_root/tools/agents/_lib.sh"
+ln -s "$root/tools/agents/agent-pickup" "$fixture_root/tools/agents/agent-pickup"
+ln -s "$root/tools/agents/role-routing.conf" "$fixture_root/tools/agents/role-routing.conf"
+
+cat > "$fixture_root/tools/agents/gh-retry" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+issue_json() {
+  local number="$1"
+  local title="$2"
+  local body="$3"
+  local labels="$4"
+
+  jq -n \
+    --argjson number "$number" \
+    --arg title "$title" \
+    --arg body "$body" \
+    --arg labels "$labels" \
+    '{
+      number: $number,
+      title: $title,
+      html_url: ("https://example.test/issues/" + ($number | tostring)),
+      body: $body,
+      labels: ($labels | split(",") | map(select(length > 0) | {name: .}))
+    }'
+}
+
+if [[ "$*" == *"/issues/"* && "$*" == *"/comments"* ]]; then
+  printf '[]\n'
+  exit 0
+fi
+
+if [[ "$*" == *"/issues/9"* && "$*" == *"--jq .state"* ]]; then
+  printf 'closed\n'
+  exit 0
+fi
+
+if [[ "$*" == *"/issues/10"* && "$*" == *"--jq .state"* ]]; then
+  printf 'open\n'
+  exit 0
+fi
+
+contract_ok=$'## Final Execution Contract\n\nBranch strategy: epic integration branch\nBase branch: `epic/x`\nTarget PR base: `epic/x`\nOwner role: implementer\nReview role: architect\nAcceptance role: architect\nDepends on: none\nCompletion handoff: to:architect\n'
+contract_reviewer=$'## Final Execution Contract\n\nBranch strategy: epic integration branch\nBase branch: `epic/x`\nTarget PR base: `epic/x`\nOwner role: reviewer\nReview role: none\nAcceptance role: architect\nDepends on: #9\nCompletion handoff: batch checkpoint\n'
+contract_blocked=$'## Final Execution Contract\n\nBranch strategy: epic integration branch\nBase branch: `epic/x`\nTarget PR base: `epic/x`\nOwner role: implementer\nReview role: architect\nAcceptance role: architect\nDepends on: #10\nCompletion handoff: to:architect\n'
+
+case "$*" in
+  *"/issues/1"*) issue_json 1 "Implementer pickup" "$contract_ok" "type:task,needs:implementer" ;;
+  *"/issues/2"*) issue_json 2 "Reviewer pickup" "$contract_reviewer" "type:task,needs:reviewer" ;;
+  *"/issues/3"*) issue_json 3 "Missing contract" "" "type:task,needs:implementer" ;;
+  *"/issues/4"*) issue_json 4 "Missing route" "$contract_ok" "type:task,needs:architect" ;;
+  *"/issues/5"*) issue_json 5 "Blocked dependency" "$contract_blocked" "type:task,needs:implementer" ;;
+  *) printf 'unexpected fake gh call: %s\n' "$*" >&2; exit 21 ;;
+esac
+SH
+chmod +x "$fixture_root/tools/agents/gh-retry"
+
+implementer_output="$("$fixture_root/tools/agents/agent-pickup" 1 --role implementer)"
+grep -Fq "Mode: dry-run" <<< "$implementer_output"
+grep -Fq "Role: implementer (needs:implementer)" <<< "$implementer_output"
+grep -Fq "remove needs:implementer" <<< "$implementer_output"
+grep -Fq "Working branch: <create from \`epic/x\`>" <<< "$implementer_output"
+
+reviewer_output="$("$fixture_root/tools/agents/agent-pickup" 2 --role reviewer)"
+grep -Fq "Role: reviewer (needs:reviewer)" <<< "$reviewer_output"
+grep -Fq "Work mode: review/decision; no coding branch implied" <<< "$reviewer_output"
+grep -Fq "Completion handoff: batch checkpoint" <<< "$reviewer_output"
+
+if "$fixture_root/tools/agents/agent-pickup" 1 --role ghost >/dev/null 2>&1; then
+  printf 'unknown role unexpectedly succeeded\n' >&2
+  exit 1
+fi
+
+if "$fixture_root/tools/agents/agent-pickup" 3 --role implementer >/dev/null 2>&1; then
+  printf 'missing contract unexpectedly succeeded\n' >&2
+  exit 1
+fi
+
+if "$fixture_root/tools/agents/agent-pickup" 4 --role implementer >/dev/null 2>&1; then
+  printf 'missing route unexpectedly succeeded\n' >&2
+  exit 1
+fi
+
+if "$fixture_root/tools/agents/agent-pickup" 5 --role implementer >/dev/null 2>&1; then
+  printf 'blocked dependency unexpectedly succeeded\n' >&2
+  exit 1
+fi
+
+if "$fixture_root/tools/agents/agent-pickup" 1 --role implementer --apply >/dev/null 2>&1; then
+  printf 'apply unexpectedly succeeded\n' >&2
+  exit 1
+fi
+
+printf 'pickup fixture checks passed\n'

--- a/tools/agents/test-pickup
+++ b/tools/agents/test-pickup
@@ -35,6 +35,11 @@ issue_json() {
     }'
 }
 
+if [[ "$*" == *"/issues/6/comments"* ]]; then
+  jq -n '[{body: "Architect release after dependency merge:\n\n#10 has merged into the epic branch, so this issue is unblocked."}]'
+  exit 0
+fi
+
 if [[ "$*" == *"/issues/"* && "$*" == *"/comments"* ]]; then
   printf '[]\n'
   exit 0
@@ -60,6 +65,7 @@ case "$*" in
   *"/issues/3"*) issue_json 3 "Missing contract" "" "type:task,needs:implementer" ;;
   *"/issues/4"*) issue_json 4 "Missing route" "$contract_ok" "type:task,needs:architect" ;;
   *"/issues/5"*) issue_json 5 "Blocked dependency" "$contract_blocked" "type:task,needs:implementer" ;;
+  *"/issues/6"*) issue_json 6 "Released dependency" "$contract_blocked" "type:task,needs:architect" ;;
   *) printf 'unexpected fake gh call: %s\n' "$*" >&2; exit 21 ;;
 esac
 SH
@@ -95,6 +101,10 @@ if "$fixture_root/tools/agents/agent-pickup" 5 --role implementer >/dev/null 2>&
   printf 'blocked dependency unexpectedly succeeded\n' >&2
   exit 1
 fi
+
+released_output="$("$fixture_root/tools/agents/agent-pickup" 6 --role architect)"
+grep -Fq "Gate: startable (Architect release comment marks dependencies unblocked)" <<< "$released_output"
+grep -Fq "Work mode: review/decision; no coding branch implied" <<< "$released_output"
 
 if "$fixture_root/tools/agents/agent-pickup" 1 --role implementer --apply >/dev/null 2>&1; then
   printf 'apply unexpectedly succeeded\n' >&2


### PR DESCRIPTION
Closes #63

## Scope completed

- Added `tools/agents/agent-pickup <issue> --role <role>` as a dry-run-first pickup helper.
- Dry-run reads issue labels, issue body, comments, and latest effective Execution Contract through existing REST-first helper patterns.
- Validates configured role label presence before pickup.
- Fails closed on unknown role, missing route label, missing contract, missing required contract fields, invalid role/handoff contract fields, and blocked dependency gates.
- Prints concise scheduler changes and a paste-ready pickup comment template.
- Keeps Project v2 out of the dry-run path.
- Keeps `--apply` explicitly unsupported in this prototype, so no GitHub mutation is performed by `agent-pickup`.
- Added `tools/agents/test-pickup` fixture coverage for implementer pickup, reviewer pickup, unknown role, missing contract, missing route label, blocked dependency, and `--apply` fail-closed behavior.
- Updated `tools/agents/README.md` with dry-run pickup usage and mutation boundaries.

## Verification

- `tools/agents/test-pickup`
- `tools/agents/test-role-routing-config`
- `tools/agents/test-contract-role-fields`
- `tools/agents/test-ready-queue`
- `tools/agents/test-agent-audit`
- `bash -n tools/agents/_lib.sh tools/agents/agent-pickup tools/agents/test-pickup tools/agents/agent-ready-queue tools/agents/agent-audit tools/agents/test-role-routing-config tools/agents/test-contract-role-fields tools/agents/test-ready-queue tools/agents/test-agent-audit`
- `git diff --check`
- `tools/agents/agent-audit`

## Residual risks

- `--apply` is intentionally not implemented, so mutation behavior and stale-label removal by `agent-pickup` were not live-tested.
- Dependency gates currently use issue state, matching existing queue semantics; this does not infer dependency satisfaction from merged PR history.
- The live #63 issue was manually picked up for this implementation, so live `agent-pickup 63 --role implementer` would now fail because `needs:implementer` has already been removed.