### PR TITLE
Add delegated permission smoke gate

### DIFF
--- a/docs/08-multi-agent-epic-workflow.md
+++ b/docs/08-multi-agent-epic-workflow.md
@@ -450,6 +450,7 @@ blocker, a shared contract changes, or user/Architect authority is needed.
 Tiny IPA has project-local helpers under `tools/agents/`:
 
 ```bash
+tools/agents/agent-permission-smoke
 tools/agents/agent-inbox architect
 tools/agents/agent-inbox implementer
 tools/agents/agent-ready-queue
@@ -459,6 +460,21 @@ tools/agents/agent-project-status <issue-number> "In Review"
 ```
 
 Use these helpers first in daily agent work. They standardize retries, avoid unnecessary Project v2 reads, and cache Project item IDs in `.agent-cache/` when a Project status update is needed.
+
+Delegated thread permission gate:
+
+```text
+Before doing GitHub writes, Git metadata writes, branch creation, or PR work,
+run `tools/agents/agent-permission-smoke`. If this delegated/resumed turn starts
+under restricted network or local Git metadata permissions, do not proceed with
+branch/PR workflow. Report the permission downgrade and wait for a user turn
+with full GitHub network access and local Git metadata write permission.
+```
+
+Architect dispatch prompts should include that gate whenever they use direct
+thread dispatch as an acceleration ping. The ping remains non-authoritative:
+the durable issue, PR, labels, comments, and Execution Contract still control
+what work may start.
 
 Inbox, issue-context, PR-context, and label-routing helpers should prefer GitHub REST API reads/writes over `gh issue list/view/edit` and `gh pr view`, because those commands can use GraphQL and have repeatedly hit TLS timeouts in this project. Project v2 remains separate and low-frequency.
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -24,6 +24,9 @@ adding new role-routing automation.
 Use `needs:*` labels as the cross-agent handoff inbox. Project status remains the visual board, but labels are the reliable CLI lookup mechanism.
 
 ```bash
+# Delegated/resumed agent turn permission check
+tools/agents/agent-permission-smoke
+
 # Architect: planning, review, merge, readiness
 tools/agents/agent-inbox architect
 
@@ -49,6 +52,13 @@ When handing work to another role, update the label and add a short issue or PR 
 The raw `gh issue list` commands still work, but agents should prefer the local helpers above. They use retry defaults, avoid Project v2 queries during ordinary pickup, and keep the command surface consistent across Codex, Claude Code, DeepSeek, and similar environments.
 
 The helpers prefer GitHub REST API reads for inbox and issue context because `gh issue list/view` can use GraphQL and has been the most common source of TLS timeouts during M3.
+
+Run `tools/agents/agent-permission-smoke` before GitHub-backed pickup when work
+arrives through cross-thread dispatch or a resumed agent turn. If GitHub API,
+remote Git, or local Git metadata writes are restricted, stop before creating a
+branch or mutating durable state. Report the permission downgrade in the thread
+and wait for a user turn with full GitHub network access and local Git metadata
+write permission.
 
 Do not put `needs:implementer` on an Epic. Implementers pick up child issues, not Epic containers. If an Epic-level concern requires execution, create a child task such as integration QA, cross-issue gap fixing, or final manual QA evidence.
 
@@ -83,16 +93,22 @@ Example: `agent/2-scaffold-fastapi-react-skeleton`
 
 ### Before starting an issue
 
-1. Read the docs referenced in the issue body.
-2. Check the parent Epic for dependencies and readiness notes.
-3. Confirm the child issue is in `Ready`.
-4. Read the issue's `Execution Contract`.
-5. Confirm every `Depends on` condition is satisfied.
-6. Move the child issue to `In progress`.
-7. Comment with `Pickup confirmed`, including branch strategy, working branch, PR base, and verification plan.
-8. Create the issue branch from the contract's base branch.
+1. Run `tools/agents/agent-permission-smoke` for delegated or resumed turns.
+2. Read the docs referenced in the issue body.
+3. Check the parent Epic for dependencies and readiness notes.
+4. Confirm the child issue is in `Ready`.
+5. Read the issue's `Execution Contract`.
+6. Confirm every `Depends on` condition is satisfied.
+7. Move the child issue to `In progress`.
+8. Comment with `Pickup confirmed`, including branch strategy, working branch, PR base, and verification plan.
+9. Create the issue branch from the contract's base branch.
 
 Do not start implementation if the `Execution Contract` is missing or the PR base is ambiguous. Move the issue to `needs:architect` and ask for the missing branch strategy.
+
+Do not start implementation if `agent-permission-smoke` fails. A cross-thread
+dispatch ping may arrive under a restricted sandbox profile; in that case the
+agent should report the downgrade instead of triggering approval prompts across
+every GitHub or Git metadata operation.
 
 Do not start implementation for a dependent issue whose `Depends on` condition is not satisfied yet. Leave the issue in `Ready` and optionally add:
 

--- a/tools/agents/README.md
+++ b/tools/agents/README.md
@@ -18,6 +18,7 @@ tools/agents/agent-inbox architect
 tools/agents/agent-inbox implementer
 tools/agents/agent-inbox reviewer
 tools/agents/agent-role-config
+tools/agents/agent-permission-smoke
 tools/agents/agent-ready-queue
 tools/agents/agent-ready-queue --role reviewer
 tools/agents/agent-pickup 63 --role implementer
@@ -36,6 +37,12 @@ config is shell-readable and defines roles, each role's inbox label, and the
 primary next-action labels. Use `tools/agents/agent-role-config` to print the
 active config compactly. Future projects can adapt the role set by changing
 that one config file instead of editing every helper script.
+
+`agent-permission-smoke` is the first check for delegated or resumed agent
+turns. It verifies non-mutating GitHub API reads, remote Git reads, and local
+Git metadata writes. If it fails, do not begin branch/PR work from that turn;
+report the permission downgrade and wait for a user turn with full GitHub
+network access and local Git metadata write permission.
 
 `agent-inbox` reads primary next-action labels only. It deliberately avoids Project v2
 queries because labels are faster and more reliable for agent pickup. It uses

--- a/tools/agents/agent-permission-smoke
+++ b/tools/agents/agent-permission-smoke
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo="${GH_REPO:-farmerhunter/tiny-ipa}"
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  tools/agents/agent-permission-smoke
+
+Checks whether the current agent turn can perform the basic non-mutating
+permissions needed before issue pickup:
+
+- read the GitHub API through gh
+- read the remote Git repository
+- write temporary Git metadata in this local checkout
+
+It does not mutate GitHub, create branches, push, or change Project state.
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+if [[ $# -gt 0 ]]; then
+  usage >&2
+  exit 2
+fi
+
+failures=0
+
+check() {
+  local label="$1"
+  shift
+
+  if "$@" >/tmp/agent-permission-smoke.out 2>/tmp/agent-permission-smoke.err; then
+    printf 'ok: %s\n' "$label"
+  else
+    printf 'fail: %s\n' "$label" >&2
+    sed 's/^/  /' /tmp/agent-permission-smoke.err >&2 || true
+    failures=$((failures + 1))
+  fi
+}
+
+check "GitHub API read via gh" gh api "repos/$repo" --jq .full_name
+check "remote Git read" git ls-remote --heads origin HEAD
+
+git_dir="$(git -C "$root" rev-parse --git-dir)"
+case "$git_dir" in
+  /*) ;;
+  *) git_dir="$root/$git_dir" ;;
+esac
+
+probe="$git_dir/codex-permission-smoke.$$"
+if { : > "$probe"; } 2>/tmp/agent-permission-smoke.err; then
+  rm -f "$probe"
+  printf 'ok: local Git metadata write\n'
+else
+  printf 'fail: local Git metadata write\n' >&2
+  sed 's/^/  /' /tmp/agent-permission-smoke.err >&2 || true
+  failures=$((failures + 1))
+fi
+
+rm -f /tmp/agent-permission-smoke.out /tmp/agent-permission-smoke.err
+
+if (( failures > 0 )); then
+  cat >&2 <<'MESSAGE'
+
+Permission smoke failed. Do not start branch/PR workflow from this turn.
+Report the permission downgrade and wait for a user turn with full GitHub
+network access and local Git metadata write permission.
+MESSAGE
+  exit 1
+fi
+
+printf 'permission smoke passed\n'


### PR DESCRIPTION
## Summary

- Add `tools/agents/agent-permission-smoke` for delegated/resumed agent turns.
- Document the startup gate in agent helper docs and development workflow.
- Add Architect dispatch protocol text: if permissions are downgraded, stop before branch/PR work and report it.

## Verification

- `bash -n tools/agents/agent-permission-smoke`: passed
- `tools/agents/agent-permission-smoke`: passed
- `git diff --check`: passed

## Dogfood Notes

- This follow-up comes from #83 dogfood where a cross-thread dispatch turn temporarily ran under restricted network and local Git metadata permissions.
- The helper is intentionally non-mutating: it reads GitHub API, reads remote Git, and writes/removes a temporary local `.git` probe file only.

Closes #93
