### PR TITLE
[#83 P0] Add REST comment and batch accept helpers

### DIFF
--- a/tools/agents/README.md
+++ b/tools/agents/README.md
@@ -23,6 +23,8 @@ tools/agents/agent-ready-queue --role reviewer
 tools/agents/agent-pickup 63 --role implementer
 tools/agents/agent-handoff 64 --from implementer
 tools/agents/agent-handoff 64 --from reviewer --to implementer
+tools/agents/agent-comment issue 86 --body-file /tmp/comment.md
+tools/agents/agent-batch-accept --epic 83 --issue 86 --issue 87
 tools/agents/agent-audit
 ```
 
@@ -72,6 +74,21 @@ label changes plus a compact completion/handoff comment template. Use
 `--to <role|none|batch>` to override the contract route for explicit handoffs.
 The dry-run path does not mutate labels, post comments, close issues, or read
 Project v2. `--apply` is not implemented in the current prototype.
+
+`agent-comment` is a REST-first durable comment helper. It supports explicit
+`issue` and `pr` targets by number, requires `--body-file` input, previews by
+default, and posts only with `--apply`. It uses the REST issue-comments endpoint
+for both issue and PR conversation comments, avoiding GraphQL-backed
+`gh issue comment` / `gh pr comment` ordinary paths. It fails closed on unknown
+target types, missing or empty body files, target/type mismatches, and failed
+REST writes.
+
+`agent-batch-accept` is dry-run only. It takes an Epic plus child issues or PRs
+and prints an Architect batch acceptance plan: integration branch, child issue
+state, PR base/head hints, linked issues, changed files, REST status hints when
+available, merge/close/label/Project plans, release or hold notes, and a durable
+batch checkpoint comment template. It never merges PRs, closes issues, mutates
+labels, updates Project v2, or integrates into `main`.
 
 `agent-audit` is a read-only consistency check. It looks for common workflow
 drift without touching GitHub Project v2:

--- a/tools/agents/agent-batch-accept
+++ b/tools/agents/agent-batch-accept
@@ -110,6 +110,19 @@ pr_issue_refs() {
   grep -Eo '#[0-9]+' <<< "$text" | tr -d '#' | sort -nu || true
 }
 
+known_issue_refs() {
+  local text="$1"
+  local known="$2"
+  local ref
+
+  while IFS= read -r ref; do
+    [[ -z "$ref" ]] && continue
+    if grep -Fxq "$ref" <<< "$known"; then
+      printf '%s\n' "$ref"
+    fi
+  done < <(pr_issue_refs "$text")
+}
+
 find_pr_for_issue() {
   local issue="$1"
   local prs_json="$2"
@@ -129,6 +142,7 @@ find_pr_for_issue() {
 print_pr_summary() {
   local pr="$1"
   local integration_branch="$2"
+  local known_issues="$3"
   local pr_json files_json status_json
   local title state draft url base head linked_issues status total_contexts
 
@@ -139,7 +153,7 @@ print_pr_summary() {
   url="$(jq -r '.html_url' <<< "$pr_json")"
   base="$(jq -r '.base.ref' <<< "$pr_json")"
   head="$(jq -r '.head.ref' <<< "$pr_json")"
-  linked_issues="$(pr_issue_refs "$(jq -r '(.title // "") + "\n" + (.body // "")' <<< "$pr_json")" | sed 's/^/#/' | agent_join_lines)"
+  linked_issues="$(known_issue_refs "$(jq -r '(.title // "") + "\n" + (.body // "")' <<< "$pr_json")" "$known_issues" | sed 's/^/#/' | agent_join_lines)"
   [[ -n "$linked_issues" ]] || linked_issues="none detected"
 
   printf '%s\n' "- PR #$pr $title"
@@ -178,6 +192,10 @@ if [[ -z "$integration_branch" ]]; then
 fi
 
 open_prs_json="$("$gh_retry" gh api -X GET "$(repo_api_path "$repo")/pulls" -f state=open -f per_page=100)"
+known_issues="$epic"$'\n'
+for issue in "${issues[@]}"; do
+  known_issues="${known_issues}${issue}"$'\n'
+done
 
 printf '#%s %s\n' "$epic" "$epic_title"
 printf 'Mode: dry-run\n'
@@ -241,7 +259,7 @@ if (( ${#printed_prs[@]} == 0 )); then
   printf '%s\n' '- none detected or supplied'
 else
   for pr in "${printed_prs[@]}"; do
-    print_pr_summary "$pr" "$integration_branch"
+    print_pr_summary "$pr" "$integration_branch" "$known_issues"
   done
 fi
 

--- a/tools/agents/agent-batch-accept
+++ b/tools/agents/agent-batch-accept
@@ -1,0 +1,279 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo="${GH_REPO:-farmerhunter/tiny-ipa}"
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+gh_retry="$root/tools/agents/gh-retry"
+source "$root/tools/agents/_lib.sh"
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  tools/agents/agent-batch-accept --epic <issue> [--issue <issue>]... [--pr <pr>]...
+
+Dry-runs an Architect batch acceptance plan. It does not merge PRs, close
+issues, mutate labels, update Project v2, or integrate into main.
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" || $# -eq 0 ]]; then
+  usage
+  exit 0
+fi
+
+epic=""
+issues=()
+prs=()
+apply=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --epic)
+      if [[ -z "${2:-}" ]]; then
+        printf '%s\n' '--epic requires an issue number' >&2
+        exit 2
+      fi
+      epic="$2"
+      require_number "$epic" "Epic issue"
+      shift 2
+      ;;
+    --issue)
+      if [[ -z "${2:-}" ]]; then
+        printf '%s\n' '--issue requires an issue number' >&2
+        exit 2
+      fi
+      require_number "$2" "Child issue"
+      issues+=("$2")
+      shift 2
+      ;;
+    --pr)
+      if [[ -z "${2:-}" ]]; then
+        printf '%s\n' '--pr requires a PR number' >&2
+        exit 2
+      fi
+      require_number "$2" "Pull request"
+      prs+=("$2")
+      shift 2
+      ;;
+    --dry-run)
+      apply=0
+      shift
+      ;;
+    --apply)
+      apply=1
+      shift
+      ;;
+    *)
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$epic" ]]; then
+  printf '%s\n' '--epic is required' >&2
+  exit 2
+fi
+if (( ${#issues[@]} == 0 && ${#prs[@]} == 0 )); then
+  printf '%s\n' 'At least one --issue or --pr is required' >&2
+  exit 2
+fi
+if [[ "$apply" -eq 1 ]]; then
+  printf '%s\n' '--apply is not implemented; agent-batch-accept is dry-run only' >&2
+  exit 2
+fi
+
+extract_first_value() {
+  local prefix="$1"
+  local text="$2"
+
+  awk -v prefix="$prefix" '
+    index($0, prefix) == 1 {
+      sub(prefix "[[:space:]]*", "")
+      print
+      found = 1
+      exit
+    }
+    END {
+      if (!found) print ""
+    }
+  ' <<< "$text"
+}
+
+strip_ticks() {
+  sed -E 's/^`//; s/`$//'
+}
+
+pr_issue_refs() {
+  local text="$1"
+
+  grep -Eo '#[0-9]+' <<< "$text" | tr -d '#' | sort -nu || true
+}
+
+find_pr_for_issue() {
+  local issue="$1"
+  local prs_json="$2"
+
+  jq -r --arg issue "$issue" '
+    .[]
+    | select(
+        (.title | contains("#" + $issue)) or
+        ((.body // "") | contains("#" + $issue)) or
+        (.head.ref | contains("/" + $issue + "-")) or
+        (.head.ref | contains("-" + $issue + "-"))
+      )
+    | .number
+  ' <<< "$prs_json" | head -n 1
+}
+
+print_pr_summary() {
+  local pr="$1"
+  local integration_branch="$2"
+  local pr_json files_json status_json
+  local title state draft url base head linked_issues status total_contexts
+
+  pr_json="$("$gh_retry" gh api "$(repo_api_path "$repo")/pulls/$pr")"
+  title="$(jq -r '.title' <<< "$pr_json")"
+  state="$(jq -r '.state' <<< "$pr_json")"
+  draft="$(jq -r '.draft' <<< "$pr_json")"
+  url="$(jq -r '.html_url' <<< "$pr_json")"
+  base="$(jq -r '.base.ref' <<< "$pr_json")"
+  head="$(jq -r '.head.ref' <<< "$pr_json")"
+  linked_issues="$(pr_issue_refs "$(jq -r '(.title // "") + "\n" + (.body // "")' <<< "$pr_json")" | sed 's/^/#/' | agent_join_lines)"
+  [[ -n "$linked_issues" ]] || linked_issues="none detected"
+
+  printf '%s\n' "- PR #$pr $title"
+  printf '  state: %s; draft: %s\n' "$state" "$draft"
+  printf '  url: %s\n' "$url"
+  printf '  base: %s; head: %s\n' "$base" "$head"
+  if [[ -n "$integration_branch" && "$base" != "$integration_branch" ]]; then
+    printf '  base warning: expected %s\n' "$integration_branch"
+  fi
+  printf '  linked issues: %s\n' "$linked_issues"
+
+  files_json="$("$gh_retry" gh api -X GET "$(repo_api_path "$repo")/pulls/$pr/files" -f per_page=100)"
+  printf '  changed files:\n'
+  jq -r '.[0:12][] | "    - \(.status) \(.filename) +\(.additions)/-\(.deletions)"' <<< "$files_json"
+  if (( $(jq 'length' <<< "$files_json") > 12 )); then
+    printf '    - ... %s total files\n' "$(jq 'length' <<< "$files_json")"
+  fi
+
+  status_json="$("$gh_retry" gh api "$(repo_api_path "$repo")/commits/$(jq -r '.head.sha' <<< "$pr_json")/status")"
+  status="$(jq -r '.state' <<< "$status_json")"
+  total_contexts="$(jq -r '.total_count' <<< "$status_json")"
+  if [[ "$total_contexts" == "0" ]]; then
+    printf '  check/status hint: no REST status contexts found\n'
+  else
+    printf '  check/status hint: %s (%s contexts)\n' "$status" "$total_contexts"
+  fi
+}
+
+epic_json="$("$gh_retry" gh api "$(repo_api_path "$repo")/issues/$epic")"
+epic_title="$(jq -r '.title' <<< "$epic_json")"
+epic_url="$(jq -r '.html_url' <<< "$epic_json")"
+epic_body="$(jq -r '.body // ""' <<< "$epic_json")"
+integration_branch="$(extract_first_value "Integration branch:" "$epic_body" | strip_ticks)"
+if [[ -z "$integration_branch" ]]; then
+  integration_branch="$(extract_first_value "Child PR target:" "$epic_body" | strip_ticks)"
+fi
+
+open_prs_json="$("$gh_retry" gh api -X GET "$(repo_api_path "$repo")/pulls" -f state=open -f per_page=100)"
+
+printf '#%s %s\n' "$epic" "$epic_title"
+printf 'Mode: dry-run\n'
+printf 'Epic URL: %s\n' "$epic_url"
+if [[ -n "$integration_branch" ]]; then
+  printf 'Integration branch: %s\n' "$integration_branch"
+else
+  printf 'Integration branch: not detected; verify manually\n'
+fi
+printf 'Final main integration: separate Architect/user-gated decision\n'
+
+printf '\nChild issues:\n'
+if (( ${#issues[@]} == 0 )); then
+  printf '%s\n' '- none supplied'
+else
+  for issue in "${issues[@]}"; do
+    issue_json="$("$gh_retry" gh api "$(repo_api_path "$repo")/issues/$issue")"
+    issue_title="$(jq -r '.title' <<< "$issue_json")"
+    issue_state="$(jq -r '.state' <<< "$issue_json")"
+    issue_url="$(jq -r '.html_url' <<< "$issue_json")"
+    issue_labels="$(jq -r '[.labels[].name] | join(", ")' <<< "$issue_json")"
+    issue_body="$(jq -r '.body // ""' <<< "$issue_json")"
+    issue_comments="$("$gh_retry" gh api -X GET "$(repo_api_path "$repo")/issues/$issue/comments" \
+      -f per_page=100 \
+      --jq '[.[].body] | join("\n")')"
+    contract="$(extract_latest_contract_block "$issue_body"$'\n'"$issue_comments")"
+    target_base="$(extract_contract_value "Target PR base:" "$contract" | strip_ticks)"
+    handoff="$(extract_contract_value "Completion handoff:" "$contract")"
+    matched_pr="$(find_pr_for_issue "$issue" "$open_prs_json")"
+
+    printf '%s\n' "- Issue #$issue $issue_title"
+    printf '  state: %s\n' "$issue_state"
+    printf '  url: %s\n' "$issue_url"
+    printf '  labels: %s\n' "$issue_labels"
+    printf '  contract PR base: %s\n' "$target_base"
+    printf '  completion handoff: %s\n' "$handoff"
+    if [[ -n "$matched_pr" ]]; then
+      printf '  open PR candidate: #%s\n' "$matched_pr"
+    else
+      printf '  open PR candidate: none detected\n'
+    fi
+  done
+fi
+
+printf '\nPull requests:\n'
+printed_prs=()
+for issue in "${issues[@]}"; do
+  matched_pr="$(find_pr_for_issue "$issue" "$open_prs_json")"
+  [[ -n "$matched_pr" ]] || continue
+  if ! agent_contains_value "$matched_pr" "${printed_prs[@]}"; then
+    printed_prs+=("$matched_pr")
+  fi
+done
+for pr in "${prs[@]}"; do
+  if ! agent_contains_value "$pr" "${printed_prs[@]}"; then
+    printed_prs+=("$pr")
+  fi
+done
+
+if (( ${#printed_prs[@]} == 0 )); then
+  printf '%s\n' '- none detected or supplied'
+else
+  for pr in "${printed_prs[@]}"; do
+    print_pr_summary "$pr" "$integration_branch"
+  done
+fi
+
+printf '\nMerge plan if accepted:\n'
+printf '%s\n' "- verify listed child PRs target ${integration_branch:-the Epic integration branch}"
+printf '%s\n' '- merge accepted child PRs into the Epic integration branch only'
+printf '%s\n' '- do not merge final Epic work into main from this helper'
+
+printf '\nIssue / label / Project plan if accepted:\n'
+printf '%s\n' '- close accepted child issues after merge evidence is confirmed'
+printf '%s\n' '- remove stale primary next-action labels from accepted child issues'
+printf '%s\n' '- leave Project v2 unchanged in this dry-run; sync manually or with a dedicated helper'
+
+printf '\nRelease / hold note:\n'
+printf '%s\n' '- batch checkpoint: Architect decides whether to release P1/P2 after reviewing the full P0 batch'
+
+printf '\nDurable batch checkpoint comment template:\n'
+printf '%s\n' '## Batch acceptance checkpoint'
+printf '\n'
+printf 'Scope reviewed:\n'
+printf '%s\n' '- <child issues and PRs reviewed>'
+printf '\n'
+printf 'Verification:\n'
+printf '%s\n' '- <checks, files, and review evidence>'
+printf '\n'
+printf 'Decision:\n'
+printf '%s\n' '- <accept / hold / request changes>'
+printf '\n'
+printf 'Residual risks:\n'
+printf '%s\n' '- <known limits or none>'
+printf '\n'
+printf 'Next release:\n'
+printf '%s\n' '- <release next batch or hold>'
+printf '\n'
+printf 'Warning: final main integration remains separate and Architect/user-gated.\n'

--- a/tools/agents/agent-comment
+++ b/tools/agents/agent-comment
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo="${GH_REPO:-farmerhunter/tiny-ipa}"
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+gh_retry="$root/tools/agents/gh-retry"
+source "$root/tools/agents/_lib.sh"
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  tools/agents/agent-comment <issue|pr> <number> --body-file <path> [--dry-run|--apply]
+
+Previews or posts an issue/PR conversation comment using REST API paths.
+Dry-run is the default. --apply is required to write the comment.
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" || $# -lt 1 ]]; then
+  usage
+  exit 0
+fi
+
+target_type="${1:-}"
+target_number="${2:-}"
+shift 2 || {
+  usage >&2
+  exit 2
+}
+
+body_file=""
+apply=0
+
+case "$target_type" in
+  issue|pr)
+    ;;
+  *)
+    printf 'Unknown target type: %s\n' "$target_type" >&2
+    printf '%s\n' 'Use issue or pr.' >&2
+    exit 2
+    ;;
+esac
+
+require_number "$target_number" "Target number"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --body-file)
+      if [[ -z "${2:-}" ]]; then
+        printf '%s\n' '--body-file requires a path' >&2
+        exit 2
+      fi
+      body_file="$2"
+      shift 2
+      ;;
+    --dry-run)
+      apply=0
+      shift
+      ;;
+    --apply)
+      apply=1
+      shift
+      ;;
+    *)
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$body_file" ]]; then
+  printf '%s\n' '--body-file is required' >&2
+  exit 2
+fi
+if [[ ! -f "$body_file" ]]; then
+  printf 'Body file not found: %s\n' "$body_file" >&2
+  exit 2
+fi
+if ! grep -q '[^[:space:]]' "$body_file"; then
+  printf 'Body file is empty: %s\n' "$body_file" >&2
+  exit 2
+fi
+
+body="$(< "$body_file")"
+body_lines="$(wc -l < "$body_file" | tr -d ' ')"
+body_bytes="$(wc -c < "$body_file" | tr -d ' ')"
+
+target_json=""
+case "$target_type" in
+  issue)
+    target_json="$("$gh_retry" gh api "$(repo_api_path "$repo")/issues/$target_number")"
+    if jq -e 'has("pull_request")' >/dev/null <<< "$target_json"; then
+      printf 'Target #%s is a pull request; use target type pr\n' "$target_number" >&2
+      exit 2
+    fi
+    ;;
+  pr)
+    target_json="$("$gh_retry" gh api "$(repo_api_path "$repo")/pulls/$target_number")"
+    ;;
+esac
+
+title="$(jq -r '.title' <<< "$target_json")"
+url="$(jq -r '.html_url' <<< "$target_json")"
+
+printf '#%s %s\n' "$target_number" "$title"
+if [[ "$apply" -eq 1 ]]; then
+  printf 'Mode: apply\n'
+else
+  printf 'Mode: dry-run\n'
+fi
+printf 'Target: %s\n' "$target_type"
+printf 'URL: %s\n' "$url"
+printf 'Body file: %s (%s lines, %s bytes)\n' "$body_file" "$body_lines" "$body_bytes"
+
+if [[ "$apply" -eq 0 ]]; then
+  printf '\nComment preview:\n'
+  printf '%s\n' '---'
+  printf '%s\n' "$body"
+  printf '%s\n' '---'
+  printf '\nNo GitHub comment was posted. Re-run with --apply to post.\n'
+  exit 0
+fi
+
+comment_json="$("$gh_retry" gh api -X POST "$(repo_api_path "$repo")/issues/$target_number/comments" \
+  -f body="$body")"
+comment_url="$(jq -r '.html_url' <<< "$comment_json")"
+
+printf 'Posted comment: %s\n' "$comment_url"

--- a/tools/agents/test-agent-comment
+++ b/tools/agents/test-agent-comment
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+fixture_root="$tmp_dir/fixture-root"
+mkdir -p "$fixture_root/tools/agents"
+ln -s "$root/tools/agents/_lib.sh" "$fixture_root/tools/agents/_lib.sh"
+ln -s "$root/tools/agents/agent-comment" "$fixture_root/tools/agents/agent-comment"
+
+cat > "$fixture_root/tools/agents/gh-retry" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "$*" in
+  *"POST"*"issues/1/comments"*)
+    jq -n '{html_url:"https://example.test/issues/1#comment"}'
+    ;;
+  *"POST"*"issues/2/comments"*)
+    jq -n '{html_url:"https://example.test/pull/2#comment"}'
+    ;;
+  *"POST"*"issues/3/comments"*)
+    printf 'write failed\n' >&2
+    exit 22
+    ;;
+  *"/issues/1"*)
+    jq -n '{number:1,title:"Issue one",html_url:"https://example.test/issues/1"}'
+    ;;
+  *"/issues/2"*)
+    jq -n '{number:2,title:"PR issue shell",html_url:"https://example.test/issues/2",pull_request:{url:"https://api.example.test/pulls/2"}}'
+    ;;
+  *"/issues/3"*)
+    jq -n '{number:3,title:"Write failure",html_url:"https://example.test/issues/3"}'
+    ;;
+  *"/pulls/2"*)
+    jq -n '{number:2,title:"Pull two",html_url:"https://example.test/pull/2"}'
+    ;;
+  *)
+    printf 'unexpected fake gh call: %s\n' "$*" >&2
+    exit 21
+    ;;
+esac
+SH
+chmod +x "$fixture_root/tools/agents/gh-retry"
+
+body_file="$tmp_dir/comment.md"
+empty_file="$tmp_dir/empty.md"
+missing_file="$tmp_dir/missing.md"
+printf 'hello from fixture\nsecond line\n' > "$body_file"
+printf '   \n' > "$empty_file"
+
+issue_dry="$("$fixture_root/tools/agents/agent-comment" issue 1 --body-file "$body_file")"
+grep -Fq "Mode: dry-run" <<< "$issue_dry"
+grep -Fq "Target: issue" <<< "$issue_dry"
+grep -Fq "hello from fixture" <<< "$issue_dry"
+grep -Fq "No GitHub comment was posted" <<< "$issue_dry"
+
+pr_dry="$("$fixture_root/tools/agents/agent-comment" pr 2 --body-file "$body_file" --dry-run)"
+grep -Fq "Target: pr" <<< "$pr_dry"
+grep -Fq "Pull two" <<< "$pr_dry"
+
+issue_apply="$("$fixture_root/tools/agents/agent-comment" issue 1 --body-file "$body_file" --apply)"
+grep -Fq "Mode: apply" <<< "$issue_apply"
+grep -Fq "Posted comment: https://example.test/issues/1#comment" <<< "$issue_apply"
+
+if "$fixture_root/tools/agents/agent-comment" discussion 1 --body-file "$body_file" >/dev/null 2>&1; then
+  printf 'unknown target unexpectedly succeeded\n' >&2
+  exit 1
+fi
+
+if "$fixture_root/tools/agents/agent-comment" issue 1 --body-file "$missing_file" >/dev/null 2>&1; then
+  printf 'missing body file unexpectedly succeeded\n' >&2
+  exit 1
+fi
+
+if "$fixture_root/tools/agents/agent-comment" issue 1 --body-file "$empty_file" >/dev/null 2>&1; then
+  printf 'empty body file unexpectedly succeeded\n' >&2
+  exit 1
+fi
+
+if "$fixture_root/tools/agents/agent-comment" issue 2 --body-file "$body_file" >/dev/null 2>&1; then
+  printf 'issue target for PR unexpectedly succeeded\n' >&2
+  exit 1
+fi
+
+if "$fixture_root/tools/agents/agent-comment" issue 3 --body-file "$body_file" --apply >/dev/null 2>&1; then
+  printf 'failed REST write unexpectedly succeeded\n' >&2
+  exit 1
+fi
+
+printf 'agent-comment fixture checks passed\n'

--- a/tools/agents/test-batch-accept
+++ b/tools/agents/test-batch-accept
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+fixture_root="$tmp_dir/fixture-root"
+mkdir -p "$fixture_root/tools/agents"
+ln -s "$root/tools/agents/_lib.sh" "$fixture_root/tools/agents/_lib.sh"
+ln -s "$root/tools/agents/agent-batch-accept" "$fixture_root/tools/agents/agent-batch-accept"
+
+cat > "$fixture_root/tools/agents/gh-retry" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+issue_json() {
+  local number="$1"
+  local title="$2"
+  local body="$3"
+  local labels="$4"
+
+  jq -n \
+    --argjson number "$number" \
+    --arg title "$title" \
+    --arg body "$body" \
+    --arg labels "$labels" \
+    '{
+      number: $number,
+      title: $title,
+      state: "open",
+      html_url: ("https://example.test/issues/" + ($number | tostring)),
+      body: $body,
+      labels: ($labels | split(",") | map(select(length > 0) | {name: .}))
+    }'
+}
+
+contract() {
+  local handoff="${1:-batch checkpoint}"
+  printf '## Execution Contract\n\nOwner role: implementer\nReview role: reviewer\nAcceptance role: architect\nBranch strategy: epic integration branch\nBase branch: `epic/83-helper-dogfood-follow-up`\nTarget PR base: `epic/83-helper-dogfood-follow-up`\nDepends on: none\nCompletion handoff: %s\n' "$handoff"
+}
+
+case "$*" in
+  *"/issues/83"*)
+    issue_json 83 "Epic" $'## Epic Execution Contract\n\nIntegration branch: `epic/83-helper-dogfood-follow-up`\nChild PR target: `epic/83-helper-dogfood-follow-up`\n' "type:epic"
+    ;;
+  *"/issues/86/comments"*|*"/issues/87/comments"*)
+    printf '[]\n'
+    ;;
+  *"/issues/86"*)
+    issue_json 86 "Comment helper" "$(contract)" "type:task"
+    ;;
+  *"/issues/87"*)
+    issue_json 87 "Batch helper" "$(contract)" "type:task"
+    ;;
+  *"/pulls"*"state=open"*)
+    jq -n '[{
+      number: 101,
+      title: "[#86] Add agent-comment",
+      body: "Closes #86",
+      state: "open",
+      draft: false,
+      html_url: "https://example.test/pull/101",
+      base: {ref: "epic/83-helper-dogfood-follow-up"},
+      head: {ref: "agent/86-comment", sha: "abc123"}
+    }]'
+    ;;
+  *"/pulls/101/files"*)
+    jq -n '[{status:"added",filename:"tools/agents/agent-comment",additions:120,deletions:0}]'
+    ;;
+  *"/commits/abc123/status"*)
+    jq -n '{state:"success",total_count:1}'
+    ;;
+  *"/pulls/101"*)
+    jq -n '{
+      number: 101,
+      title: "[#86] Add agent-comment",
+      body: "Closes #86",
+      state: "open",
+      draft: false,
+      html_url: "https://example.test/pull/101",
+      base: {ref: "epic/83-helper-dogfood-follow-up"},
+      head: {ref: "agent/86-comment", sha: "abc123"}
+    }'
+    ;;
+  *)
+    printf 'unexpected fake gh call: %s\n' "$*" >&2
+    exit 21
+    ;;
+esac
+SH
+chmod +x "$fixture_root/tools/agents/gh-retry"
+
+batch_output="$("$fixture_root/tools/agents/agent-batch-accept" --epic 83 --issue 86 --issue 87)"
+grep -Fq "Mode: dry-run" <<< "$batch_output"
+grep -Fq "Integration branch: epic/83-helper-dogfood-follow-up" <<< "$batch_output"
+grep -Fq "Final main integration: separate Architect/user-gated decision" <<< "$batch_output"
+grep -Fq "Issue #86 Comment helper" <<< "$batch_output"
+grep -Fq "open PR candidate: #101" <<< "$batch_output"
+grep -Fq "Issue #87 Batch helper" <<< "$batch_output"
+grep -Fq "open PR candidate: none detected" <<< "$batch_output"
+grep -Fq "PR #101 [#86] Add agent-comment" <<< "$batch_output"
+grep -Fq "base: epic/83-helper-dogfood-follow-up; head: agent/86-comment" <<< "$batch_output"
+grep -Fq "linked issues: #86" <<< "$batch_output"
+grep -Fq "added tools/agents/agent-comment +120/-0" <<< "$batch_output"
+grep -Fq "check/status hint: success (1 contexts)" <<< "$batch_output"
+grep -Fq "merge accepted child PRs into the Epic integration branch only" <<< "$batch_output"
+grep -Fq "Batch acceptance checkpoint" <<< "$batch_output"
+
+pr_output="$("$fixture_root/tools/agents/agent-batch-accept" --epic 83 --pr 101)"
+grep -Fq "Pull requests:" <<< "$pr_output"
+grep -Fq "PR #101 [#86] Add agent-comment" <<< "$pr_output"
+
+if "$fixture_root/tools/agents/agent-batch-accept" --epic 83 --issue 86 --apply >/dev/null 2>&1; then
+  printf 'apply unexpectedly succeeded\n' >&2
+  exit 1
+fi
+
+if "$fixture_root/tools/agents/agent-batch-accept" --epic 83 >/dev/null 2>&1; then
+  printf 'empty batch unexpectedly succeeded\n' >&2
+  exit 1
+fi
+
+if "$fixture_root/tools/agents/agent-batch-accept" --epic x --issue 86 >/dev/null 2>&1; then
+  printf 'non-numeric epic unexpectedly succeeded\n' >&2
+  exit 1
+fi
+
+printf 'batch-accept fixture checks passed\n'

--- a/tools/agents/test-batch-accept
+++ b/tools/agents/test-batch-accept
@@ -57,7 +57,7 @@ case "$*" in
     jq -n '[{
       number: 101,
       title: "[#86] Add agent-comment",
-      body: "Closes #86",
+      body: "Refs #83 and closes #86. Follow-up from PR #101.",
       state: "open",
       draft: false,
       html_url: "https://example.test/pull/101",
@@ -75,7 +75,7 @@ case "$*" in
     jq -n '{
       number: 101,
       title: "[#86] Add agent-comment",
-      body: "Closes #86",
+      body: "Refs #83 and closes #86. Follow-up from PR #101.",
       state: "open",
       draft: false,
       html_url: "https://example.test/pull/101",
@@ -101,7 +101,8 @@ grep -Fq "Issue #87 Batch helper" <<< "$batch_output"
 grep -Fq "open PR candidate: none detected" <<< "$batch_output"
 grep -Fq "PR #101 [#86] Add agent-comment" <<< "$batch_output"
 grep -Fq "base: epic/83-helper-dogfood-follow-up; head: agent/86-comment" <<< "$batch_output"
-grep -Fq "linked issues: #86" <<< "$batch_output"
+grep -Fq "linked issues: #83, #86" <<< "$batch_output"
+! grep -Fq "linked issues: #83, #86, #101" <<< "$batch_output"
 grep -Fq "added tools/agents/agent-comment +120/-0" <<< "$batch_output"
 grep -Fq "check/status hint: success (1 contexts)" <<< "$batch_output"
 grep -Fq "merge accepted child PRs into the Epic integration branch only" <<< "$batch_output"


### PR DESCRIPTION
## Scope completed
- Refs #86: added `tools/agents/agent-comment` as a REST-first issue/PR conversation comment helper.
  - Explicit `issue|pr` target by number.
  - Required `--body-file` input.
  - Default dry-run preview and explicit `--apply` write path.
  - Fails closed for unknown target type, missing/empty body files, issue/PR type mismatch, and REST write failure.
- Refs #87: added dry-run-only `tools/agents/agent-batch-accept`.
  - Reads an Epic plus child issues/PRs.
  - Prints integration branch, issue state, PR base/head hints, linked issues, changed files, REST status hints, merge plan, issue/label/Project plan, release/hold note, durable batch checkpoint template, and final-main warning.
  - No live merge/close/status/label/Project writes.
- Added focused fixtures: `tools/agents/test-agent-comment` and `tools/agents/test-batch-accept`.
- Updated `tools/agents/README.md` with concise usage and behavior notes.

## Verification
- `tools/agents/test-agent-comment && tools/agents/test-batch-accept`
- `tools/agents/test-pickup && tools/agents/test-handoff && tools/agents/test-role-routing-config && tools/agents/test-contract-role-fields && tools/agents/test-ready-queue && tools/agents/test-agent-audit`
- `bash -n tools/agents/_lib.sh tools/agents/agent-comment tools/agents/test-agent-comment tools/agents/agent-batch-accept tools/agents/test-batch-accept tools/agents/agent-pickup tools/agents/agent-handoff tools/agents/agent-ready-queue tools/agents/agent-audit tools/agents/agent-inbox tools/agents/agent-label tools/agents/agent-issue-context tools/agents/agent-pr-context && git diff --check`
- Safe live dry-run: `tools/agents/agent-comment issue 86 --body-file /tmp/tiny-ipa-agent-comment-dry-run.md`
- Safe live dry-run before PR creation: `tools/agents/agent-batch-accept --epic 83 --issue 86 --issue 87`
- Safe live dry-run after PR creation: `tools/agents/agent-batch-accept --epic 83 --issue 86 --issue 87` detected PR #88, changed files, linked issues, and no REST status contexts.
- Live apply dogfood: `tools/agents/agent-comment issue 86 --body-file /private/tmp/tiny-ipa-86-completion.md --apply`
- Live apply dogfood: `tools/agents/agent-comment issue 87 --body-file /private/tmp/tiny-ipa-87-completion.md --apply`
- Live read-only audit: `tools/agents/agent-audit`
- Final inbox check: `tools/agents/agent-inbox all`

## Dogfood observations
- Helper fast paths used first: `agent-inbox implementer`, `agent-ready-queue --role implementer`, `agent-audit`, `agent-pickup` for #86/#87, and `agent-issue-context` for #83/#86/#87.
- Sandbox initially blocked the local proxy path for GitHub API reads; rerunning helpers with approved escalation let the REST-first helper paths work.
- Observed GitHub TLS retries on `agent-inbox` and `agent-ready-queue`, matching the Architect note that `agent-audit` was clean but comment reads can hit transient TLS timeouts.
- Direct-thread dispatch was useful only as an acceleration ping. Durable state remained GitHub issues, labels, comments, this branch, and this PR.
- `agent-comment` avoided shell Markdown hazards through body-file input and was used for the #86/#87 completion comments.
- `agent-batch-accept` reduced manual batch reconstruction into one low-token dry-run report and correctly avoided a fake next actor for `batch checkpoint`.

## Residual risks
- `agent-batch-accept` is intentionally dry-run only and does not inspect GitHub Checks API check-runs; it reports REST commit status contexts when available and calls out absent status contexts separately.
- Issue closure, label cleanup, Project v2 status sync, and P1/P2 release remain Architect/reviewer-gated follow-up actions.
- Final `main` integration is explicitly out of scope and remains separate Architect/user-gated work.