### PR TITLE
[M5 #76] Add scheduler-facing focus phoneme settings

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -8,7 +8,6 @@ Callers construct them from ``sqlite3.Row`` dicts or raw kwargs.
 from dataclasses import dataclass, field
 from typing import List, Optional
 
-
 # ---------------------------------------------------------------------------
 # Words
 # ---------------------------------------------------------------------------
@@ -64,6 +63,7 @@ class Settings:
     show_accent_compare: bool = False
     practice_mode: str = "ipa_first"
     review_strength: str = "normal"
+    focus_phonemes: List[str] = field(default_factory=list)
     updated_at: str = ""
 
 

--- a/backend/app/routes/settings.py
+++ b/backend/app/routes/settings.py
@@ -31,6 +31,7 @@ def settings_get():
                 "show_accent_compare": False,
                 "practice_mode": "ipa_first",
                 "review_strength": "normal",
+                "focus_phonemes": [],
             }
         return {
             "primary_accent": s.primary_accent,
@@ -39,6 +40,7 @@ def settings_get():
             "show_accent_compare": s.show_accent_compare,
             "practice_mode": s.practice_mode,
             "review_strength": s.review_strength,
+            "focus_phonemes": s.focus_phonemes,
         }
 
 
@@ -100,6 +102,15 @@ async def settings_put(request: Request):
             else:
                 existing.review_strength = v
 
+        if "focus_phonemes" in body:
+            v = body["focus_phonemes"]
+            if not isinstance(v, list) or any(
+                not isinstance(item, str) or not item.strip() for item in v
+            ):
+                errors.append("focus_phonemes must be a list of non-empty strings")
+            else:
+                existing.focus_phonemes = [item.strip() for item in v]
+
         if errors:
             raise HTTPException(
                 status_code=400,
@@ -116,4 +127,5 @@ async def settings_put(request: Request):
             "show_accent_compare": existing.show_accent_compare,
             "practice_mode": existing.practice_mode,
             "review_strength": existing.review_strength,
+            "focus_phonemes": existing.focus_phonemes,
         }

--- a/backend/app/services/db_schema.py
+++ b/backend/app/services/db_schema.py
@@ -9,7 +9,6 @@ it uses ``IF NOT EXISTS`` on every table.
 import sqlite3
 from typing import List
 
-
 TABLES_DDL: List[str] = [
     # ------------------------------------------------------------------
     # words
@@ -57,6 +56,7 @@ TABLES_DDL: List[str] = [
         show_accent_compare  INTEGER NOT NULL,   -- boolean 0/1
         practice_mode        TEXT    NOT NULL,
         review_strength      TEXT    NOT NULL,
+        focus_phonemes       TEXT    NOT NULL DEFAULT '[]', -- JSON array
         updated_at           TEXT    NOT NULL
     )
     """,
@@ -136,6 +136,25 @@ def init_db(conn: sqlite3.Connection) -> None:
     """
     for ddl in TABLES_DDL:
         conn.execute(ddl)
+    ensure_settings_schema(conn)
+
+
+def ensure_settings_schema(conn: sqlite3.Connection) -> None:
+    """Apply tiny compatibility patches for existing settings tables."""
+    table = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='settings'"
+    ).fetchone()
+    if table is None:
+        return
+
+    columns = {
+        row["name"]
+        for row in conn.execute("PRAGMA table_info(settings)").fetchall()
+    }
+    if "focus_phonemes" not in columns:
+        conn.execute(
+            "ALTER TABLE settings ADD COLUMN focus_phonemes TEXT NOT NULL DEFAULT '[]'"
+        )
 
 
 def table_names(conn: sqlite3.Connection) -> List[str]:

--- a/backend/app/services/db_store.py
+++ b/backend/app/services/db_store.py
@@ -11,7 +11,7 @@ import sqlite3
 from typing import List, Optional
 
 from app.models import Attempt, DailySession, Phoneme, SessionItem, Settings, Word
-
+from app.services.db_schema import ensure_settings_schema
 
 # ============================================================================
 # Serialisation helpers
@@ -89,6 +89,7 @@ def _settings_from_row(row: sqlite3.Row) -> Settings:
         show_accent_compare=bool(row["show_accent_compare"]),
         practice_mode=row["practice_mode"],
         review_strength=row["review_strength"],
+        focus_phonemes=_parse_list(row["focus_phonemes"]) or [],
         updated_at=row["updated_at"],
     )
 
@@ -202,16 +203,17 @@ def get_phoneme_by_id(conn: sqlite3.Connection, phoneme_id: str) -> Optional[Pho
 
 def upsert_settings(conn: sqlite3.Connection, settings: Settings) -> None:
     """Create or replace the settings row for a given user_id."""
+    ensure_settings_schema(conn)
     conn.execute(
         """
         INSERT OR REPLACE INTO settings (
             user_id, primary_accent, daily_word_count,
             show_translation, show_accent_compare,
-            practice_mode, review_strength, updated_at
+            practice_mode, review_strength, focus_phonemes, updated_at
         ) VALUES (
             :user_id, :primary_accent, :daily_word_count,
             :show_translation, :show_accent_compare,
-            :practice_mode, :review_strength, :updated_at
+            :practice_mode, :review_strength, :focus_phonemes, :updated_at
         )
         """,
         {
@@ -222,12 +224,14 @@ def upsert_settings(conn: sqlite3.Connection, settings: Settings) -> None:
             "show_accent_compare": int(settings.show_accent_compare),
             "practice_mode": settings.practice_mode,
             "review_strength": settings.review_strength,
+            "focus_phonemes": _to_json(settings.focus_phonemes),
             "updated_at": settings.updated_at,
         },
     )
 
 
 def get_settings(conn: sqlite3.Connection, user_id: str = "default") -> Optional[Settings]:
+    ensure_settings_schema(conn)
     row = conn.execute(
         "SELECT * FROM settings WHERE user_id = ?", (user_id,)
     ).fetchone()

--- a/backend/tests/test_import_words.py
+++ b/backend/tests/test_import_words.py
@@ -15,11 +15,10 @@ if str(_SCRIPTS) not in sys.path:
 
 from import_words import build_phoneme_rows, import_words  # noqa: E402
 
-from app.db import get_connection, get_db  # noqa: E402
+from app.db import get_connection  # noqa: E402
 from app.models import Settings  # noqa: E402
 from app.services.db_schema import init_db, table_names  # noqa: E402
 from app.services.db_store import (  # noqa: E402
-    count_phonemes,
     count_words,
     get_phoneme_by_id,
     get_settings,
@@ -81,6 +80,43 @@ class TestSchemaInitialisation:
         after = table_names(conn)
         conn.close()
         assert before == after
+
+    def test_init_adds_focus_phonemes_to_existing_settings_table(self, temp_db):
+        conn = get_connection(temp_db)
+        conn.execute(
+            """
+            CREATE TABLE settings (
+                user_id              TEXT PRIMARY KEY,
+                primary_accent       TEXT    NOT NULL,
+                daily_word_count     INTEGER NOT NULL,
+                show_translation     INTEGER NOT NULL,
+                show_accent_compare  INTEGER NOT NULL,
+                practice_mode        TEXT    NOT NULL,
+                review_strength      TEXT    NOT NULL,
+                updated_at           TEXT    NOT NULL
+            )
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO settings (
+                user_id, primary_accent, daily_word_count,
+                show_translation, show_accent_compare,
+                practice_mode, review_strength, updated_at
+            ) VALUES ('default', 'US', 10, 1, 0, 'ipa_first', 'normal', '2026-06-06T00:00:00Z')
+            """
+        )
+        init_db(conn)
+        columns = {
+            row["name"]
+            for row in conn.execute("PRAGMA table_info(settings)").fetchall()
+        }
+        settings = get_settings(conn, "default")
+        conn.close()
+
+        assert "focus_phonemes" in columns
+        assert settings is not None
+        assert settings.focus_phonemes == []
 
 
 # ---------------------------------------------------------------------------
@@ -204,6 +240,7 @@ class TestSettingsStore:
             show_accent_compare=False,
             practice_mode="ipa_first",
             review_strength="normal",
+            focus_phonemes=["/ʃ/", "/ɪ/"],
             updated_at="2026-06-06T00:00:00Z",
         )
         upsert_settings(self.conn, s)
@@ -215,6 +252,7 @@ class TestSettingsStore:
         assert got.show_accent_compare is False
         assert got.practice_mode == "ipa_first"
         assert got.review_strength == "normal"
+        assert got.focus_phonemes == ["/ʃ/", "/ɪ/"]
 
     def test_get_missing_settings(self):
         assert get_settings(self.conn, "no_such_user") is None
@@ -259,6 +297,7 @@ class TestImportWords:
         assert settings.user_id == "default"
         assert settings.primary_accent == "US"
         assert settings.daily_word_count == 10
+        assert settings.focus_phonemes == []
 
     def test_import_preserves_accent_fields(self, temp_db):
         """After import, ship.ipa_uk and phoneme_tags_uk are stored."""

--- a/backend/tests/test_progress_api.py
+++ b/backend/tests/test_progress_api.py
@@ -14,8 +14,9 @@ if str(_SCRIPTS) not in sys.path:
     sys.path.insert(0, str(_SCRIPTS))
 
 from import_words import import_words  # noqa: E402
+
+from app.db import get_connection  # noqa: E402
 from app.main import app  # noqa: E402
-from app.db import get_connection, get_db  # noqa: E402
 from app.services.db_schema import init_db  # noqa: E402
 from app.services.progress import build_progress_response  # noqa: E402
 
@@ -158,7 +159,13 @@ class TestStreak:
         init_db(conn)
         # Insert settings so build_progress_response doesn't 500
         conn.execute(
-            "INSERT INTO settings VALUES ('default','US',10,1,0,'ipa_first','normal','2026-01-01T00:00:00Z')"
+            """
+            INSERT INTO settings (
+                user_id, primary_accent, daily_word_count,
+                show_translation, show_accent_compare,
+                practice_mode, review_strength, updated_at
+            ) VALUES ('default','US',10,1,0,'ipa_first','normal','2026-01-01T00:00:00Z')
+            """
         )
         conn.commit()
         resp = build_progress_response(conn)
@@ -170,7 +177,13 @@ class TestStreak:
         conn = get_connection(db_path)
         init_db(conn)
         conn.execute(
-            "INSERT INTO settings VALUES ('default','US',10,1,0,'ipa_first','normal','2026-01-01T00:00:00Z')"
+            """
+            INSERT INTO settings (
+                user_id, primary_accent, daily_word_count,
+                show_translation, show_accent_compare,
+                practice_mode, review_strength, updated_at
+            ) VALUES ('default','US',10,1,0,'ipa_first','normal','2026-01-01T00:00:00Z')
+            """
         )
         today = date.today()
         yesterday = today - timedelta(days=1)
@@ -192,7 +205,13 @@ class TestStreak:
         conn = get_connection(db_path)
         init_db(conn)
         conn.execute(
-            "INSERT INTO settings VALUES ('default','US',10,1,0,'ipa_first','normal','2026-01-01T00:00:00Z')"
+            """
+            INSERT INTO settings (
+                user_id, primary_accent, daily_word_count,
+                show_translation, show_accent_compare,
+                practice_mode, review_strength, updated_at
+            ) VALUES ('default','US',10,1,0,'ipa_first','normal','2026-01-01T00:00:00Z')
+            """
         )
         today = date.today()
         two_days_ago = today - timedelta(days=2)
@@ -223,7 +242,13 @@ class TestPhonemeOrdering:
         conn = get_connection(db_path)
         init_db(conn)
         conn.execute(
-            "INSERT INTO settings VALUES ('default','US',10,1,0,'ipa_first','normal','2026-01-01T00:00:00Z')"
+            """
+            INSERT INTO settings (
+                user_id, primary_accent, daily_word_count,
+                show_translation, show_accent_compare,
+                practice_mode, review_strength, updated_at
+            ) VALUES ('default','US',10,1,0,'ipa_first','normal','2026-01-01T00:00:00Z')
+            """
         )
         # Insert stats with varying accuracy
         stats = [
@@ -239,7 +264,10 @@ class TestPhonemeOrdering:
         ]
         for phoneme_id, cnt, correct in stats:
             conn.execute(
-                "INSERT INTO phoneme_stats VALUES ('default','US',?,?,?,'2026-01-01T00:00:00Z',NULL,'new')",
+                """
+                INSERT INTO phoneme_stats
+                VALUES ('default','US',?,?,?,'2026-01-01T00:00:00Z',NULL,'new')
+                """,
                 (phoneme_id, cnt, correct),
             )
         conn.commit()

--- a/backend/tests/test_settings_api.py
+++ b/backend/tests/test_settings_api.py
@@ -13,8 +13,9 @@ if str(_SCRIPTS) not in sys.path:
     sys.path.insert(0, str(_SCRIPTS))
 
 from import_words import import_words  # noqa: E402
-from app.main import app  # noqa: E402
+
 from app.db import get_connection  # noqa: E402
+from app.main import app  # noqa: E402
 from app.services.db_schema import init_db  # noqa: E402
 from app.services.db_store import get_settings  # noqa: E402
 
@@ -50,16 +51,19 @@ class TestSettingsApi:
         assert data["primary_accent"] == "US"
         assert data["daily_word_count"] == 10
         assert data["show_translation"] is True
+        assert data["focus_phonemes"] == []
 
     def test_put_updates_and_persists(self, client, seeded_db):
         resp = client.put("/api/settings", json={
             "daily_word_count": 5,
             "show_translation": False,
+            "focus_phonemes": ["/ʃ/", " /ɪ/ "],
         })
         assert resp.status_code == 200
         data = resp.json()
         assert data["daily_word_count"] == 5
         assert data["show_translation"] is False
+        assert data["focus_phonemes"] == ["/ʃ/", "/ɪ/"]
         # Other fields unchanged
         assert data["primary_accent"] == "US"
 
@@ -70,6 +74,7 @@ class TestSettingsApi:
         assert s is not None
         assert s.daily_word_count == 5
         assert s.show_translation is False
+        assert s.focus_phonemes == ["/ʃ/", "/ɪ/"]
 
     def test_put_invalid_daily_word_count(self, client):
         resp = client.put("/api/settings", json={"daily_word_count": 100})
@@ -84,6 +89,20 @@ class TestSettingsApi:
 
     def test_put_invalid_practice_mode(self, client):
         resp = client.put("/api/settings", json={"practice_mode": "random"})
+        assert resp.status_code == 400
+        assert resp.json()["detail"]["error"] == "SETTINGS_INVALID"
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            {"focus_phonemes": "/ʃ/"},
+            {"focus_phonemes": ["/ʃ/", ""]},
+            {"focus_phonemes": ["/ʃ/", 123]},
+            {"focus_phonemes": None},
+        ],
+    )
+    def test_put_invalid_focus_phonemes(self, client, payload):
+        resp = client.put("/api/settings", json=payload)
         assert resp.status_code == 400
         assert resp.json()["detail"]["error"] == "SETTINGS_INVALID"
 
@@ -108,5 +127,6 @@ class TestSettingsApi:
             resp = c.get("/api/settings")
             assert resp.status_code == 200
             assert resp.json()["daily_word_count"] == 10
+            assert resp.json()["focus_phonemes"] == []
         finally:
             db_mod.DEFAULT_DB_PATH = orig


### PR DESCRIPTION
## Summary
- Add `focus_phonemes` to the Settings dataclass, settings schema, repository serialization, and settings API responses.
- Store `focus_phonemes` as a JSON list with `[]` defaults for fresh imports and existing SQLite settings tables.
- Validate PUT `/api/settings` payloads so `focus_phonemes` must be a list of non-empty strings.
- Update settings/import/schema compatibility tests and brittle settings inserts in affected tests.

## Verification
- `backend/.venv/bin/python -m pytest backend/tests/test_settings_api.py backend/tests/test_import_words.py backend/tests/test_progress_api.py backend/tests/test_today_persistence.py -q`
- `backend/.venv/bin/python -m pytest backend/tests -q`
- `backend/.venv/bin/python -m ruff check backend/app/models.py backend/app/services/db_schema.py backend/app/services/db_store.py backend/app/routes/settings.py backend/tests/test_settings_api.py backend/tests/test_import_words.py backend/tests/test_progress_api.py`

Closes #76
