### PR TITLE
[#83 P1] Add release queue and dogfood report helpers

### DIFF
--- a/tools/agents/README.md
+++ b/tools/agents/README.md
@@ -25,6 +25,8 @@ tools/agents/agent-handoff 64 --from implementer
 tools/agents/agent-handoff 64 --from reviewer --to implementer
 tools/agents/agent-comment issue 86 --body-file /tmp/comment.md
 tools/agents/agent-batch-accept --epic 83 --issue 86 --issue 87
+tools/agents/agent-release-queue --epic 83 --role implementer --issue 89 --issue 90
+tools/agents/agent-dogfood-report --helper "agent-audit: clean" --verification "tests passed" --durable "PR #91"
 tools/agents/agent-audit
 ```
 
@@ -89,6 +91,18 @@ state, PR base/head hints, linked issues, changed files, REST status hints when
 available, merge/close/label/Project plans, release or hold notes, and a durable
 batch checkpoint comment template. It never merges PRs, closes issues, mutates
 labels, updates Project v2, or integrates into `main`.
+
+`agent-release-queue` is dry-run only. It takes an Epic, a target role, and one
+or more child issues, checks dependency gates from the latest effective
+Execution Contract, and prints planned next-action label changes, release
+comments, hold reasons, and Project sync decisions. It can check closed issue
+dependencies and merged PR dependencies, but it never mutates labels, comments,
+Project v2, issues, PRs, or `main`.
+
+`agent-dogfood-report` is explicit-input only. It formats compact handoff
+sections for helper commands used, verification, durable GitHub state,
+direct-thread dispatch, fallback/manual work, manual steps reduced, and residual
+risks. It deliberately does not parse arbitrary terminal logs or infer success.
 
 `agent-audit` is a read-only consistency check. It looks for common workflow
 drift without touching GitHub Project v2:

--- a/tools/agents/agent-dogfood-report
+++ b/tools/agents/agent-dogfood-report
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  tools/agents/agent-dogfood-report \
+    --helper <text> --verification <text> --durable <text> \
+    [--dispatch <text>] [--fallback <text>] [--manual-step <text>] [--risk <text>]
+
+Generates a compact explicit-input dogfood report. It does not parse arbitrary
+logs, read GitHub, or mutate state.
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" || $# -eq 0 ]]; then
+  usage
+  exit 0
+fi
+
+helpers=()
+verification=()
+durable=()
+dispatch=()
+fallback=()
+manual_steps=()
+risks=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --helper)
+      [[ -n "${2:-}" ]] || { printf '%s\n' '--helper requires text' >&2; exit 2; }
+      helpers+=("$2")
+      shift 2
+      ;;
+    --verification)
+      [[ -n "${2:-}" ]] || { printf '%s\n' '--verification requires text' >&2; exit 2; }
+      verification+=("$2")
+      shift 2
+      ;;
+    --durable)
+      [[ -n "${2:-}" ]] || { printf '%s\n' '--durable requires text' >&2; exit 2; }
+      durable+=("$2")
+      shift 2
+      ;;
+    --dispatch)
+      [[ -n "${2:-}" ]] || { printf '%s\n' '--dispatch requires text' >&2; exit 2; }
+      dispatch+=("$2")
+      shift 2
+      ;;
+    --fallback)
+      [[ -n "${2:-}" ]] || { printf '%s\n' '--fallback requires text' >&2; exit 2; }
+      fallback+=("$2")
+      shift 2
+      ;;
+    --manual-step)
+      [[ -n "${2:-}" ]] || { printf '%s\n' '--manual-step requires text' >&2; exit 2; }
+      manual_steps+=("$2")
+      shift 2
+      ;;
+    --risk)
+      [[ -n "${2:-}" ]] || { printf '%s\n' '--risk requires text' >&2; exit 2; }
+      risks+=("$2")
+      shift 2
+      ;;
+    *)
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if (( ${#helpers[@]} == 0 )); then
+  printf '%s\n' 'At least one --helper entry is required' >&2
+  exit 2
+fi
+if (( ${#verification[@]} == 0 )); then
+  printf '%s\n' 'At least one --verification entry is required' >&2
+  exit 2
+fi
+if (( ${#durable[@]} == 0 )); then
+  printf '%s\n' 'At least one --durable entry is required' >&2
+  exit 2
+fi
+
+print_section() {
+  local title="$1"
+  shift
+  local items=("$@")
+  local item
+
+  printf '%s\n' "$title"
+  if (( ${#items[@]} == 0 )); then
+    printf '%s\n' '- none'
+  else
+    for item in "${items[@]}"; do
+      printf '%s\n' "- $item"
+    done
+  fi
+  printf '\n'
+}
+
+printf '%s\n\n' '## Dogfood report'
+print_section 'Helper commands used:' "${helpers[@]}"
+print_section 'Verification:' "${verification[@]}"
+print_section 'Durable GitHub state:' "${durable[@]}"
+print_section 'Direct-thread dispatch:' "${dispatch[@]}"
+print_section 'Fallback / manual steps:' "${fallback[@]}"
+print_section 'Manual steps reduced:' "${manual_steps[@]}"
+print_section 'Residual risks:' "${risks[@]}"

--- a/tools/agents/agent-release-queue
+++ b/tools/agents/agent-release-queue
@@ -1,0 +1,254 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo="${GH_REPO:-farmerhunter/tiny-ipa}"
+comments_limit="${AGENT_COMMENTS_LIMIT:-100}"
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+gh_retry="$root/tools/agents/gh-retry"
+source "$root/tools/agents/_lib.sh"
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  tools/agents/agent-release-queue --epic <issue> --role <role> --issue <issue>...
+
+Dry-runs dependency-gated release of selected issues into a configured role
+inbox. It does not mutate labels, comments, Project v2, issues, PRs, or main.
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" || $# -eq 0 ]]; then
+  usage
+  exit 0
+fi
+
+epic=""
+role=""
+issues=()
+apply=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --epic)
+      if [[ -z "${2:-}" ]]; then
+        printf '%s\n' '--epic requires an issue number' >&2
+        exit 2
+      fi
+      epic="$2"
+      require_number "$epic" "Epic issue"
+      shift 2
+      ;;
+    --role)
+      if [[ -z "${2:-}" ]]; then
+        printf '%s\n' '--role requires a role name' >&2
+        exit 2
+      fi
+      role="$2"
+      shift 2
+      ;;
+    --issue)
+      if [[ -z "${2:-}" ]]; then
+        printf '%s\n' '--issue requires an issue number' >&2
+        exit 2
+      fi
+      require_number "$2" "Child issue"
+      issues+=("$2")
+      shift 2
+      ;;
+    --dry-run)
+      apply=0
+      shift
+      ;;
+    --apply)
+      apply=1
+      shift
+      ;;
+    *)
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$epic" ]]; then
+  printf '%s\n' '--epic is required' >&2
+  exit 2
+fi
+if [[ -z "$role" ]]; then
+  printf '%s\n' '--role is required' >&2
+  exit 2
+fi
+if (( ${#issues[@]} == 0 )); then
+  printf '%s\n' 'At least one --issue is required' >&2
+  exit 2
+fi
+if [[ "$apply" -eq 1 ]]; then
+  printf '%s\n' '--apply is not implemented; agent-release-queue is dry-run only' >&2
+  exit 2
+fi
+
+role_label="$(agent_role_label_for_role "$role")"
+
+strip_ticks() {
+  sed -E 's/^`//; s/`$//'
+}
+
+extract_first_value() {
+  local prefix="$1"
+  local text="$2"
+
+  awk -v prefix="$prefix" '
+    index($0, prefix) == 1 {
+      sub(prefix "[[:space:]]*", "")
+      print
+      found = 1
+      exit
+    }
+    END {
+      if (!found) print ""
+    }
+  ' <<< "$text"
+}
+
+current_primary_labels() {
+  local labels="$1"
+  local next_label
+
+  while IFS= read -r next_label; do
+    [[ -z "$next_label" ]] && continue
+    if grep -Fxq "$next_label" <<< "$labels"; then
+      printf '%s\n' "$next_label"
+    fi
+  done < <(agent_primary_next_labels)
+}
+
+dependency_gate() {
+  local depends="$1"
+  local token issue_ref issue_state pr_ref pr_json pr_state merged base
+  local issue_dep_text
+  local holds=()
+
+  if [[ "$depends" == "MISSING" || -z "$depends" ]]; then
+    printf '%s\n' 'hold: missing Depends on'
+    return 1
+  fi
+  if [[ "$depends" == *"none"* ]]; then
+    printf '%s\n' 'startable'
+    return 0
+  fi
+
+  issue_dep_text="$(sed -E 's/PR #[0-9]+//g' <<< "$depends")"
+  while IFS= read -r issue_ref; do
+    [[ -z "$issue_ref" ]] && continue
+    issue_state="$("$gh_retry" gh api "$(repo_api_path "$repo")/issues/$issue_ref" --jq '.state')"
+    if [[ "$issue_state" != "closed" ]]; then
+      holds+=("#$issue_ref open")
+    fi
+  done < <(grep -Eo '#[0-9]+' <<< "$issue_dep_text" | tr -d '#' | sort -nu || true)
+
+  while IFS= read -r token; do
+    [[ -z "$token" ]] && continue
+    pr_ref="${token#PR #}"
+    pr_json="$("$gh_retry" gh api "$(repo_api_path "$repo")/pulls/$pr_ref")"
+    pr_state="$(jq -r '.state' <<< "$pr_json")"
+    merged="$(jq -r '.merged' <<< "$pr_json")"
+    base="$(jq -r '.base.ref' <<< "$pr_json")"
+    if [[ "$pr_state" != "closed" || "$merged" != "true" ]]; then
+      holds+=("PR #$pr_ref not merged")
+    elif [[ -n "$integration_branch" && "$base" != "$integration_branch" ]]; then
+      holds+=("PR #$pr_ref merged to $base, expected $integration_branch")
+    fi
+  done < <(grep -Eo 'PR #[0-9]+' <<< "$depends" | sort -u || true)
+
+  if (( ${#holds[@]} > 0 )); then
+    printf 'hold: %s\n' "$(printf '%s\n' "${holds[@]}" | agent_join_lines)"
+    return 1
+  fi
+
+  printf '%s\n' 'startable'
+}
+
+epic_json="$("$gh_retry" gh api "$(repo_api_path "$repo")/issues/$epic")"
+epic_title="$(jq -r '.title' <<< "$epic_json")"
+epic_url="$(jq -r '.html_url' <<< "$epic_json")"
+epic_body="$(jq -r '.body // ""' <<< "$epic_json")"
+integration_branch="$(extract_first_value "Integration branch:" "$epic_body" | strip_ticks)"
+if [[ -z "$integration_branch" ]]; then
+  integration_branch="$(extract_first_value "Child PR target:" "$epic_body" | strip_ticks)"
+fi
+
+printf '#%s %s\n' "$epic" "$epic_title"
+printf 'Mode: dry-run\n'
+printf 'Release role: %s (%s)\n' "$role" "$role_label"
+printf 'Epic URL: %s\n' "$epic_url"
+printf 'Integration branch: %s\n' "${integration_branch:-not detected; verify manually}"
+printf 'Final main integration: separate Architect/user-gated decision\n'
+
+printf '\nRelease candidates:\n'
+for issue in "${issues[@]}"; do
+  issue_json="$("$gh_retry" gh api "$(repo_api_path "$repo")/issues/$issue")"
+  title="$(jq -r '.title' <<< "$issue_json")"
+  state="$(jq -r '.state' <<< "$issue_json")"
+  url="$(jq -r '.html_url' <<< "$issue_json")"
+  labels="$(jq -r '[.labels[].name] | join("\n")' <<< "$issue_json")"
+  label_text="$(jq -r '[.labels[].name] | join(", ")' <<< "$issue_json")"
+  body="$(jq -r '.body // ""' <<< "$issue_json")"
+  comments="$("$gh_retry" gh api -X GET "$(repo_api_path "$repo")/issues/$issue/comments" \
+    -f per_page="$comments_limit" \
+    --jq '[.[].body] | join("\n")')"
+  contract="$(extract_latest_contract_block "$body"$'\n'"$comments")"
+  target_base="$(extract_contract_value "Target PR base:" "$contract" | strip_ticks)"
+  depends="$(extract_contract_value "Depends on:" "$contract")"
+  gate="$(dependency_gate "$depends")" || true
+  current_primary="$(current_primary_labels "$labels")"
+
+  printf '%s\n' "- Issue #$issue $title"
+  printf '  state: %s\n' "$state"
+  printf '  url: %s\n' "$url"
+  printf '  labels: %s\n' "$label_text"
+  printf '  target PR base: %s\n' "$target_base"
+  printf '  depends on: %s\n' "$depends"
+  printf '  gate: %s\n' "$gate"
+  printf '  planned scheduler changes:\n'
+  if [[ "$gate" == startable ]]; then
+    if [[ -n "$current_primary" ]]; then
+      while IFS= read -r next_label; do
+        [[ -z "$next_label" ]] && continue
+        [[ "$next_label" == "$role_label" ]] && continue
+        printf '    - remove %s\n' "$next_label"
+      done <<< "$current_primary"
+    else
+      printf '%s\n' '    - no current primary next-action label to remove'
+    fi
+    if grep -Fxq "$role_label" <<< "$labels"; then
+      printf '    - keep %s\n' "$role_label"
+    else
+      printf '    - add %s\n' "$role_label"
+    fi
+    printf '%s\n' '    - post release comment'
+  else
+    printf '%s\n' '    - no label changes while held'
+    printf '%s\n' '    - post hold note if release is deferred'
+  fi
+  printf '%s\n' '    - Project v2 sync is secondary and not part of this dry-run'
+done
+
+printf '\nRelease comment template:\n'
+printf '%s\n' '## Architect release'
+printf '\n'
+printf 'Released to: %s (%s)\n' "$role" "$role_label"
+printf 'Epic: #%s\n' "$epic"
+printf '\n'
+printf 'Issues:\n'
+for issue in "${issues[@]}"; do
+  printf '%s\n' "- #$issue"
+done
+printf '\n'
+printf 'Dependency gate:\n'
+printf '%s\n' '- <startable or hold reason>'
+printf '\n'
+printf 'Residual risks:\n'
+printf '%s\n' '- <known limits or none>'
+
+printf '\nDogfood note:\n'
+printf '%s\n' '- This helper would consolidate release comments, next-action label planning, dependency holds, and Project sync decisions into one dry-run report.'

--- a/tools/agents/test-dogfood-report
+++ b/tools/agents/test-dogfood-report
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+report="$("$root/tools/agents/agent-dogfood-report" \
+  --helper "agent-inbox implementer: #89/#90" \
+  --verification "tools/agents/test-release-queue: passed" \
+  --durable "PR #91" \
+  --dispatch "source thread ping only" \
+  --fallback "none" \
+  --manual-step "release comments and labels planned together" \
+  --risk "Project sync remains manual")"
+
+grep -Fq "## Dogfood report" <<< "$report"
+grep -Fq "Helper commands used:" <<< "$report"
+grep -Fq "agent-inbox implementer: #89/#90" <<< "$report"
+grep -Fq "Verification:" <<< "$report"
+grep -Fq "Durable GitHub state:" <<< "$report"
+grep -Fq "Direct-thread dispatch:" <<< "$report"
+grep -Fq "Fallback / manual steps:" <<< "$report"
+grep -Fq "Manual steps reduced:" <<< "$report"
+grep -Fq "Residual risks:" <<< "$report"
+grep -Fq "Project sync remains manual" <<< "$report"
+
+minimal="$("$root/tools/agents/agent-dogfood-report" \
+  --helper "agent-audit: clean" \
+  --verification "bash -n: passed" \
+  --durable "issue #90")"
+grep -Fq "Direct-thread dispatch:" <<< "$minimal"
+grep -Fq -- "- none" <<< "$minimal"
+grep -Fq "Residual risks:" <<< "$minimal"
+
+if "$root/tools/agents/agent-dogfood-report" --helper "x" --durable "issue #90" >/dev/null 2>&1; then
+  printf 'missing verification unexpectedly succeeded\n' >&2
+  exit 1
+fi
+
+if "$root/tools/agents/agent-dogfood-report" --verification "x" --durable "issue #90" >/dev/null 2>&1; then
+  printf 'missing helper unexpectedly succeeded\n' >&2
+  exit 1
+fi
+
+if "$root/tools/agents/agent-dogfood-report" --helper "x" --verification "x" >/dev/null 2>&1; then
+  printf 'missing durable state unexpectedly succeeded\n' >&2
+  exit 1
+fi
+
+printf 'dogfood-report fixture checks passed\n'

--- a/tools/agents/test-release-queue
+++ b/tools/agents/test-release-queue
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+fixture_root="$tmp_dir/fixture-root"
+mkdir -p "$fixture_root/tools/agents"
+ln -s "$root/tools/agents/_lib.sh" "$fixture_root/tools/agents/_lib.sh"
+ln -s "$root/tools/agents/agent-release-queue" "$fixture_root/tools/agents/agent-release-queue"
+ln -s "$root/tools/agents/role-routing.conf" "$fixture_root/tools/agents/role-routing.conf"
+
+cat > "$fixture_root/tools/agents/gh-retry" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+issue_json() {
+  local number="$1"
+  local title="$2"
+  local state="$3"
+  local body="$4"
+  local labels="$5"
+
+  jq -n \
+    --argjson number "$number" \
+    --arg title "$title" \
+    --arg state "$state" \
+    --arg body "$body" \
+    --arg labels "$labels" \
+    '{
+      number: $number,
+      title: $title,
+      state: $state,
+      html_url: ("https://example.test/issues/" + ($number | tostring)),
+      body: $body,
+      labels: ($labels | split(",") | map(select(length > 0) | {name: .}))
+    }'
+}
+
+contract() {
+  local depends="$1"
+  printf '## Execution Contract\n\nOwner role: implementer\nReview role: reviewer\nAcceptance role: architect\nBranch strategy: epic integration branch\nBase branch: `epic/83-helper-dogfood-follow-up`\nTarget PR base: `epic/83-helper-dogfood-follow-up`\nDepends on: %s\nCompletion handoff: batch checkpoint\n' "$depends"
+}
+
+case "$*" in
+  *"/issues/83"*)
+    issue_json 83 "Epic" open $'Integration branch: `epic/83-helper-dogfood-follow-up`\n' "type:epic"
+    ;;
+  *"/issues/86"*"--jq .state"*|*"/issues/87"*"--jq .state"*)
+    printf 'closed\n'
+    ;;
+  *"/issues/88"*"--jq .state"*)
+    printf 'open\n'
+    ;;
+  *"/issues/89/comments"*|*"/issues/90/comments"*|*"/issues/91/comments"*)
+    printf '[]\n'
+    ;;
+  *"/issues/89"*)
+    issue_json 89 "Release helper" open "$(contract "#86, #87, PR #88 merged into Epic branch")" "type:task"
+    ;;
+  *"/issues/90"*)
+    issue_json 90 "Already routed" open "$(contract none)" "type:task,needs:implementer"
+    ;;
+  *"/issues/91"*)
+    issue_json 91 "Blocked helper" open "$(contract "#88")" "type:task"
+    ;;
+  *"/pulls/88"*)
+    jq -n '{number:88,state:"closed",merged:true,base:{ref:"epic/83-helper-dogfood-follow-up"}}'
+    ;;
+  *)
+    printf 'unexpected fake gh call: %s\n' "$*" >&2
+    exit 21
+    ;;
+esac
+SH
+chmod +x "$fixture_root/tools/agents/gh-retry"
+
+release_output="$("$fixture_root/tools/agents/agent-release-queue" --epic 83 --role implementer --issue 89 --issue 90)"
+grep -Fq "Mode: dry-run" <<< "$release_output"
+grep -Fq "Release role: implementer (needs:implementer)" <<< "$release_output"
+grep -Fq "Issue #89 Release helper" <<< "$release_output"
+grep -Fq "gate: startable" <<< "$release_output"
+grep -Fq "add needs:implementer" <<< "$release_output"
+grep -Fq "Issue #90 Already routed" <<< "$release_output"
+grep -Fq "keep needs:implementer" <<< "$release_output"
+grep -Fq "Project v2 sync is secondary" <<< "$release_output"
+grep -Fq "Release comment template:" <<< "$release_output"
+
+blocked_output="$("$fixture_root/tools/agents/agent-release-queue" --epic 83 --role implementer --issue 91)"
+grep -Fq "Issue #91 Blocked helper" <<< "$blocked_output"
+grep -Fq "gate: hold: #88 open" <<< "$blocked_output"
+grep -Fq "no label changes while held" <<< "$blocked_output"
+
+if "$fixture_root/tools/agents/agent-release-queue" --epic 83 --role ghost --issue 89 >/dev/null 2>&1; then
+  printf 'unknown role unexpectedly succeeded\n' >&2
+  exit 1
+fi
+
+if "$fixture_root/tools/agents/agent-release-queue" --epic 83 --role implementer --issue 89 --apply >/dev/null 2>&1; then
+  printf 'apply unexpectedly succeeded\n' >&2
+  exit 1
+fi
+
+if "$fixture_root/tools/agents/agent-release-queue" --epic 83 --role implementer >/dev/null 2>&1; then
+  printf 'empty release unexpectedly succeeded\n' >&2
+  exit 1
+fi
+
+printf 'release-queue fixture checks passed\n'


### PR DESCRIPTION
## Scope completed
- Refs #89: added dry-run-only `tools/agents/agent-release-queue`.
  - Inputs: `--epic`, `--role`, repeated `--issue`.
  - Checks dependency gates from each issue's latest effective Execution Contract.
  - Supports closed issue dependencies and merged PR dependencies such as `PR #88 merged into Epic branch`.
  - Prints planned next-action label changes, release comment template, hold reasons, and Project sync decisions.
  - `--apply` fails closed; no mutation behavior was added.
- Refs #90: added explicit-input `tools/agents/agent-dogfood-report`.
  - Formats helper commands used, verification, durable GitHub state, direct-thread dispatch, fallback/manual steps, manual steps reduced, and residual risks.
  - Requires explicit `--helper`, `--verification`, and `--durable` inputs.
  - Does not parse arbitrary logs, read GitHub, or mutate state.
- Added focused fixtures: `tools/agents/test-release-queue` and `tools/agents/test-dogfood-report`.
- Updated `tools/agents/README.md` with concise usage and behavior notes.

## Verification
- `tools/agents/test-release-queue && tools/agents/test-dogfood-report`
- `bash -n tools/agents/agent-release-queue tools/agents/agent-dogfood-report tools/agents/test-release-queue tools/agents/test-dogfood-report && git diff --check`
- Relevant helper regression checks: `tools/agents/test-agent-comment && tools/agents/test-batch-accept && tools/agents/test-pickup && tools/agents/test-handoff && tools/agents/test-role-routing-config && tools/agents/test-contract-role-fields && tools/agents/test-ready-queue && tools/agents/test-agent-audit`
- Safe live dry-run: `tools/agents/agent-release-queue --epic 83 --role implementer --issue 89 --issue 90`
- Safe local example: `tools/agents/agent-dogfood-report --helper ... --verification ... --durable ...`
- Live read-only audit: `tools/agents/agent-audit`

## Dogfood observations
- Helper fast paths used first: `agent-inbox implementer`, `agent-ready-queue --role implementer`, `agent-audit`, `agent-pickup` dry-runs for #89/#90, and `agent-issue-context` for #83/#89/#90.
- #89 would have reduced P0 manual release work by putting dependency gates, next-action label planning, release comment wording, and Project sync decisions into one dry-run report.
- #90 would have reduced P0 completion wording overhead by generating a compact dogfood report section from explicit inputs rather than hand-writing each section.
- Direct-thread dispatch remained an acceleration ping only; durable state stayed in GitHub issues, comments, labels, contracts, branch, and this PR.
- I intentionally did not update labels during pickup because the current assignment said not to update labels.

## Residual risks
- `agent-release-queue` is intentionally dry-run only; no live label/comment/Project mutation was implemented or tested.
- Dependency parsing is deliberately narrow: issue refs must be closed, and `PR #n` refs must be merged into the detected Epic integration branch. Broader dependency prose remains a manual review concern.
- Project v2 sync remains secondary/manual and is only reported as a plan.
- `agent-dogfood-report` avoids broad log parsing, so callers must provide accurate explicit inputs.
- Final `main` integration remains explicitly Architect/user-gated.