### PR TITLE
[M5 #78] Add scheduler settings UI controls

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -159,6 +159,7 @@ export interface SettingsData {
   show_accent_compare: boolean;
   practice_mode: string;
   review_strength: string;
+  focus_phonemes: string[];
 }
 
 export async function fetchSettings(): Promise<SettingsData> {

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -2,8 +2,8 @@
  * SettingsPage — display and edit user settings.
  *
  * Only exposes MVP-supported controls.  Future settings (UK accent,
- * reveal_first, extra_review/quick, accent compare) are intentionally
- * hidden until the practice flow supports them.
+ * reveal_first, accent compare) are intentionally hidden until the practice
+ * flow supports them.
  */
 
 import { useEffect, useState } from "react";
@@ -19,13 +19,17 @@ interface Props {
 
 export default function SettingsPage({ onBack }: Props) {
   const [settings, setSettings] = useState<SettingsData | null>(null);
+  const [focusInput, setFocusInput] = useState("");
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [saved, setSaved] = useState(false);
 
   useEffect(() => {
     fetchSettings()
-      .then(setSettings)
+      .then((data) => {
+        setSettings(data);
+        setFocusInput(data.focus_phonemes.join(", "));
+      })
       .catch((e) => setError(e.message))
       .finally(() => setLoading(false));
   }, []);
@@ -40,11 +44,20 @@ export default function SettingsPage({ onBack }: Props) {
     try {
       const updated = await saveSettings(patch);
       setSettings(updated);
+      setFocusInput(updated.focus_phonemes.join(", "));
       setSaved(true);
       setTimeout(() => setSaved(false), 2000);
-    } catch (e: any) {
-      setError(e.message);
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Failed to save settings");
     }
+  };
+
+  const saveFocusPhonemes = () => {
+    const focus_phonemes = focusInput
+      .split(",")
+      .map((item) => item.trim())
+      .filter(Boolean);
+    void update({ focus_phonemes });
   };
 
   return (
@@ -72,6 +85,41 @@ export default function SettingsPage({ onBack }: Props) {
             onChange={e => update({ show_translation: e.target.checked })} />
         </label>
 
+        <label className="setting-row">
+          <span>Review strength</span>
+          <select value={settings.review_strength}
+            onChange={e => update({ review_strength: e.target.value })}>
+            <option value="quick">Quick</option>
+            <option value="normal">Normal</option>
+            <option value="extra_review">Extra review</option>
+          </select>
+        </label>
+
+        <label className="setting-row setting-row-stacked">
+          <span>Focus phonemes</span>
+          <input
+            className="focus-input"
+            type="text"
+            value={focusInput}
+            placeholder="/ʃ/, /æ/"
+            onBlur={saveFocusPhonemes}
+            onChange={e => setFocusInput(e.target.value)}
+            onKeyDown={e => {
+              if (e.key === "Enter") {
+                e.currentTarget.blur();
+              }
+            }}
+          />
+        </label>
+
+        {settings.focus_phonemes.length > 0 && (
+          <div className="phoneme-chip-list">
+            {settings.focus_phonemes.map((phoneme) => (
+              <span className="phoneme-chip" key={phoneme}>{phoneme}</span>
+            ))}
+          </div>
+        )}
+
         {/* ---- Future controls (hidden until practice flow supports them) ----
         <label className="setting-row">
           <span>Primary accent</span>
@@ -80,10 +128,6 @@ export default function SettingsPage({ onBack }: Props) {
         <label className="setting-row">
           <span>Practice mode</span>
           <select value={settings.practice_mode} … />
-        </label>
-        <label className="setting-row">
-          <span>Review strength</span>
-          <select value={settings.review_strength} … />
         </label>
         <label className="setting-row">
           <span>Show accent compare</span>

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -446,9 +446,40 @@ button {
   text-align: center;
 }
 
+.setting-row-stacked {
+  align-items: flex-start;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.setting-row .focus-input {
+  box-sizing: border-box;
+  width: 100%;
+  padding: 6px 8px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  font-size: 0.9rem;
+}
+
 .setting-row input[type="checkbox"] {
   width: 20px;
   height: 20px;
+}
+
+.phoneme-chip-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 4px 0 8px;
+}
+
+.phoneme-chip {
+  border: 1px solid #d6e4ff;
+  border-radius: 4px;
+  color: #174ea6;
+  font-size: 0.85rem;
+  line-height: 1;
+  padding: 5px 7px;
 }
 
 .save-confirm {


### PR DESCRIPTION
## Summary
- Add `focus_phonemes` to frontend settings typing.
- Expose Settings controls for `review_strength` and comma-separated `focus_phonemes`.
- Preserve existing save confirmation/error behavior and keep Today practice UI unchanged.
- Add compact focus phoneme chips and mobile-friendly layout styling.

## Verification
- `npm run build`
- `npx eslint src/api.ts src/pages/SettingsPage.tsx --max-warnings=0`
- `backend/.venv/bin/python -m pytest backend/tests/test_settings_api.py -q`
- Manual Settings smoke with local Vite + current backend on 390px viewport: load Settings, save review strength, save focus phonemes, refresh, verify re-render/chips and no console errors.
- `tools/agents/agent-audit`

Known note:
- Full `npm run lint` still reports a pre-existing unrelated `no-explicit-any` in `frontend/src/components/ChoiceQuestion.tsx`.

Closes #78
