### PR TITLE
Fix helper empty arrays on bash 3.2

### DIFF
--- a/tools/agents/agent-batch-accept
+++ b/tools/agents/agent-batch-accept
@@ -193,9 +193,11 @@ fi
 
 open_prs_json="$("$gh_retry" gh api -X GET "$(repo_api_path "$repo")/pulls" -f state=open -f per_page=100)"
 known_issues="$epic"$'\n'
-for issue in "${issues[@]}"; do
-  known_issues="${known_issues}${issue}"$'\n'
-done
+if (( ${#issues[@]} > 0 )); then
+  for issue in "${issues[@]}"; do
+    known_issues="${known_issues}${issue}"$'\n'
+  done
+fi
 
 printf '#%s %s\n' "$epic" "$epic_title"
 printf 'Mode: dry-run\n'
@@ -242,18 +244,22 @@ fi
 
 printf '\nPull requests:\n'
 printed_prs=()
-for issue in "${issues[@]}"; do
-  matched_pr="$(find_pr_for_issue "$issue" "$open_prs_json")"
-  [[ -n "$matched_pr" ]] || continue
-  if ! agent_contains_value "$matched_pr" "${printed_prs[@]}"; then
-    printed_prs+=("$matched_pr")
-  fi
-done
-for pr in "${prs[@]}"; do
-  if ! agent_contains_value "$pr" "${printed_prs[@]}"; then
-    printed_prs+=("$pr")
-  fi
-done
+if (( ${#issues[@]} > 0 )); then
+  for issue in "${issues[@]}"; do
+    matched_pr="$(find_pr_for_issue "$issue" "$open_prs_json")"
+    [[ -n "$matched_pr" ]] || continue
+    if (( ${#printed_prs[@]} == 0 )) || ! agent_contains_value "$matched_pr" "${printed_prs[@]}"; then
+      printed_prs+=("$matched_pr")
+    fi
+  done
+fi
+if (( ${#prs[@]} > 0 )); then
+  for pr in "${prs[@]}"; do
+    if (( ${#printed_prs[@]} == 0 )) || ! agent_contains_value "$pr" "${printed_prs[@]}"; then
+      printed_prs+=("$pr")
+    fi
+  done
+fi
 
 if (( ${#printed_prs[@]} == 0 )); then
   printf '%s\n' '- none detected or supplied'

--- a/tools/agents/agent-dogfood-report
+++ b/tools/agents/agent-dogfood-report
@@ -104,7 +104,23 @@ printf '%s\n\n' '## Dogfood report'
 print_section 'Helper commands used:' "${helpers[@]}"
 print_section 'Verification:' "${verification[@]}"
 print_section 'Durable GitHub state:' "${durable[@]}"
-print_section 'Direct-thread dispatch:' "${dispatch[@]}"
-print_section 'Fallback / manual steps:' "${fallback[@]}"
-print_section 'Manual steps reduced:' "${manual_steps[@]}"
-print_section 'Residual risks:' "${risks[@]}"
+if (( ${#dispatch[@]} == 0 )); then
+  print_section 'Direct-thread dispatch:'
+else
+  print_section 'Direct-thread dispatch:' "${dispatch[@]}"
+fi
+if (( ${#fallback[@]} == 0 )); then
+  print_section 'Fallback / manual steps:'
+else
+  print_section 'Fallback / manual steps:' "${fallback[@]}"
+fi
+if (( ${#manual_steps[@]} == 0 )); then
+  print_section 'Manual steps reduced:'
+else
+  print_section 'Manual steps reduced:' "${manual_steps[@]}"
+fi
+if (( ${#risks[@]} == 0 )); then
+  print_section 'Residual risks:'
+else
+  print_section 'Residual risks:' "${risks[@]}"
+fi


### PR DESCRIPTION
## Summary

- Fix bash 3.2 + `set -u` empty-array failures in `agent-batch-accept` optional issue/PR loops.
- Fix `agent-dogfood-report` optional empty sections so omitted dispatch/fallback/manual/risk entries print `- none` instead of expanding empty arrays.

## Verification

- `tools/agents/test-agent-comment`: passed
- `tools/agents/test-batch-accept`: passed
- `tools/agents/test-release-queue`: passed
- `tools/agents/test-dogfood-report`: passed
- `tools/agents/agent-audit`: clean

## Helper Dogfood Notes

- Startup helpers used: `agent-inbox implementer`, `agent-ready-queue --role implementer`, `agent-audit`, and `agent-issue-context 83`.
- `agent-pickup 83 --role implementer` was attempted but blocked on free-form contract field validation (`Review role: reviewer after PR is ready`, completion handoff text). Durable issue context and ready queue still made the focused contract clear.
- Initial sandboxed GitHub reads failed on the local proxy; rerunning helper reads with approved network access succeeded.
- Direct thread dispatch accelerated awareness only; this PR and issue #83 remain the durable state.

## Boundaries

- Targets only `epic/83-helper-dogfood-follow-up`.
- Does not merge to `main`, close #83, release P2, or mutate Project state.
