### PR TITLE
[M5 #75] Implement phoneme-aware scheduler scoring core

### DIFF
--- a/backend/app/services/scheduler.py
+++ b/backend/app/services/scheduler.py
@@ -1,16 +1,36 @@
 """Word selection for daily practice sessions.
 
-The scheduler selects ``daily_word_count`` words from the ``words`` table.
-For M2 the selection is simple — usable words, shuffle, take N. Weak-phoneme
-weighting and new/review ratio are M5 concerns.
+The scheduler intentionally stays small: it filters unusable content, suppresses
+short-term repeats when the pool allows it, then scores candidates using
+phoneme stats and deterministic tie-breaking.
 """
 
-import random
+from __future__ import annotations
+
+import hashlib
+import json
 import sqlite3
-from typing import List
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Optional, Sequence, Set
 
 from app.models import Word
 from app.services.db_store import get_word_by_id
+
+_REVIEW_STRENGTH_MULTIPLIERS = {
+    "quick": 0.35,
+    "low": 0.35,
+    "normal": 1.0,
+    "extra_review": 1.7,
+    "high": 1.7,
+}
+
+
+@dataclass(frozen=True)
+class _Candidate:
+    word_id: str
+    phoneme_tags: List[str]
+    score: float
+    has_seen_phoneme: bool
 
 
 def select_daily_words(
@@ -18,10 +38,14 @@ def select_daily_words(
     daily_word_count: int = 10,
     accent: str = "US",
     seed: int = 0,
+    *,
+    user_id: str = "default",
+    review_strength: str = "normal",
+    focus_phonemes: Optional[Sequence[str]] = None,
 ) -> List[Word]:
     """Select ``daily_word_count`` usable words for today's practice.
 
-    Usable = ipa_us is present and content_status is not 'disabled'.
+    Usable = accent IPA is present and content_status is not 'disabled'.
 
     Args:
         conn: Database connection.
@@ -29,23 +53,52 @@ def select_daily_words(
         accent: "US" or "UK" — only words with the matching IPA field.
         seed: Deterministic seed for shuffle. Use the date-derived value
               so same-day calls return the same order.
+        user_id: User whose phoneme stats and recent sessions should be read.
+        review_strength: Weighting mode for weak-phoneme review.
+        focus_phonemes: Optional phoneme ids/symbols to boost for this session.
 
     Returns:
         List of Word dataclasses, length ≤ daily_word_count.
     """
+    if daily_word_count <= 0:
+        return []
+
+    accent = accent.upper()
     ipa_field = "ipa_us" if accent.upper() == "US" else "ipa_uk"
+    tag_field = "phoneme_tags_us" if accent.upper() == "US" else "phoneme_tags_uk"
     rows = conn.execute(
         f"""
-        SELECT id FROM words
+        SELECT id, {tag_field} AS phoneme_tags
+        FROM words
         WHERE {ipa_field} IS NOT NULL AND {ipa_field} != ''
           AND content_status != 'disabled'
         """
     ).fetchall()
 
-    word_ids = [r["id"] for r in rows]
-    rng = random.Random(seed)
-    rng.shuffle(word_ids)
-    selected_ids = word_ids[:daily_word_count]
+    recent_word_ids = _recent_word_ids(conn, user_id=user_id, accent=accent)
+    usable_rows = rows
+    non_recent_rows = [r for r in rows if r["id"] not in recent_word_ids]
+    if len(non_recent_rows) >= daily_word_count:
+        usable_rows = non_recent_rows
+
+    stats = _phoneme_stats(conn, user_id=user_id, accent=accent)
+    focus = _normalise_focus_phonemes(conn, focus_phonemes or [])
+    review_multiplier = _REVIEW_STRENGTH_MULTIPLIERS.get(review_strength, 1.0)
+
+    candidates = [
+        _score_candidate(
+            word_id=r["id"],
+            phoneme_tags=_parse_tags(r["phoneme_tags"]),
+            stats=stats,
+            focus_phonemes=focus,
+            review_multiplier=review_multiplier,
+            seed=seed,
+            is_recent=r["id"] in recent_word_ids,
+        )
+        for r in usable_rows
+    ]
+    candidates.sort(key=lambda c: (-c.score, c.word_id))
+    selected_ids = _choose_with_new_word_balance(candidates, daily_word_count)
 
     words: List[Word] = []
     for wid in selected_ids:
@@ -53,3 +106,183 @@ def select_daily_words(
         if w is not None:
             words.append(w)
     return words
+
+
+def _parse_tags(raw: Optional[str]) -> List[str]:
+    if not raw:
+        return []
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return []
+    if not isinstance(parsed, list):
+        return []
+    return [str(tag) for tag in parsed if tag]
+
+
+def _recent_word_ids(
+    conn: sqlite3.Connection,
+    *,
+    user_id: str,
+    accent: str,
+    session_limit: int = 3,
+) -> Set[str]:
+    session_rows = conn.execute(
+        """
+        SELECT id
+        FROM daily_sessions
+        WHERE user_id = ? AND primary_accent = ?
+        ORDER BY session_date DESC, created_at DESC
+        LIMIT ?
+        """,
+        (user_id, accent, session_limit),
+    ).fetchall()
+    if not session_rows:
+        return set()
+
+    placeholders = ",".join("?" for _ in session_rows)
+    item_rows = conn.execute(
+        f"""
+        SELECT DISTINCT word_id
+        FROM session_items
+        WHERE session_id IN ({placeholders})
+        """,
+        tuple(r["id"] for r in session_rows),
+    ).fetchall()
+    return {r["word_id"] for r in item_rows}
+
+
+def _phoneme_stats(
+    conn: sqlite3.Connection,
+    *,
+    user_id: str,
+    accent: str,
+) -> Dict[str, sqlite3.Row]:
+    rows = conn.execute(
+        """
+        SELECT *
+        FROM phoneme_stats
+        WHERE user_id = ? AND primary_accent = ?
+        """,
+        (user_id, accent),
+    ).fetchall()
+    return {r["phoneme_id"]: r for r in rows}
+
+
+def _normalise_focus_phonemes(
+    conn: sqlite3.Connection,
+    focus_phonemes: Iterable[str],
+) -> Set[str]:
+    focus = {str(p).strip() for p in focus_phonemes if str(p).strip()}
+    if not focus:
+        return set()
+
+    rows = conn.execute("SELECT id, symbol FROM phonemes").fetchall()
+    aliases: Dict[str, Set[str]] = {}
+    for row in rows:
+        values = {row["id"], row["symbol"]}
+        aliases[row["id"]] = values
+        aliases[row["symbol"]] = values
+
+    normalised = set()
+    for phoneme in focus:
+        normalised.update(aliases.get(phoneme, {phoneme}))
+    return normalised
+
+
+def _score_candidate(
+    *,
+    word_id: str,
+    phoneme_tags: List[str],
+    stats: Dict[str, sqlite3.Row],
+    focus_phonemes: Set[str],
+    review_multiplier: float,
+    seed: int,
+    is_recent: bool,
+) -> _Candidate:
+    review_scores = [
+        _phoneme_review_score(stats[tag])
+        for tag in phoneme_tags
+        if tag in stats
+    ]
+    review_score = 0.0
+    if review_scores:
+        review_score = max(review_scores) + (sum(review_scores) * 0.2)
+
+    focus_matches = len(set(phoneme_tags) & focus_phonemes)
+    focus_bonus = 2.25 * focus_matches
+    new_bonus = 0.35 if not review_scores else 0.0
+    recent_penalty = -8.0 if is_recent else 0.0
+    tie_breaker = _stable_fraction(f"{seed}:{word_id}") * 0.01
+
+    return _Candidate(
+        word_id=word_id,
+        phoneme_tags=phoneme_tags,
+        score=(review_score * review_multiplier) + focus_bonus + new_bonus + recent_penalty
+        + tie_breaker,
+        has_seen_phoneme=bool(review_scores),
+    )
+
+
+def _phoneme_review_score(row: sqlite3.Row) -> float:
+    attempt_count = max(int(row["attempt_count"]), 0)
+    correct_count = max(int(row["correct_count"]), 0)
+    accuracy = correct_count / attempt_count if attempt_count else 0.0
+
+    score = 0.0
+    mastery_status = row["mastery_status"]
+    if mastery_status == "weak":
+        score += 3.0
+    elif mastery_status == "learning":
+        score += 1.0
+    elif mastery_status == "mastered":
+        score -= 0.25
+
+    if attempt_count:
+        score += max(0.0, 0.85 - accuracy) * 2.0
+    if row["last_wrong_at"]:
+        score += 1.25
+    return score
+
+
+def _choose_with_new_word_balance(
+    candidates: List[_Candidate],
+    daily_word_count: int,
+) -> List[str]:
+    if len(candidates) <= daily_word_count:
+        return [c.word_id for c in candidates]
+
+    new_candidates = [c for c in candidates if not c.has_seen_phoneme]
+    if daily_word_count <= 1 or not new_candidates:
+        return [c.word_id for c in candidates[:daily_word_count]]
+
+    desired_new = min(len(new_candidates), max(1, daily_word_count // 4))
+    review_slots = max(daily_word_count - desired_new, 0)
+    selected: List[_Candidate] = []
+
+    for candidate in candidates:
+        if candidate.has_seen_phoneme and len(selected) < review_slots:
+            selected.append(candidate)
+
+    selected_ids = {c.word_id for c in selected}
+    for candidate in new_candidates:
+        if len([c for c in selected if not c.has_seen_phoneme]) >= desired_new:
+            break
+        if candidate.word_id not in selected_ids:
+            selected.append(candidate)
+            selected_ids.add(candidate.word_id)
+
+    for candidate in candidates:
+        if len(selected) >= daily_word_count:
+            break
+        if candidate.word_id not in selected_ids:
+            selected.append(candidate)
+            selected_ids.add(candidate.word_id)
+
+    selected.sort(key=lambda c: (-c.score, c.word_id))
+    return [c.word_id for c in selected[:daily_word_count]]
+
+
+def _stable_fraction(value: str) -> float:
+    digest = hashlib.md5(value.encode()).hexdigest()
+    return int(digest[:8], 16) / 0xFFFFFFFF

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -1,0 +1,214 @@
+"""Unit tests for phoneme-aware daily word scheduling."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import List, Optional
+
+import pytest
+
+from app.db import get_connection
+from app.models import DailySession, SessionItem
+from app.services.db_schema import init_db
+from app.services.db_store import create_session, create_session_item
+from app.services.scheduler import select_daily_words
+
+
+@pytest.fixture(name="conn")
+def conn_fixture(tmp_path: Path):
+    db_path = str(tmp_path / "scheduler.sqlite")
+    conn = get_connection(db_path)
+    init_db(conn)
+    yield conn
+    conn.close()
+
+
+def _insert_word(
+    conn,
+    word_id: str,
+    tags: List[str],
+    *,
+    status: str = "core_selected",
+    ipa: Optional[str] = None,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO words (
+            id, word, level, ipa_us, ipa_uk, phoneme_tags_us, phoneme_tags_uk,
+            content_status
+        ) VALUES (?, ?, 'beginner', ?, ?, ?, ?, ?)
+        """,
+        (
+            word_id,
+            word_id,
+            ipa or f"/{word_id}/",
+            ipa or f"/{word_id}/",
+            _json(tags),
+            _json(tags),
+            status,
+        ),
+    )
+
+
+def _insert_stat(
+    conn,
+    phoneme_id: str,
+    *,
+    attempts: int,
+    correct: int,
+    mastery: str,
+    last_wrong_at: Optional[str] = "2026-06-01T00:00:00Z",
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO phoneme_stats (
+            user_id, primary_accent, phoneme_id, attempt_count, correct_count,
+            last_attempt_at, last_wrong_at, mastery_status
+        ) VALUES ('default', 'US', ?, ?, ?, '2026-06-02T00:00:00Z', ?, ?)
+        """,
+        (phoneme_id, attempts, correct, last_wrong_at, mastery),
+    )
+
+
+def _insert_recent_session(conn, word_ids: List[str], *, session_id: str = "recent") -> None:
+    session = DailySession(
+        id=session_id,
+        user_id="default",
+        session_date="2026-06-09",
+        primary_accent="US",
+        status="complete",
+        created_at=datetime.now(timezone.utc).isoformat(),
+    )
+    create_session(conn, session)
+    for index, word_id in enumerate(word_ids):
+        create_session_item(
+            conn,
+            SessionItem(
+                id=f"{session_id}_item_{index}",
+                session_id=session_id,
+                word_id=word_id,
+                order_index=index,
+                target_phonemes=[],
+                question_type="choose_ipa",
+                status="complete",
+            ),
+        )
+
+
+def _json(values: List[str]) -> str:
+    import json
+
+    return json.dumps(values)
+
+
+def _ids(words) -> List[str]:
+    return [word.id for word in words]
+
+
+def test_weak_phoneme_words_rank_higher(conn):
+    _insert_word(conn, "ship", ["/weak/", "/p/"])
+    _insert_word(conn, "cat", ["/strong/", "/t/"])
+    _insert_word(conn, "new", ["/fresh/"])
+    _insert_stat(conn, "/weak/", attempts=5, correct=1, mastery="weak")
+    _insert_stat(conn, "/strong/", attempts=6, correct=6, mastery="mastered", last_wrong_at=None)
+
+    selected = select_daily_words(conn, daily_word_count=2, seed=101)
+
+    assert _ids(selected)[0] == "ship"
+    assert "cat" not in _ids(selected)
+
+
+def test_disabled_words_are_never_selected(conn):
+    _insert_word(conn, "disabled", ["/weak/"], status="disabled")
+    _insert_word(conn, "active", ["/other/"])
+    _insert_stat(conn, "/weak/", attempts=8, correct=0, mastery="weak")
+
+    selected = select_daily_words(conn, daily_word_count=2, seed=7)
+
+    assert _ids(selected) == ["active"]
+
+
+def test_recent_words_are_suppressed_when_alternatives_exist(conn):
+    for word_id in ("recent_a", "recent_b", "fresh_a", "fresh_b"):
+        _insert_word(conn, word_id, [f"/{word_id}/"])
+    _insert_recent_session(conn, ["recent_a", "recent_b"])
+
+    selected = select_daily_words(conn, daily_word_count=2, seed=9)
+
+    assert set(_ids(selected)) == {"fresh_a", "fresh_b"}
+
+
+def test_recent_words_can_fill_when_pool_is_small(conn):
+    _insert_word(conn, "recent", ["/r/"])
+    _insert_word(conn, "fresh", ["/f/"])
+    _insert_recent_session(conn, ["recent"])
+
+    selected = select_daily_words(conn, daily_word_count=2, seed=9)
+
+    assert set(_ids(selected)) == {"recent", "fresh"}
+
+
+def test_new_words_remain_in_mix_when_weak_review_exists(conn):
+    _insert_word(conn, "weak_one", ["/weak/"])
+    _insert_word(conn, "weak_two", ["/weak/"])
+    _insert_word(conn, "weak_three", ["/weak/"])
+    _insert_word(conn, "fresh", ["/fresh/"])
+    _insert_stat(conn, "/weak/", attempts=8, correct=1, mastery="weak")
+
+    selected = select_daily_words(conn, daily_word_count=3, seed=10)
+
+    assert "fresh" in _ids(selected)
+    assert _ids(selected)[0].startswith("weak_")
+
+
+def test_focus_phonemes_boost_matching_words_without_excluding_others(conn):
+    _insert_word(conn, "focus_a", ["/focus/"])
+    _insert_word(conn, "focus_b", ["/focus/"])
+    _insert_word(conn, "other", ["/other/"])
+
+    selected = select_daily_words(
+        conn,
+        daily_word_count=3,
+        seed=5,
+        focus_phonemes=["/focus/"],
+    )
+
+    assert _ids(selected)[:2] == ["focus_a", "focus_b"]
+    assert "other" in _ids(selected)
+
+
+def test_review_strength_changes_weak_word_weighting(conn):
+    _insert_word(conn, "weak", ["/weak/"])
+    _insert_word(conn, "focus", ["/focus/"])
+    _insert_stat(conn, "/weak/", attempts=6, correct=0, mastery="weak")
+
+    quick = select_daily_words(
+        conn,
+        daily_word_count=1,
+        seed=3,
+        review_strength="quick",
+        focus_phonemes=["/focus/"],
+    )
+    extra_review = select_daily_words(
+        conn,
+        daily_word_count=1,
+        seed=3,
+        review_strength="extra_review",
+        focus_phonemes=["/focus/"],
+    )
+
+    assert _ids(quick) == ["focus"]
+    assert _ids(extra_review) == ["weak"]
+
+
+def test_selection_is_deterministic_for_same_seed(conn):
+    for word_id in ("a", "b", "c", "d", "e"):
+        _insert_word(conn, word_id, [f"/{word_id}/"])
+
+    first = select_daily_words(conn, daily_word_count=3, seed=123)
+    second = select_daily_words(conn, daily_word_count=3, seed=123)
+    different_seed = select_daily_words(conn, daily_word_count=3, seed=124)
+
+    assert _ids(first) == _ids(second)
+    assert _ids(first) != _ids(different_seed)


### PR DESCRIPTION
## Summary
- Replace shuffle-and-take daily word selection with a phoneme-aware scoring core.
- Add usable-word filtering, recent-session suppression, weak phoneme weighting, focus phoneme boosts, review strength multipliers, deterministic tie-breaking, and a small new-word balance.
- Add focused backend scheduler unit tests for the M5 scoring contract.

## Verification
- `backend/.venv/bin/python -m pytest backend/tests/test_scheduler.py -q`
- `backend/.venv/bin/python -m pytest backend/tests/test_scheduler.py backend/tests/test_today_persistence.py backend/tests/test_attempts.py backend/tests/test_progress_api.py -q`
- `backend/.venv/bin/python -m pytest backend/tests -q`
- `backend/.venv/bin/python -m ruff check backend/app/services/scheduler.py backend/tests/test_scheduler.py`

Closes #75
