### PR TITLE
[#64] Add dry-run role-generic agent-handoff

### DIFF
--- a/tools/agents/README.md
+++ b/tools/agents/README.md
@@ -21,6 +21,8 @@ tools/agents/agent-role-config
 tools/agents/agent-ready-queue
 tools/agents/agent-ready-queue --role reviewer
 tools/agents/agent-pickup 63 --role implementer
+tools/agents/agent-handoff 64 --from implementer
+tools/agents/agent-handoff 64 --from reviewer --to implementer
 tools/agents/agent-audit
 ```
 
@@ -61,6 +63,15 @@ Contract, checks role and handoff fields, checks dependency gates, and prints
 the scheduler changes plus a compact pickup comment template. The dry-run path
 does not mutate labels, post comments, or read Project v2. `--apply` is not
 implemented in the current prototype.
+
+`agent-handoff` is also dry-run first. It validates the caller's `--from` role
+against the configured primary next-action labels, extracts the latest effective
+Execution Contract, resolves `Completion handoff:` values such as `to:<role>`,
+`batch checkpoint`, `close after evidence`, and `hold`, and prints the planned
+label changes plus a compact completion/handoff comment template. Use
+`--to <role|none|batch>` to override the contract route for explicit handoffs.
+The dry-run path does not mutate labels, post comments, close issues, or read
+Project v2. `--apply` is not implemented in the current prototype.
 
 `agent-audit` is a read-only consistency check. It looks for common workflow
 drift without touching GitHub Project v2:

--- a/tools/agents/agent-audit
+++ b/tools/agents/agent-audit
@@ -67,7 +67,7 @@ pickup_is_active() {
     /Pickup confirmed/ {
       active = 1
     }
-    /completion handoff|Completion handoff|Routing: moved this issue back|Architect sync after PR merge/ {
+    /completion handoff|Completion handoff|handoff complete|Handoff complete|Routing: moved this issue back|Architect sync after PR merge/ {
       active = 0
     }
     END {

--- a/tools/agents/agent-handoff
+++ b/tools/agents/agent-handoff
@@ -1,0 +1,342 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo="${GH_REPO:-farmerhunter/tiny-ipa}"
+comments_limit="${AGENT_COMMENTS_LIMIT:-100}"
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+gh_retry="$root/tools/agents/gh-retry"
+source "$root/tools/agents/_lib.sh"
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  tools/agents/agent-handoff <issue-number> --from <role> [--to <role|none|batch>]
+
+Dry-runs role-generic issue handoff. The default path does not mutate GitHub,
+does not post comments, does not close issues, and does not read Project v2.
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" || $# -lt 1 ]]; then
+  usage
+  exit 0
+fi
+
+issue="$1"
+shift
+from_role=""
+to_override=""
+apply=0
+require_number "$issue" "Issue number"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --from)
+      if [[ -z "${2:-}" ]]; then
+        printf '%s\n' '--from requires a role name' >&2
+        exit 2
+      fi
+      from_role="$2"
+      shift 2
+      ;;
+    --to)
+      if [[ -z "${2:-}" ]]; then
+        printf '%s\n' '--to requires a target' >&2
+        exit 2
+      fi
+      to_override="$2"
+      shift 2
+      ;;
+    --apply)
+      apply=1
+      shift
+      ;;
+    *)
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$from_role" ]]; then
+  printf '%s\n' '--from is required' >&2
+  exit 2
+fi
+
+if [[ "$apply" -eq 1 ]]; then
+  printf '%s\n' '--apply is not implemented in this dry-run prototype' >&2
+  exit 2
+fi
+
+from_label="$(agent_role_label_for_role "$from_role")"
+
+normalize_contract_target() {
+  local raw="$1"
+  local role
+
+  case "$raw" in
+    to:*)
+      role="${raw#to:}"
+      agent_role_label_for_role "$role" >/dev/null
+      printf 'role:%s\n' "$role"
+      ;;
+    batch|"batch checkpoint")
+      printf 'batch\n'
+      ;;
+    none)
+      printf 'none\n'
+      ;;
+    "close after evidence")
+      printf 'close-after-evidence\n'
+      ;;
+    hold)
+      printf 'hold\n'
+      ;;
+    "")
+      printf '%s\n' 'missing'
+      return 2
+      ;;
+    *)
+      return 2
+      ;;
+  esac
+}
+
+normalize_override_target() {
+  local raw="$1"
+
+  case "$raw" in
+    batch)
+      printf 'batch\n'
+      ;;
+    none)
+      printf 'none\n'
+      ;;
+    "")
+      printf '%s\n' 'missing'
+      return 2
+      ;;
+    *)
+      agent_role_label_for_role "$raw" >/dev/null
+      printf 'role:%s\n' "$raw"
+      ;;
+  esac
+}
+
+target_description() {
+  local normalized="$1"
+  local role label
+
+  case "$normalized" in
+    role:*)
+      role="${normalized#role:}"
+      label="$(agent_role_label_for_role "$role")"
+      printf 'to:%s (%s)' "$role" "$label"
+      ;;
+    batch)
+      printf 'batch checkpoint (no next-action label)'
+      ;;
+    none)
+      printf 'none (no next-action label)'
+      ;;
+    close-after-evidence)
+      printf 'close after evidence (manual close reminder)'
+      ;;
+    hold)
+      printf 'hold (blocked)'
+      ;;
+  esac
+}
+
+planned_label_changes() {
+  local normalized="$1"
+  local current_labels="$2"
+  local current_primary="$3"
+  local role label
+  local target_label=""
+
+  if [[ "$normalized" == role:* ]]; then
+    role="${normalized#role:}"
+    target_label="$(agent_role_label_for_role "$role")"
+  elif [[ "$normalized" == hold ]]; then
+    target_label="blocked"
+  fi
+
+  if [[ -n "$current_primary" ]]; then
+    while IFS= read -r label; do
+      [[ -z "$label" ]] && continue
+      [[ -n "$target_label" && "$label" == "$target_label" ]] && continue
+      printf '%s\n' "- remove $label"
+    done <<< "$current_primary"
+  else
+    printf '%s\n' '- no current primary next-action label to remove'
+  fi
+
+  case "$normalized" in
+    role:*)
+      if grep -Fxq "$target_label" <<< "$current_labels"; then
+        printf '%s\n' "- keep $target_label"
+      else
+        printf '%s\n' "- add $target_label"
+      fi
+      ;;
+    hold)
+      if grep -Fxq "blocked" <<< "$current_labels"; then
+        printf '%s\n' '- keep blocked'
+      else
+        printf '%s\n' '- add blocked'
+      fi
+      ;;
+    batch|none|close-after-evidence)
+      printf '%s\n' '- add no next-action label'
+      ;;
+  esac
+}
+
+next_action_text() {
+  local normalized="$1"
+  local role
+
+  case "$normalized" in
+    role:implementer)
+      printf 'Implementer picks up fixes, verification, or follow-up work.'
+      ;;
+    role:reviewer)
+      printf 'Reviewer performs review or QA; no coding branch is implied.'
+      ;;
+    role:architect)
+      printf 'Architect reviews, accepts, plans, or decides next routing.'
+      ;;
+    role:*)
+      role="${normalized#role:}"
+      printf '%s picks up the next role-specific action.' "$role"
+      ;;
+    batch)
+      printf 'No per-issue next actor; include this in the batch checkpoint.'
+      ;;
+    none)
+      printf 'No next route; leave unrouted only if the contract explicitly allows it.'
+      ;;
+    close-after-evidence)
+      printf 'Confirm evidence and close manually; this helper does not close issues.'
+      ;;
+    hold)
+      printf 'Resolve the hold reason before routing to another actor.'
+      ;;
+  esac
+}
+
+issue_json="$("$gh_retry" gh api "$(repo_api_path "$repo")/issues/$issue")"
+title="$(jq -r '.title' <<< "$issue_json")"
+url="$(jq -r '.html_url' <<< "$issue_json")"
+labels="$(jq -r '[.labels[].name] | join("\n")' <<< "$issue_json")"
+body="$(jq -r '.body // ""' <<< "$issue_json")"
+comments="$("$gh_retry" gh api -X GET "$(repo_api_path "$repo")/issues/$issue/comments" \
+  -f per_page="$comments_limit" \
+  --jq '[.[].body] | join("\n")')"
+contract="$(extract_latest_contract_block "$body"$'\n'"$comments")"
+
+if [[ -z "$contract" ]]; then
+  printf 'Handoff blocked: issue #%s has no Execution Contract\n' "$issue" >&2
+  exit 2
+fi
+
+current_primary=()
+while IFS= read -r next_label; do
+  [[ -z "$next_label" ]] && continue
+  if grep -Fxq "$next_label" <<< "$labels"; then
+    current_primary+=("$next_label")
+  fi
+done < <(agent_primary_next_labels)
+
+if (( ${#current_primary[@]} > 1 )); then
+  printf 'Handoff blocked: issue #%s has multiple current next-action labels: %s\n' \
+    "$issue" "$(IFS=,; echo "${current_primary[*]}")" >&2
+  exit 2
+fi
+
+if (( ${#current_primary[@]} == 1 )) && [[ "${current_primary[0]}" != "$from_label" ]]; then
+  printf 'Handoff blocked: issue #%s is routed to %s, not %s\n' \
+    "$issue" "${current_primary[0]}" "$from_label" >&2
+  exit 2
+fi
+
+missing=()
+for prefix in \
+  "Owner role:" \
+  "Review role:" \
+  "Acceptance role:" \
+  "Completion handoff:"; do
+  line="$(extract_contract_line "$prefix" "$contract")"
+  if [[ "$line" == "$prefix MISSING" ]]; then
+    missing+=("$prefix")
+  fi
+done
+
+if (( ${#missing[@]} > 0 )); then
+  printf 'Handoff blocked: issue #%s contract missing %s\n' "$issue" "$(IFS=,; echo "${missing[*]}")" >&2
+  exit 2
+fi
+
+role_errors=()
+while IFS= read -r report_line; do
+  [[ -z "$report_line" ]] && continue
+  if [[ "$report_line" == "Completion handoff:"* && -n "$to_override" ]]; then
+    continue
+  fi
+  if [[ "$report_line" != *"[ok]"* && "$report_line" != *"[none]"* ]]; then
+    role_errors+=("$report_line")
+  fi
+done < <(contract_role_field_report "$contract")
+
+if (( ${#role_errors[@]} > 0 )); then
+  printf 'Handoff blocked: issue #%s has invalid role contract fields\n' "$issue" >&2
+  printf '  %s\n' "${role_errors[@]}" >&2
+  exit 2
+fi
+
+if [[ -n "$to_override" ]]; then
+  target_source="--to $to_override"
+  normalized_target="$(normalize_override_target "$to_override")" || {
+    printf 'Handoff blocked: unsupported --to target: %s\n' "$to_override" >&2
+    exit 2
+  }
+else
+  handoff_value="$(extract_contract_value "Completion handoff:" "$contract")"
+  target_source="Completion handoff: $handoff_value"
+  normalized_target="$(normalize_contract_target "$handoff_value")" || {
+    printf 'Handoff blocked: unsupported contract handoff target: %s\n' "$handoff_value" >&2
+    exit 2
+  }
+fi
+
+current_primary_text=""
+if (( ${#current_primary[@]} > 0 )); then
+  current_primary_text="$(printf '%s\n' "${current_primary[@]}")"
+fi
+
+printf '#%s %s\n' "$issue" "$title"
+printf 'Mode: dry-run\n'
+printf 'From: %s (%s)\n' "$from_role" "$from_label"
+printf 'Target: %s\n' "$(target_description "$normalized_target")"
+printf 'Source: %s\n' "$target_source"
+printf 'URL: %s\n' "$url"
+printf 'Contract: %s\n' "$(contract_header "$contract")"
+printf '\nScheduler changes if applied:\n'
+planned_label_changes "$normalized_target" "$labels" "$current_primary_text"
+printf '%s\n' '- leave Project v2 unchanged by this dry-run path'
+printf '%s\n' '- post completion/handoff comment'
+printf '\nCompletion/handoff comment template:\n'
+printf '## %s handoff complete\n' "$from_role"
+printf '\n'
+printf 'Scope completed:\n'
+printf '%s\n' '- <what changed or what was reviewed>'
+printf '\n'
+printf 'Verification:\n'
+printf '%s\n' '- <checks run and result>'
+printf '\n'
+printf 'Residual risks:\n'
+printf '%s\n' '- <known limits or none>'
+printf '\n'
+printf 'Next action:\n'
+printf '%s\n' "- $(next_action_text "$normalized_target")"

--- a/tools/agents/test-agent-audit
+++ b/tools/agents/test-agent-audit
@@ -34,6 +34,13 @@ JSON
   exit 0
 fi
 
+if [[ "$*" == *"/issues/8/comments"* ]]; then
+  cat <<'JSON'
+[{"body": "## Pickup confirmed\n\nStarting work."}, {"body": "## Implementer handoff complete\n\nNext action: Routed back to architect."}]
+JSON
+  exit 0
+fi
+
 if [[ "$*" == *"/issues/"* && "$*" == *"/comments"* ]]; then
   printf '[]\n'
   exit 0
@@ -97,6 +104,13 @@ if [[ "$*" == *"/issues"* && "$*" == *"state=open"* ]]; then
     "html_url": "https://example.test/issues/6",
     "body": "## Final Execution Contract\n\nBranch strategy: epic integration branch\nBase branch: `epic/x`\nTarget PR base: `epic/x`\nDepends on: none\n",
     "labels": [{"name": "type:task"}, {"name": "needs:implementer"}]
+  },
+  {
+    "number": 8,
+    "title": "Handoff completed route",
+    "html_url": "https://example.test/issues/8",
+    "body": "## Final Execution Contract\n\nCompletion handoff: to:architect\n",
+    "labels": [{"name": "type:task"}, {"name": "needs:architect"}]
   }
 ]
 JSON
@@ -123,5 +137,6 @@ grep -Fq "#6 Missing handoff" <<< "$output"
 grep -Fq "handoff: MISSING (missing)" <<< "$output"
 ! grep -Fq "#3 Batch checkpoint" <<< "$output"
 ! grep -Fq "#4 Picked up without route" <<< "$output"
+! grep -Fq "#8 Handoff completed route" <<< "$output"
 
 printf 'agent-audit fixture checks passed\n'

--- a/tools/agents/test-handoff
+++ b/tools/agents/test-handoff
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+fixture_root="$tmp_dir/fixture-root"
+mkdir -p "$fixture_root/tools/agents"
+ln -s "$root/tools/agents/_lib.sh" "$fixture_root/tools/agents/_lib.sh"
+ln -s "$root/tools/agents/agent-handoff" "$fixture_root/tools/agents/agent-handoff"
+ln -s "$root/tools/agents/role-routing.conf" "$fixture_root/tools/agents/role-routing.conf"
+
+cat > "$fixture_root/tools/agents/gh-retry" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+issue_json() {
+  local number="$1"
+  local title="$2"
+  local body="$3"
+  local labels="$4"
+
+  jq -n \
+    --argjson number "$number" \
+    --arg title "$title" \
+    --arg body "$body" \
+    --arg labels "$labels" \
+    '{
+      number: $number,
+      title: $title,
+      html_url: ("https://example.test/issues/" + ($number | tostring)),
+      body: $body,
+      labels: ($labels | split(",") | map(select(length > 0) | {name: .}))
+    }'
+}
+
+if [[ "$*" == *"/issues/"* && "$*" == *"/comments"* ]]; then
+  printf '[]\n'
+  exit 0
+fi
+
+contract() {
+  local owner="$1"
+  local review="$2"
+  local acceptance="$3"
+  local handoff="$4"
+  printf '## Final Execution Contract\n\nOwner role: %s\nReview role: %s\nAcceptance role: %s\nCompletion handoff: %s\n' \
+    "$owner" "$review" "$acceptance" "$handoff"
+}
+
+case "$*" in
+  *"/issues/10"*) issue_json 10 "Bare role contract" "$(contract implementer architect architect architect)" "type:task" ;;
+  *"/issues/11"*) issue_json 11 "Same route" "$(contract reviewer none architect to:reviewer)" "type:task,needs:reviewer" ;;
+  *"/issues/1"*) issue_json 1 "Implementer to architect" "$(contract implementer architect architect to:architect)" "type:task" ;;
+  *"/issues/2"*) issue_json 2 "Implementer to reviewer" "$(contract implementer reviewer architect to:architect)" "type:task,needs:implementer" ;;
+  *"/issues/3"*) issue_json 3 "Reviewer to implementer" "$(contract reviewer none architect to:architect)" "type:task,needs:reviewer" ;;
+  *"/issues/4"*) issue_json 4 "Reviewer to architect" "$(contract reviewer none architect to:architect)" "type:task,needs:reviewer" ;;
+  *"/issues/5"*) issue_json 5 "Hold state" "$(contract implementer architect architect hold)" "type:task" ;;
+  *"/issues/6"*) issue_json 6 "Close after evidence" "$(contract implementer architect architect "close after evidence")" "type:task" ;;
+  *"/issues/7"*) issue_json 7 "Batch checkpoint" "$(contract implementer architect architect "batch checkpoint")" "type:task" ;;
+  *"/issues/8"*) issue_json 8 "Missing contract" "" "type:task" ;;
+  *"/issues/9"*) issue_json 9 "Wrong route" "$(contract implementer architect architect to:architect)" "type:task,needs:architect" ;;
+  *) printf 'unexpected fake gh call: %s\n' "$*" >&2; exit 21 ;;
+esac
+SH
+chmod +x "$fixture_root/tools/agents/gh-retry"
+
+impl_arch="$("$fixture_root/tools/agents/agent-handoff" 1 --from implementer)"
+grep -Fq "Target: to:architect (needs:architect)" <<< "$impl_arch"
+grep -Fq "add needs:architect" <<< "$impl_arch"
+grep -Fq "Completion/handoff comment template:" <<< "$impl_arch"
+grep -Fq "Scope completed:" <<< "$impl_arch"
+grep -Fq "Verification:" <<< "$impl_arch"
+grep -Fq "Residual risks:" <<< "$impl_arch"
+grep -Fq "Next action:" <<< "$impl_arch"
+
+impl_review="$("$fixture_root/tools/agents/agent-handoff" 2 --from implementer --to reviewer)"
+grep -Fq "From: implementer (needs:implementer)" <<< "$impl_review"
+grep -Fq "Target: to:reviewer (needs:reviewer)" <<< "$impl_review"
+grep -Fq "remove needs:implementer" <<< "$impl_review"
+grep -Fq "add needs:reviewer" <<< "$impl_review"
+
+review_impl="$("$fixture_root/tools/agents/agent-handoff" 3 --from reviewer --to implementer)"
+grep -Fq "Target: to:implementer (needs:implementer)" <<< "$review_impl"
+grep -Fq "remove needs:reviewer" <<< "$review_impl"
+grep -Fq "add needs:implementer" <<< "$review_impl"
+
+review_arch="$("$fixture_root/tools/agents/agent-handoff" 4 --from reviewer --to architect)"
+grep -Fq "Target: to:architect (needs:architect)" <<< "$review_arch"
+grep -Fq "Architect reviews, accepts, plans, or decides next routing." <<< "$review_arch"
+
+hold_output="$("$fixture_root/tools/agents/agent-handoff" 5 --from implementer)"
+grep -Fq "Target: hold (blocked)" <<< "$hold_output"
+grep -Fq "add blocked" <<< "$hold_output"
+
+close_output="$("$fixture_root/tools/agents/agent-handoff" 6 --from implementer)"
+grep -Fq "Target: close after evidence (manual close reminder)" <<< "$close_output"
+grep -Fq "Confirm evidence and close manually" <<< "$close_output"
+
+batch_output="$("$fixture_root/tools/agents/agent-handoff" 7 --from implementer)"
+grep -Fq "Target: batch checkpoint (no next-action label)" <<< "$batch_output"
+grep -Fq "add no next-action label" <<< "$batch_output"
+! grep -Fq "add needs:" <<< "$batch_output"
+
+none_output="$("$fixture_root/tools/agents/agent-handoff" 1 --from implementer --to none)"
+grep -Fq "Target: none (no next-action label)" <<< "$none_output"
+grep -Fq "add no next-action label" <<< "$none_output"
+
+same_route="$("$fixture_root/tools/agents/agent-handoff" 11 --from reviewer)"
+grep -Fq "Target: to:reviewer (needs:reviewer)" <<< "$same_route"
+grep -Fq "keep needs:reviewer" <<< "$same_route"
+! grep -Fq "remove needs:reviewer" <<< "$same_route"
+
+if "$fixture_root/tools/agents/agent-handoff" 1 --from ghost >/dev/null 2>&1; then
+  printf 'unknown from role unexpectedly succeeded\n' >&2
+  exit 1
+fi
+
+if "$fixture_root/tools/agents/agent-handoff" 8 --from implementer >/dev/null 2>&1; then
+  printf 'missing contract unexpectedly succeeded\n' >&2
+  exit 1
+fi
+
+if "$fixture_root/tools/agents/agent-handoff" 1 --from implementer --to ghost >/dev/null 2>&1; then
+  printf 'unknown target unexpectedly succeeded\n' >&2
+  exit 1
+fi
+
+if "$fixture_root/tools/agents/agent-handoff" 1 --from implementer --to close >/dev/null 2>&1; then
+  printf 'unsupported explicit target unexpectedly succeeded\n' >&2
+  exit 1
+fi
+
+if "$fixture_root/tools/agents/agent-handoff" 1 --from implementer --to hold >/dev/null 2>&1; then
+  printf 'unsupported explicit hold target unexpectedly succeeded\n' >&2
+  exit 1
+fi
+
+if "$fixture_root/tools/agents/agent-handoff" 10 --from implementer >/dev/null 2>&1; then
+  printf 'unsupported bare-role contract target unexpectedly succeeded\n' >&2
+  exit 1
+fi
+
+if "$fixture_root/tools/agents/agent-handoff" 9 --from implementer >/dev/null 2>&1; then
+  printf 'wrong current route unexpectedly succeeded\n' >&2
+  exit 1
+fi
+
+if "$fixture_root/tools/agents/agent-handoff" 1 --from implementer --apply >/dev/null 2>&1; then
+  printf 'apply unexpectedly succeeded\n' >&2
+  exit 1
+fi
+
+printf 'handoff fixture checks passed\n'


### PR DESCRIPTION
## Scope completed
- Added `tools/agents/agent-handoff` as a dry-run-first role-generic handoff helper.
- Reused project role routing config, primary next-action labels, Execution Contract extraction, role field validation, and concise helper output patterns.
- Supported contract handoff targets: `to:<role>`, `batch checkpoint`, `close after evidence`, and `hold`.
- Supported explicit override targets: `--to <role|none|batch>` with fail-closed handling for unknown values.
- Added `tools/agents/test-handoff` fixture coverage for implementer/reviewer/architect transitions, hold, close-after-evidence, batch checkpoint, missing contract, wrong route, unknown role/target, explicit unsupported target, and unimplemented `--apply`.
- Updated `tools/agents/README.md` with usage and dry-run boundaries.

## Verification
- `tools/agents/test-handoff`
- `tools/agents/test-pickup`
- `tools/agents/test-role-routing-config && tools/agents/test-contract-role-fields && tools/agents/test-ready-queue && tools/agents/test-agent-audit`
- `bash -n tools/agents/_lib.sh tools/agents/agent-handoff tools/agents/test-handoff tools/agents/agent-pickup tools/agents/test-pickup tools/agents/agent-ready-queue tools/agents/agent-audit tools/agents/agent-inbox tools/agents/agent-label tools/agents/agent-role-config && git diff --check`
- Live dry-run only: `tools/agents/agent-handoff 64 --from implementer`
- Live read-only audit: `tools/agents/agent-audit` completed after one transient GitHub TLS retry.

## Residual risks
- `--apply` is intentionally not implemented and fails closed; no live mutation path was tested.
- `agent-audit` currently reports #63 as an unrelated open task without a next-action label; left unchanged because this PR only handles #64.
- `agent-ready-queue` still gates on dependency issue closure rather than merged PR state, as noted in the #64 release comment and left for follow-up.