### PR TITLE
Integrate #83 helper dogfood tooling

### DIFF
--- a/docs/08-multi-agent-epic-workflow.md
+++ b/docs/08-multi-agent-epic-workflow.md
@@ -450,6 +450,7 @@ blocker, a shared contract changes, or user/Architect authority is needed.
 Tiny IPA has project-local helpers under `tools/agents/`:
 
 ```bash
+tools/agents/agent-permission-smoke
 tools/agents/agent-inbox architect
 tools/agents/agent-inbox implementer
 tools/agents/agent-ready-queue
@@ -459,6 +460,21 @@ tools/agents/agent-project-status <issue-number> "In Review"
 ```
 
 Use these helpers first in daily agent work. They standardize retries, avoid unnecessary Project v2 reads, and cache Project item IDs in `.agent-cache/` when a Project status update is needed.
+
+Delegated thread permission gate:
+
+```text
+Before doing GitHub writes, Git metadata writes, branch creation, or PR work,
+run `tools/agents/agent-permission-smoke`. If this delegated/resumed turn starts
+under restricted network or local Git metadata permissions, do not proceed with
+branch/PR workflow. Report the permission downgrade and wait for a user turn
+with full GitHub network access and local Git metadata write permission.
+```
+
+Architect dispatch prompts should include that gate whenever they use direct
+thread dispatch as an acceleration ping. The ping remains non-authoritative:
+the durable issue, PR, labels, comments, and Execution Contract still control
+what work may start.
 
 Inbox, issue-context, PR-context, and label-routing helpers should prefer GitHub REST API reads/writes over `gh issue list/view/edit` and `gh pr view`, because those commands can use GraphQL and have repeatedly hit TLS timeouts in this project. Project v2 remains separate and low-frequency.
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -24,6 +24,9 @@ adding new role-routing automation.
 Use `needs:*` labels as the cross-agent handoff inbox. Project status remains the visual board, but labels are the reliable CLI lookup mechanism.
 
 ```bash
+# Delegated/resumed agent turn permission check
+tools/agents/agent-permission-smoke
+
 # Architect: planning, review, merge, readiness
 tools/agents/agent-inbox architect
 
@@ -49,6 +52,13 @@ When handing work to another role, update the label and add a short issue or PR 
 The raw `gh issue list` commands still work, but agents should prefer the local helpers above. They use retry defaults, avoid Project v2 queries during ordinary pickup, and keep the command surface consistent across Codex, Claude Code, DeepSeek, and similar environments.
 
 The helpers prefer GitHub REST API reads for inbox and issue context because `gh issue list/view` can use GraphQL and has been the most common source of TLS timeouts during M3.
+
+Run `tools/agents/agent-permission-smoke` before GitHub-backed pickup when work
+arrives through cross-thread dispatch or a resumed agent turn. If GitHub API,
+remote Git, or local Git metadata writes are restricted, stop before creating a
+branch or mutating durable state. Report the permission downgrade in the thread
+and wait for a user turn with full GitHub network access and local Git metadata
+write permission.
 
 Do not put `needs:implementer` on an Epic. Implementers pick up child issues, not Epic containers. If an Epic-level concern requires execution, create a child task such as integration QA, cross-issue gap fixing, or final manual QA evidence.
 
@@ -83,16 +93,22 @@ Example: `agent/2-scaffold-fastapi-react-skeleton`
 
 ### Before starting an issue
 
-1. Read the docs referenced in the issue body.
-2. Check the parent Epic for dependencies and readiness notes.
-3. Confirm the child issue is in `Ready`.
-4. Read the issue's `Execution Contract`.
-5. Confirm every `Depends on` condition is satisfied.
-6. Move the child issue to `In progress`.
-7. Comment with `Pickup confirmed`, including branch strategy, working branch, PR base, and verification plan.
-8. Create the issue branch from the contract's base branch.
+1. Run `tools/agents/agent-permission-smoke` for delegated or resumed turns.
+2. Read the docs referenced in the issue body.
+3. Check the parent Epic for dependencies and readiness notes.
+4. Confirm the child issue is in `Ready`.
+5. Read the issue's `Execution Contract`.
+6. Confirm every `Depends on` condition is satisfied.
+7. Move the child issue to `In progress`.
+8. Comment with `Pickup confirmed`, including branch strategy, working branch, PR base, and verification plan.
+9. Create the issue branch from the contract's base branch.
 
 Do not start implementation if the `Execution Contract` is missing or the PR base is ambiguous. Move the issue to `needs:architect` and ask for the missing branch strategy.
+
+Do not start implementation if `agent-permission-smoke` fails. A cross-thread
+dispatch ping may arrive under a restricted sandbox profile; in that case the
+agent should report the downgrade instead of triggering approval prompts across
+every GitHub or Git metadata operation.
 
 Do not start implementation for a dependent issue whose `Depends on` condition is not satisfied yet. Leave the issue in `Ready` and optionally add:
 

--- a/tools/agents/README.md
+++ b/tools/agents/README.md
@@ -23,6 +23,8 @@ tools/agents/agent-ready-queue --role reviewer
 tools/agents/agent-pickup 63 --role implementer
 tools/agents/agent-handoff 64 --from implementer
 tools/agents/agent-handoff 64 --from reviewer --to implementer
+tools/agents/agent-comment issue 86 --body-file /tmp/comment.md
+tools/agents/agent-batch-accept --epic 83 --issue 86 --issue 87
 tools/agents/agent-audit
 ```
 
@@ -72,6 +74,21 @@ label changes plus a compact completion/handoff comment template. Use
 `--to <role|none|batch>` to override the contract route for explicit handoffs.
 The dry-run path does not mutate labels, post comments, close issues, or read
 Project v2. `--apply` is not implemented in the current prototype.
+
+`agent-comment` is a REST-first durable comment helper. It supports explicit
+`issue` and `pr` targets by number, requires `--body-file` input, previews by
+default, and posts only with `--apply`. It uses the REST issue-comments endpoint
+for both issue and PR conversation comments, avoiding GraphQL-backed
+`gh issue comment` / `gh pr comment` ordinary paths. It fails closed on unknown
+target types, missing or empty body files, target/type mismatches, and failed
+REST writes.
+
+`agent-batch-accept` is dry-run only. It takes an Epic plus child issues or PRs
+and prints an Architect batch acceptance plan: integration branch, child issue
+state, PR base/head hints, linked issues, changed files, REST status hints when
+available, merge/close/label/Project plans, release or hold notes, and a durable
+batch checkpoint comment template. It never merges PRs, closes issues, mutates
+labels, updates Project v2, or integrates into `main`.
 
 `agent-audit` is a read-only consistency check. It looks for common workflow
 drift without touching GitHub Project v2:

--- a/tools/agents/README.md
+++ b/tools/agents/README.md
@@ -18,6 +18,7 @@ tools/agents/agent-inbox architect
 tools/agents/agent-inbox implementer
 tools/agents/agent-inbox reviewer
 tools/agents/agent-role-config
+tools/agents/agent-permission-smoke
 tools/agents/agent-ready-queue
 tools/agents/agent-ready-queue --role reviewer
 tools/agents/agent-pickup 63 --role implementer
@@ -36,6 +37,12 @@ config is shell-readable and defines roles, each role's inbox label, and the
 primary next-action labels. Use `tools/agents/agent-role-config` to print the
 active config compactly. Future projects can adapt the role set by changing
 that one config file instead of editing every helper script.
+
+`agent-permission-smoke` is the first check for delegated or resumed agent
+turns. It verifies non-mutating GitHub API reads, remote Git reads, and local
+Git metadata writes. If it fails, do not begin branch/PR work from that turn;
+report the permission downgrade and wait for a user turn with full GitHub
+network access and local Git metadata write permission.
 
 `agent-inbox` reads primary next-action labels only. It deliberately avoids Project v2
 queries because labels are faster and more reliable for agent pickup. It uses

--- a/tools/agents/README.md
+++ b/tools/agents/README.md
@@ -25,6 +25,8 @@ tools/agents/agent-handoff 64 --from implementer
 tools/agents/agent-handoff 64 --from reviewer --to implementer
 tools/agents/agent-comment issue 86 --body-file /tmp/comment.md
 tools/agents/agent-batch-accept --epic 83 --issue 86 --issue 87
+tools/agents/agent-release-queue --epic 83 --role implementer --issue 89 --issue 90
+tools/agents/agent-dogfood-report --helper "agent-audit: clean" --verification "tests passed" --durable "PR #91"
 tools/agents/agent-audit
 ```
 
@@ -89,6 +91,18 @@ state, PR base/head hints, linked issues, changed files, REST status hints when
 available, merge/close/label/Project plans, release or hold notes, and a durable
 batch checkpoint comment template. It never merges PRs, closes issues, mutates
 labels, updates Project v2, or integrates into `main`.
+
+`agent-release-queue` is dry-run only. It takes an Epic, a target role, and one
+or more child issues, checks dependency gates from the latest effective
+Execution Contract, and prints planned next-action label changes, release
+comments, hold reasons, and Project sync decisions. It can check closed issue
+dependencies and merged PR dependencies, but it never mutates labels, comments,
+Project v2, issues, PRs, or `main`.
+
+`agent-dogfood-report` is explicit-input only. It formats compact handoff
+sections for helper commands used, verification, durable GitHub state,
+direct-thread dispatch, fallback/manual work, manual steps reduced, and residual
+risks. It deliberately does not parse arbitrary terminal logs or infer success.
 
 `agent-audit` is a read-only consistency check. It looks for common workflow
 drift without touching GitHub Project v2:

--- a/tools/agents/agent-batch-accept
+++ b/tools/agents/agent-batch-accept
@@ -193,9 +193,11 @@ fi
 
 open_prs_json="$("$gh_retry" gh api -X GET "$(repo_api_path "$repo")/pulls" -f state=open -f per_page=100)"
 known_issues="$epic"$'\n'
-for issue in "${issues[@]}"; do
-  known_issues="${known_issues}${issue}"$'\n'
-done
+if (( ${#issues[@]} > 0 )); then
+  for issue in "${issues[@]}"; do
+    known_issues="${known_issues}${issue}"$'\n'
+  done
+fi
 
 printf '#%s %s\n' "$epic" "$epic_title"
 printf 'Mode: dry-run\n'
@@ -242,18 +244,22 @@ fi
 
 printf '\nPull requests:\n'
 printed_prs=()
-for issue in "${issues[@]}"; do
-  matched_pr="$(find_pr_for_issue "$issue" "$open_prs_json")"
-  [[ -n "$matched_pr" ]] || continue
-  if ! agent_contains_value "$matched_pr" "${printed_prs[@]}"; then
-    printed_prs+=("$matched_pr")
-  fi
-done
-for pr in "${prs[@]}"; do
-  if ! agent_contains_value "$pr" "${printed_prs[@]}"; then
-    printed_prs+=("$pr")
-  fi
-done
+if (( ${#issues[@]} > 0 )); then
+  for issue in "${issues[@]}"; do
+    matched_pr="$(find_pr_for_issue "$issue" "$open_prs_json")"
+    [[ -n "$matched_pr" ]] || continue
+    if (( ${#printed_prs[@]} == 0 )) || ! agent_contains_value "$matched_pr" "${printed_prs[@]}"; then
+      printed_prs+=("$matched_pr")
+    fi
+  done
+fi
+if (( ${#prs[@]} > 0 )); then
+  for pr in "${prs[@]}"; do
+    if (( ${#printed_prs[@]} == 0 )) || ! agent_contains_value "$pr" "${printed_prs[@]}"; then
+      printed_prs+=("$pr")
+    fi
+  done
+fi
 
 if (( ${#printed_prs[@]} == 0 )); then
   printf '%s\n' '- none detected or supplied'

--- a/tools/agents/agent-batch-accept
+++ b/tools/agents/agent-batch-accept
@@ -110,6 +110,19 @@ pr_issue_refs() {
   grep -Eo '#[0-9]+' <<< "$text" | tr -d '#' | sort -nu || true
 }
 
+known_issue_refs() {
+  local text="$1"
+  local known="$2"
+  local ref
+
+  while IFS= read -r ref; do
+    [[ -z "$ref" ]] && continue
+    if grep -Fxq "$ref" <<< "$known"; then
+      printf '%s\n' "$ref"
+    fi
+  done < <(pr_issue_refs "$text")
+}
+
 find_pr_for_issue() {
   local issue="$1"
   local prs_json="$2"
@@ -129,6 +142,7 @@ find_pr_for_issue() {
 print_pr_summary() {
   local pr="$1"
   local integration_branch="$2"
+  local known_issues="$3"
   local pr_json files_json status_json
   local title state draft url base head linked_issues status total_contexts
 
@@ -139,7 +153,7 @@ print_pr_summary() {
   url="$(jq -r '.html_url' <<< "$pr_json")"
   base="$(jq -r '.base.ref' <<< "$pr_json")"
   head="$(jq -r '.head.ref' <<< "$pr_json")"
-  linked_issues="$(pr_issue_refs "$(jq -r '(.title // "") + "\n" + (.body // "")' <<< "$pr_json")" | sed 's/^/#/' | agent_join_lines)"
+  linked_issues="$(known_issue_refs "$(jq -r '(.title // "") + "\n" + (.body // "")' <<< "$pr_json")" "$known_issues" | sed 's/^/#/' | agent_join_lines)"
   [[ -n "$linked_issues" ]] || linked_issues="none detected"
 
   printf '%s\n' "- PR #$pr $title"
@@ -178,6 +192,10 @@ if [[ -z "$integration_branch" ]]; then
 fi
 
 open_prs_json="$("$gh_retry" gh api -X GET "$(repo_api_path "$repo")/pulls" -f state=open -f per_page=100)"
+known_issues="$epic"$'\n'
+for issue in "${issues[@]}"; do
+  known_issues="${known_issues}${issue}"$'\n'
+done
 
 printf '#%s %s\n' "$epic" "$epic_title"
 printf 'Mode: dry-run\n'
@@ -241,7 +259,7 @@ if (( ${#printed_prs[@]} == 0 )); then
   printf '%s\n' '- none detected or supplied'
 else
   for pr in "${printed_prs[@]}"; do
-    print_pr_summary "$pr" "$integration_branch"
+    print_pr_summary "$pr" "$integration_branch" "$known_issues"
   done
 fi
 

--- a/tools/agents/agent-batch-accept
+++ b/tools/agents/agent-batch-accept
@@ -1,0 +1,279 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo="${GH_REPO:-farmerhunter/tiny-ipa}"
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+gh_retry="$root/tools/agents/gh-retry"
+source "$root/tools/agents/_lib.sh"
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  tools/agents/agent-batch-accept --epic <issue> [--issue <issue>]... [--pr <pr>]...
+
+Dry-runs an Architect batch acceptance plan. It does not merge PRs, close
+issues, mutate labels, update Project v2, or integrate into main.
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" || $# -eq 0 ]]; then
+  usage
+  exit 0
+fi
+
+epic=""
+issues=()
+prs=()
+apply=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --epic)
+      if [[ -z "${2:-}" ]]; then
+        printf '%s\n' '--epic requires an issue number' >&2
+        exit 2
+      fi
+      epic="$2"
+      require_number "$epic" "Epic issue"
+      shift 2
+      ;;
+    --issue)
+      if [[ -z "${2:-}" ]]; then
+        printf '%s\n' '--issue requires an issue number' >&2
+        exit 2
+      fi
+      require_number "$2" "Child issue"
+      issues+=("$2")
+      shift 2
+      ;;
+    --pr)
+      if [[ -z "${2:-}" ]]; then
+        printf '%s\n' '--pr requires a PR number' >&2
+        exit 2
+      fi
+      require_number "$2" "Pull request"
+      prs+=("$2")
+      shift 2
+      ;;
+    --dry-run)
+      apply=0
+      shift
+      ;;
+    --apply)
+      apply=1
+      shift
+      ;;
+    *)
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$epic" ]]; then
+  printf '%s\n' '--epic is required' >&2
+  exit 2
+fi
+if (( ${#issues[@]} == 0 && ${#prs[@]} == 0 )); then
+  printf '%s\n' 'At least one --issue or --pr is required' >&2
+  exit 2
+fi
+if [[ "$apply" -eq 1 ]]; then
+  printf '%s\n' '--apply is not implemented; agent-batch-accept is dry-run only' >&2
+  exit 2
+fi
+
+extract_first_value() {
+  local prefix="$1"
+  local text="$2"
+
+  awk -v prefix="$prefix" '
+    index($0, prefix) == 1 {
+      sub(prefix "[[:space:]]*", "")
+      print
+      found = 1
+      exit
+    }
+    END {
+      if (!found) print ""
+    }
+  ' <<< "$text"
+}
+
+strip_ticks() {
+  sed -E 's/^`//; s/`$//'
+}
+
+pr_issue_refs() {
+  local text="$1"
+
+  grep -Eo '#[0-9]+' <<< "$text" | tr -d '#' | sort -nu || true
+}
+
+find_pr_for_issue() {
+  local issue="$1"
+  local prs_json="$2"
+
+  jq -r --arg issue "$issue" '
+    .[]
+    | select(
+        (.title | contains("#" + $issue)) or
+        ((.body // "") | contains("#" + $issue)) or
+        (.head.ref | contains("/" + $issue + "-")) or
+        (.head.ref | contains("-" + $issue + "-"))
+      )
+    | .number
+  ' <<< "$prs_json" | head -n 1
+}
+
+print_pr_summary() {
+  local pr="$1"
+  local integration_branch="$2"
+  local pr_json files_json status_json
+  local title state draft url base head linked_issues status total_contexts
+
+  pr_json="$("$gh_retry" gh api "$(repo_api_path "$repo")/pulls/$pr")"
+  title="$(jq -r '.title' <<< "$pr_json")"
+  state="$(jq -r '.state' <<< "$pr_json")"
+  draft="$(jq -r '.draft' <<< "$pr_json")"
+  url="$(jq -r '.html_url' <<< "$pr_json")"
+  base="$(jq -r '.base.ref' <<< "$pr_json")"
+  head="$(jq -r '.head.ref' <<< "$pr_json")"
+  linked_issues="$(pr_issue_refs "$(jq -r '(.title // "") + "\n" + (.body // "")' <<< "$pr_json")" | sed 's/^/#/' | agent_join_lines)"
+  [[ -n "$linked_issues" ]] || linked_issues="none detected"
+
+  printf '%s\n' "- PR #$pr $title"
+  printf '  state: %s; draft: %s\n' "$state" "$draft"
+  printf '  url: %s\n' "$url"
+  printf '  base: %s; head: %s\n' "$base" "$head"
+  if [[ -n "$integration_branch" && "$base" != "$integration_branch" ]]; then
+    printf '  base warning: expected %s\n' "$integration_branch"
+  fi
+  printf '  linked issues: %s\n' "$linked_issues"
+
+  files_json="$("$gh_retry" gh api -X GET "$(repo_api_path "$repo")/pulls/$pr/files" -f per_page=100)"
+  printf '  changed files:\n'
+  jq -r '.[0:12][] | "    - \(.status) \(.filename) +\(.additions)/-\(.deletions)"' <<< "$files_json"
+  if (( $(jq 'length' <<< "$files_json") > 12 )); then
+    printf '    - ... %s total files\n' "$(jq 'length' <<< "$files_json")"
+  fi
+
+  status_json="$("$gh_retry" gh api "$(repo_api_path "$repo")/commits/$(jq -r '.head.sha' <<< "$pr_json")/status")"
+  status="$(jq -r '.state' <<< "$status_json")"
+  total_contexts="$(jq -r '.total_count' <<< "$status_json")"
+  if [[ "$total_contexts" == "0" ]]; then
+    printf '  check/status hint: no REST status contexts found\n'
+  else
+    printf '  check/status hint: %s (%s contexts)\n' "$status" "$total_contexts"
+  fi
+}
+
+epic_json="$("$gh_retry" gh api "$(repo_api_path "$repo")/issues/$epic")"
+epic_title="$(jq -r '.title' <<< "$epic_json")"
+epic_url="$(jq -r '.html_url' <<< "$epic_json")"
+epic_body="$(jq -r '.body // ""' <<< "$epic_json")"
+integration_branch="$(extract_first_value "Integration branch:" "$epic_body" | strip_ticks)"
+if [[ -z "$integration_branch" ]]; then
+  integration_branch="$(extract_first_value "Child PR target:" "$epic_body" | strip_ticks)"
+fi
+
+open_prs_json="$("$gh_retry" gh api -X GET "$(repo_api_path "$repo")/pulls" -f state=open -f per_page=100)"
+
+printf '#%s %s\n' "$epic" "$epic_title"
+printf 'Mode: dry-run\n'
+printf 'Epic URL: %s\n' "$epic_url"
+if [[ -n "$integration_branch" ]]; then
+  printf 'Integration branch: %s\n' "$integration_branch"
+else
+  printf 'Integration branch: not detected; verify manually\n'
+fi
+printf 'Final main integration: separate Architect/user-gated decision\n'
+
+printf '\nChild issues:\n'
+if (( ${#issues[@]} == 0 )); then
+  printf '%s\n' '- none supplied'
+else
+  for issue in "${issues[@]}"; do
+    issue_json="$("$gh_retry" gh api "$(repo_api_path "$repo")/issues/$issue")"
+    issue_title="$(jq -r '.title' <<< "$issue_json")"
+    issue_state="$(jq -r '.state' <<< "$issue_json")"
+    issue_url="$(jq -r '.html_url' <<< "$issue_json")"
+    issue_labels="$(jq -r '[.labels[].name] | join(", ")' <<< "$issue_json")"
+    issue_body="$(jq -r '.body // ""' <<< "$issue_json")"
+    issue_comments="$("$gh_retry" gh api -X GET "$(repo_api_path "$repo")/issues/$issue/comments" \
+      -f per_page=100 \
+      --jq '[.[].body] | join("\n")')"
+    contract="$(extract_latest_contract_block "$issue_body"$'\n'"$issue_comments")"
+    target_base="$(extract_contract_value "Target PR base:" "$contract" | strip_ticks)"
+    handoff="$(extract_contract_value "Completion handoff:" "$contract")"
+    matched_pr="$(find_pr_for_issue "$issue" "$open_prs_json")"
+
+    printf '%s\n' "- Issue #$issue $issue_title"
+    printf '  state: %s\n' "$issue_state"
+    printf '  url: %s\n' "$issue_url"
+    printf '  labels: %s\n' "$issue_labels"
+    printf '  contract PR base: %s\n' "$target_base"
+    printf '  completion handoff: %s\n' "$handoff"
+    if [[ -n "$matched_pr" ]]; then
+      printf '  open PR candidate: #%s\n' "$matched_pr"
+    else
+      printf '  open PR candidate: none detected\n'
+    fi
+  done
+fi
+
+printf '\nPull requests:\n'
+printed_prs=()
+for issue in "${issues[@]}"; do
+  matched_pr="$(find_pr_for_issue "$issue" "$open_prs_json")"
+  [[ -n "$matched_pr" ]] || continue
+  if ! agent_contains_value "$matched_pr" "${printed_prs[@]}"; then
+    printed_prs+=("$matched_pr")
+  fi
+done
+for pr in "${prs[@]}"; do
+  if ! agent_contains_value "$pr" "${printed_prs[@]}"; then
+    printed_prs+=("$pr")
+  fi
+done
+
+if (( ${#printed_prs[@]} == 0 )); then
+  printf '%s\n' '- none detected or supplied'
+else
+  for pr in "${printed_prs[@]}"; do
+    print_pr_summary "$pr" "$integration_branch"
+  done
+fi
+
+printf '\nMerge plan if accepted:\n'
+printf '%s\n' "- verify listed child PRs target ${integration_branch:-the Epic integration branch}"
+printf '%s\n' '- merge accepted child PRs into the Epic integration branch only'
+printf '%s\n' '- do not merge final Epic work into main from this helper'
+
+printf '\nIssue / label / Project plan if accepted:\n'
+printf '%s\n' '- close accepted child issues after merge evidence is confirmed'
+printf '%s\n' '- remove stale primary next-action labels from accepted child issues'
+printf '%s\n' '- leave Project v2 unchanged in this dry-run; sync manually or with a dedicated helper'
+
+printf '\nRelease / hold note:\n'
+printf '%s\n' '- batch checkpoint: Architect decides whether to release P1/P2 after reviewing the full P0 batch'
+
+printf '\nDurable batch checkpoint comment template:\n'
+printf '%s\n' '## Batch acceptance checkpoint'
+printf '\n'
+printf 'Scope reviewed:\n'
+printf '%s\n' '- <child issues and PRs reviewed>'
+printf '\n'
+printf 'Verification:\n'
+printf '%s\n' '- <checks, files, and review evidence>'
+printf '\n'
+printf 'Decision:\n'
+printf '%s\n' '- <accept / hold / request changes>'
+printf '\n'
+printf 'Residual risks:\n'
+printf '%s\n' '- <known limits or none>'
+printf '\n'
+printf 'Next release:\n'
+printf '%s\n' '- <release next batch or hold>'
+printf '\n'
+printf 'Warning: final main integration remains separate and Architect/user-gated.\n'

--- a/tools/agents/agent-comment
+++ b/tools/agents/agent-comment
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo="${GH_REPO:-farmerhunter/tiny-ipa}"
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+gh_retry="$root/tools/agents/gh-retry"
+source "$root/tools/agents/_lib.sh"
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  tools/agents/agent-comment <issue|pr> <number> --body-file <path> [--dry-run|--apply]
+
+Previews or posts an issue/PR conversation comment using REST API paths.
+Dry-run is the default. --apply is required to write the comment.
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" || $# -lt 1 ]]; then
+  usage
+  exit 0
+fi
+
+target_type="${1:-}"
+target_number="${2:-}"
+shift 2 || {
+  usage >&2
+  exit 2
+}
+
+body_file=""
+apply=0
+
+case "$target_type" in
+  issue|pr)
+    ;;
+  *)
+    printf 'Unknown target type: %s\n' "$target_type" >&2
+    printf '%s\n' 'Use issue or pr.' >&2
+    exit 2
+    ;;
+esac
+
+require_number "$target_number" "Target number"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --body-file)
+      if [[ -z "${2:-}" ]]; then
+        printf '%s\n' '--body-file requires a path' >&2
+        exit 2
+      fi
+      body_file="$2"
+      shift 2
+      ;;
+    --dry-run)
+      apply=0
+      shift
+      ;;
+    --apply)
+      apply=1
+      shift
+      ;;
+    *)
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$body_file" ]]; then
+  printf '%s\n' '--body-file is required' >&2
+  exit 2
+fi
+if [[ ! -f "$body_file" ]]; then
+  printf 'Body file not found: %s\n' "$body_file" >&2
+  exit 2
+fi
+if ! grep -q '[^[:space:]]' "$body_file"; then
+  printf 'Body file is empty: %s\n' "$body_file" >&2
+  exit 2
+fi
+
+body="$(< "$body_file")"
+body_lines="$(wc -l < "$body_file" | tr -d ' ')"
+body_bytes="$(wc -c < "$body_file" | tr -d ' ')"
+
+target_json=""
+case "$target_type" in
+  issue)
+    target_json="$("$gh_retry" gh api "$(repo_api_path "$repo")/issues/$target_number")"
+    if jq -e 'has("pull_request")' >/dev/null <<< "$target_json"; then
+      printf 'Target #%s is a pull request; use target type pr\n' "$target_number" >&2
+      exit 2
+    fi
+    ;;
+  pr)
+    target_json="$("$gh_retry" gh api "$(repo_api_path "$repo")/pulls/$target_number")"
+    ;;
+esac
+
+title="$(jq -r '.title' <<< "$target_json")"
+url="$(jq -r '.html_url' <<< "$target_json")"
+
+printf '#%s %s\n' "$target_number" "$title"
+if [[ "$apply" -eq 1 ]]; then
+  printf 'Mode: apply\n'
+else
+  printf 'Mode: dry-run\n'
+fi
+printf 'Target: %s\n' "$target_type"
+printf 'URL: %s\n' "$url"
+printf 'Body file: %s (%s lines, %s bytes)\n' "$body_file" "$body_lines" "$body_bytes"
+
+if [[ "$apply" -eq 0 ]]; then
+  printf '\nComment preview:\n'
+  printf '%s\n' '---'
+  printf '%s\n' "$body"
+  printf '%s\n' '---'
+  printf '\nNo GitHub comment was posted. Re-run with --apply to post.\n'
+  exit 0
+fi
+
+comment_json="$("$gh_retry" gh api -X POST "$(repo_api_path "$repo")/issues/$target_number/comments" \
+  -f body="$body")"
+comment_url="$(jq -r '.html_url' <<< "$comment_json")"
+
+printf 'Posted comment: %s\n' "$comment_url"

--- a/tools/agents/agent-dogfood-report
+++ b/tools/agents/agent-dogfood-report
@@ -104,7 +104,23 @@ printf '%s\n\n' '## Dogfood report'
 print_section 'Helper commands used:' "${helpers[@]}"
 print_section 'Verification:' "${verification[@]}"
 print_section 'Durable GitHub state:' "${durable[@]}"
-print_section 'Direct-thread dispatch:' "${dispatch[@]}"
-print_section 'Fallback / manual steps:' "${fallback[@]}"
-print_section 'Manual steps reduced:' "${manual_steps[@]}"
-print_section 'Residual risks:' "${risks[@]}"
+if (( ${#dispatch[@]} == 0 )); then
+  print_section 'Direct-thread dispatch:'
+else
+  print_section 'Direct-thread dispatch:' "${dispatch[@]}"
+fi
+if (( ${#fallback[@]} == 0 )); then
+  print_section 'Fallback / manual steps:'
+else
+  print_section 'Fallback / manual steps:' "${fallback[@]}"
+fi
+if (( ${#manual_steps[@]} == 0 )); then
+  print_section 'Manual steps reduced:'
+else
+  print_section 'Manual steps reduced:' "${manual_steps[@]}"
+fi
+if (( ${#risks[@]} == 0 )); then
+  print_section 'Residual risks:'
+else
+  print_section 'Residual risks:' "${risks[@]}"
+fi

--- a/tools/agents/agent-dogfood-report
+++ b/tools/agents/agent-dogfood-report
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  tools/agents/agent-dogfood-report \
+    --helper <text> --verification <text> --durable <text> \
+    [--dispatch <text>] [--fallback <text>] [--manual-step <text>] [--risk <text>]
+
+Generates a compact explicit-input dogfood report. It does not parse arbitrary
+logs, read GitHub, or mutate state.
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" || $# -eq 0 ]]; then
+  usage
+  exit 0
+fi
+
+helpers=()
+verification=()
+durable=()
+dispatch=()
+fallback=()
+manual_steps=()
+risks=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --helper)
+      [[ -n "${2:-}" ]] || { printf '%s\n' '--helper requires text' >&2; exit 2; }
+      helpers+=("$2")
+      shift 2
+      ;;
+    --verification)
+      [[ -n "${2:-}" ]] || { printf '%s\n' '--verification requires text' >&2; exit 2; }
+      verification+=("$2")
+      shift 2
+      ;;
+    --durable)
+      [[ -n "${2:-}" ]] || { printf '%s\n' '--durable requires text' >&2; exit 2; }
+      durable+=("$2")
+      shift 2
+      ;;
+    --dispatch)
+      [[ -n "${2:-}" ]] || { printf '%s\n' '--dispatch requires text' >&2; exit 2; }
+      dispatch+=("$2")
+      shift 2
+      ;;
+    --fallback)
+      [[ -n "${2:-}" ]] || { printf '%s\n' '--fallback requires text' >&2; exit 2; }
+      fallback+=("$2")
+      shift 2
+      ;;
+    --manual-step)
+      [[ -n "${2:-}" ]] || { printf '%s\n' '--manual-step requires text' >&2; exit 2; }
+      manual_steps+=("$2")
+      shift 2
+      ;;
+    --risk)
+      [[ -n "${2:-}" ]] || { printf '%s\n' '--risk requires text' >&2; exit 2; }
+      risks+=("$2")
+      shift 2
+      ;;
+    *)
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if (( ${#helpers[@]} == 0 )); then
+  printf '%s\n' 'At least one --helper entry is required' >&2
+  exit 2
+fi
+if (( ${#verification[@]} == 0 )); then
+  printf '%s\n' 'At least one --verification entry is required' >&2
+  exit 2
+fi
+if (( ${#durable[@]} == 0 )); then
+  printf '%s\n' 'At least one --durable entry is required' >&2
+  exit 2
+fi
+
+print_section() {
+  local title="$1"
+  shift
+  local items=("$@")
+  local item
+
+  printf '%s\n' "$title"
+  if (( ${#items[@]} == 0 )); then
+    printf '%s\n' '- none'
+  else
+    for item in "${items[@]}"; do
+      printf '%s\n' "- $item"
+    done
+  fi
+  printf '\n'
+}
+
+printf '%s\n\n' '## Dogfood report'
+print_section 'Helper commands used:' "${helpers[@]}"
+print_section 'Verification:' "${verification[@]}"
+print_section 'Durable GitHub state:' "${durable[@]}"
+print_section 'Direct-thread dispatch:' "${dispatch[@]}"
+print_section 'Fallback / manual steps:' "${fallback[@]}"
+print_section 'Manual steps reduced:' "${manual_steps[@]}"
+print_section 'Residual risks:' "${risks[@]}"

--- a/tools/agents/agent-permission-smoke
+++ b/tools/agents/agent-permission-smoke
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo="${GH_REPO:-farmerhunter/tiny-ipa}"
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  tools/agents/agent-permission-smoke
+
+Checks whether the current agent turn can perform the basic non-mutating
+permissions needed before issue pickup:
+
+- read the GitHub API through gh
+- read the remote Git repository
+- write temporary Git metadata in this local checkout
+
+It does not mutate GitHub, create branches, push, or change Project state.
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+if [[ $# -gt 0 ]]; then
+  usage >&2
+  exit 2
+fi
+
+failures=0
+
+check() {
+  local label="$1"
+  shift
+
+  if "$@" >/tmp/agent-permission-smoke.out 2>/tmp/agent-permission-smoke.err; then
+    printf 'ok: %s\n' "$label"
+  else
+    printf 'fail: %s\n' "$label" >&2
+    sed 's/^/  /' /tmp/agent-permission-smoke.err >&2 || true
+    failures=$((failures + 1))
+  fi
+}
+
+check "GitHub API read via gh" gh api "repos/$repo" --jq .full_name
+check "remote Git read" git ls-remote --heads origin HEAD
+
+git_dir="$(git -C "$root" rev-parse --git-dir)"
+case "$git_dir" in
+  /*) ;;
+  *) git_dir="$root/$git_dir" ;;
+esac
+
+probe="$git_dir/codex-permission-smoke.$$"
+if { : > "$probe"; } 2>/tmp/agent-permission-smoke.err; then
+  rm -f "$probe"
+  printf 'ok: local Git metadata write\n'
+else
+  printf 'fail: local Git metadata write\n' >&2
+  sed 's/^/  /' /tmp/agent-permission-smoke.err >&2 || true
+  failures=$((failures + 1))
+fi
+
+rm -f /tmp/agent-permission-smoke.out /tmp/agent-permission-smoke.err
+
+if (( failures > 0 )); then
+  cat >&2 <<'MESSAGE'
+
+Permission smoke failed. Do not start branch/PR workflow from this turn.
+Report the permission downgrade and wait for a user turn with full GitHub
+network access and local Git metadata write permission.
+MESSAGE
+  exit 1
+fi
+
+printf 'permission smoke passed\n'

--- a/tools/agents/agent-release-queue
+++ b/tools/agents/agent-release-queue
@@ -1,0 +1,254 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo="${GH_REPO:-farmerhunter/tiny-ipa}"
+comments_limit="${AGENT_COMMENTS_LIMIT:-100}"
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+gh_retry="$root/tools/agents/gh-retry"
+source "$root/tools/agents/_lib.sh"
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  tools/agents/agent-release-queue --epic <issue> --role <role> --issue <issue>...
+
+Dry-runs dependency-gated release of selected issues into a configured role
+inbox. It does not mutate labels, comments, Project v2, issues, PRs, or main.
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" || $# -eq 0 ]]; then
+  usage
+  exit 0
+fi
+
+epic=""
+role=""
+issues=()
+apply=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --epic)
+      if [[ -z "${2:-}" ]]; then
+        printf '%s\n' '--epic requires an issue number' >&2
+        exit 2
+      fi
+      epic="$2"
+      require_number "$epic" "Epic issue"
+      shift 2
+      ;;
+    --role)
+      if [[ -z "${2:-}" ]]; then
+        printf '%s\n' '--role requires a role name' >&2
+        exit 2
+      fi
+      role="$2"
+      shift 2
+      ;;
+    --issue)
+      if [[ -z "${2:-}" ]]; then
+        printf '%s\n' '--issue requires an issue number' >&2
+        exit 2
+      fi
+      require_number "$2" "Child issue"
+      issues+=("$2")
+      shift 2
+      ;;
+    --dry-run)
+      apply=0
+      shift
+      ;;
+    --apply)
+      apply=1
+      shift
+      ;;
+    *)
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$epic" ]]; then
+  printf '%s\n' '--epic is required' >&2
+  exit 2
+fi
+if [[ -z "$role" ]]; then
+  printf '%s\n' '--role is required' >&2
+  exit 2
+fi
+if (( ${#issues[@]} == 0 )); then
+  printf '%s\n' 'At least one --issue is required' >&2
+  exit 2
+fi
+if [[ "$apply" -eq 1 ]]; then
+  printf '%s\n' '--apply is not implemented; agent-release-queue is dry-run only' >&2
+  exit 2
+fi
+
+role_label="$(agent_role_label_for_role "$role")"
+
+strip_ticks() {
+  sed -E 's/^`//; s/`$//'
+}
+
+extract_first_value() {
+  local prefix="$1"
+  local text="$2"
+
+  awk -v prefix="$prefix" '
+    index($0, prefix) == 1 {
+      sub(prefix "[[:space:]]*", "")
+      print
+      found = 1
+      exit
+    }
+    END {
+      if (!found) print ""
+    }
+  ' <<< "$text"
+}
+
+current_primary_labels() {
+  local labels="$1"
+  local next_label
+
+  while IFS= read -r next_label; do
+    [[ -z "$next_label" ]] && continue
+    if grep -Fxq "$next_label" <<< "$labels"; then
+      printf '%s\n' "$next_label"
+    fi
+  done < <(agent_primary_next_labels)
+}
+
+dependency_gate() {
+  local depends="$1"
+  local token issue_ref issue_state pr_ref pr_json pr_state merged base
+  local issue_dep_text
+  local holds=()
+
+  if [[ "$depends" == "MISSING" || -z "$depends" ]]; then
+    printf '%s\n' 'hold: missing Depends on'
+    return 1
+  fi
+  if [[ "$depends" == *"none"* ]]; then
+    printf '%s\n' 'startable'
+    return 0
+  fi
+
+  issue_dep_text="$(sed -E 's/PR #[0-9]+//g' <<< "$depends")"
+  while IFS= read -r issue_ref; do
+    [[ -z "$issue_ref" ]] && continue
+    issue_state="$("$gh_retry" gh api "$(repo_api_path "$repo")/issues/$issue_ref" --jq '.state')"
+    if [[ "$issue_state" != "closed" ]]; then
+      holds+=("#$issue_ref open")
+    fi
+  done < <(grep -Eo '#[0-9]+' <<< "$issue_dep_text" | tr -d '#' | sort -nu || true)
+
+  while IFS= read -r token; do
+    [[ -z "$token" ]] && continue
+    pr_ref="${token#PR #}"
+    pr_json="$("$gh_retry" gh api "$(repo_api_path "$repo")/pulls/$pr_ref")"
+    pr_state="$(jq -r '.state' <<< "$pr_json")"
+    merged="$(jq -r '.merged' <<< "$pr_json")"
+    base="$(jq -r '.base.ref' <<< "$pr_json")"
+    if [[ "$pr_state" != "closed" || "$merged" != "true" ]]; then
+      holds+=("PR #$pr_ref not merged")
+    elif [[ -n "$integration_branch" && "$base" != "$integration_branch" ]]; then
+      holds+=("PR #$pr_ref merged to $base, expected $integration_branch")
+    fi
+  done < <(grep -Eo 'PR #[0-9]+' <<< "$depends" | sort -u || true)
+
+  if (( ${#holds[@]} > 0 )); then
+    printf 'hold: %s\n' "$(printf '%s\n' "${holds[@]}" | agent_join_lines)"
+    return 1
+  fi
+
+  printf '%s\n' 'startable'
+}
+
+epic_json="$("$gh_retry" gh api "$(repo_api_path "$repo")/issues/$epic")"
+epic_title="$(jq -r '.title' <<< "$epic_json")"
+epic_url="$(jq -r '.html_url' <<< "$epic_json")"
+epic_body="$(jq -r '.body // ""' <<< "$epic_json")"
+integration_branch="$(extract_first_value "Integration branch:" "$epic_body" | strip_ticks)"
+if [[ -z "$integration_branch" ]]; then
+  integration_branch="$(extract_first_value "Child PR target:" "$epic_body" | strip_ticks)"
+fi
+
+printf '#%s %s\n' "$epic" "$epic_title"
+printf 'Mode: dry-run\n'
+printf 'Release role: %s (%s)\n' "$role" "$role_label"
+printf 'Epic URL: %s\n' "$epic_url"
+printf 'Integration branch: %s\n' "${integration_branch:-not detected; verify manually}"
+printf 'Final main integration: separate Architect/user-gated decision\n'
+
+printf '\nRelease candidates:\n'
+for issue in "${issues[@]}"; do
+  issue_json="$("$gh_retry" gh api "$(repo_api_path "$repo")/issues/$issue")"
+  title="$(jq -r '.title' <<< "$issue_json")"
+  state="$(jq -r '.state' <<< "$issue_json")"
+  url="$(jq -r '.html_url' <<< "$issue_json")"
+  labels="$(jq -r '[.labels[].name] | join("\n")' <<< "$issue_json")"
+  label_text="$(jq -r '[.labels[].name] | join(", ")' <<< "$issue_json")"
+  body="$(jq -r '.body // ""' <<< "$issue_json")"
+  comments="$("$gh_retry" gh api -X GET "$(repo_api_path "$repo")/issues/$issue/comments" \
+    -f per_page="$comments_limit" \
+    --jq '[.[].body] | join("\n")')"
+  contract="$(extract_latest_contract_block "$body"$'\n'"$comments")"
+  target_base="$(extract_contract_value "Target PR base:" "$contract" | strip_ticks)"
+  depends="$(extract_contract_value "Depends on:" "$contract")"
+  gate="$(dependency_gate "$depends")" || true
+  current_primary="$(current_primary_labels "$labels")"
+
+  printf '%s\n' "- Issue #$issue $title"
+  printf '  state: %s\n' "$state"
+  printf '  url: %s\n' "$url"
+  printf '  labels: %s\n' "$label_text"
+  printf '  target PR base: %s\n' "$target_base"
+  printf '  depends on: %s\n' "$depends"
+  printf '  gate: %s\n' "$gate"
+  printf '  planned scheduler changes:\n'
+  if [[ "$gate" == startable ]]; then
+    if [[ -n "$current_primary" ]]; then
+      while IFS= read -r next_label; do
+        [[ -z "$next_label" ]] && continue
+        [[ "$next_label" == "$role_label" ]] && continue
+        printf '    - remove %s\n' "$next_label"
+      done <<< "$current_primary"
+    else
+      printf '%s\n' '    - no current primary next-action label to remove'
+    fi
+    if grep -Fxq "$role_label" <<< "$labels"; then
+      printf '    - keep %s\n' "$role_label"
+    else
+      printf '    - add %s\n' "$role_label"
+    fi
+    printf '%s\n' '    - post release comment'
+  else
+    printf '%s\n' '    - no label changes while held'
+    printf '%s\n' '    - post hold note if release is deferred'
+  fi
+  printf '%s\n' '    - Project v2 sync is secondary and not part of this dry-run'
+done
+
+printf '\nRelease comment template:\n'
+printf '%s\n' '## Architect release'
+printf '\n'
+printf 'Released to: %s (%s)\n' "$role" "$role_label"
+printf 'Epic: #%s\n' "$epic"
+printf '\n'
+printf 'Issues:\n'
+for issue in "${issues[@]}"; do
+  printf '%s\n' "- #$issue"
+done
+printf '\n'
+printf 'Dependency gate:\n'
+printf '%s\n' '- <startable or hold reason>'
+printf '\n'
+printf 'Residual risks:\n'
+printf '%s\n' '- <known limits or none>'
+
+printf '\nDogfood note:\n'
+printf '%s\n' '- This helper would consolidate release comments, next-action label planning, dependency holds, and Project sync decisions into one dry-run report.'

--- a/tools/agents/test-agent-comment
+++ b/tools/agents/test-agent-comment
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+fixture_root="$tmp_dir/fixture-root"
+mkdir -p "$fixture_root/tools/agents"
+ln -s "$root/tools/agents/_lib.sh" "$fixture_root/tools/agents/_lib.sh"
+ln -s "$root/tools/agents/agent-comment" "$fixture_root/tools/agents/agent-comment"
+
+cat > "$fixture_root/tools/agents/gh-retry" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "$*" in
+  *"POST"*"issues/1/comments"*)
+    jq -n '{html_url:"https://example.test/issues/1#comment"}'
+    ;;
+  *"POST"*"issues/2/comments"*)
+    jq -n '{html_url:"https://example.test/pull/2#comment"}'
+    ;;
+  *"POST"*"issues/3/comments"*)
+    printf 'write failed\n' >&2
+    exit 22
+    ;;
+  *"/issues/1"*)
+    jq -n '{number:1,title:"Issue one",html_url:"https://example.test/issues/1"}'
+    ;;
+  *"/issues/2"*)
+    jq -n '{number:2,title:"PR issue shell",html_url:"https://example.test/issues/2",pull_request:{url:"https://api.example.test/pulls/2"}}'
+    ;;
+  *"/issues/3"*)
+    jq -n '{number:3,title:"Write failure",html_url:"https://example.test/issues/3"}'
+    ;;
+  *"/pulls/2"*)
+    jq -n '{number:2,title:"Pull two",html_url:"https://example.test/pull/2"}'
+    ;;
+  *)
+    printf 'unexpected fake gh call: %s\n' "$*" >&2
+    exit 21
+    ;;
+esac
+SH
+chmod +x "$fixture_root/tools/agents/gh-retry"
+
+body_file="$tmp_dir/comment.md"
+empty_file="$tmp_dir/empty.md"
+missing_file="$tmp_dir/missing.md"
+printf 'hello from fixture\nsecond line\n' > "$body_file"
+printf '   \n' > "$empty_file"
+
+issue_dry="$("$fixture_root/tools/agents/agent-comment" issue 1 --body-file "$body_file")"
+grep -Fq "Mode: dry-run" <<< "$issue_dry"
+grep -Fq "Target: issue" <<< "$issue_dry"
+grep -Fq "hello from fixture" <<< "$issue_dry"
+grep -Fq "No GitHub comment was posted" <<< "$issue_dry"
+
+pr_dry="$("$fixture_root/tools/agents/agent-comment" pr 2 --body-file "$body_file" --dry-run)"
+grep -Fq "Target: pr" <<< "$pr_dry"
+grep -Fq "Pull two" <<< "$pr_dry"
+
+issue_apply="$("$fixture_root/tools/agents/agent-comment" issue 1 --body-file "$body_file" --apply)"
+grep -Fq "Mode: apply" <<< "$issue_apply"
+grep -Fq "Posted comment: https://example.test/issues/1#comment" <<< "$issue_apply"
+
+if "$fixture_root/tools/agents/agent-comment" discussion 1 --body-file "$body_file" >/dev/null 2>&1; then
+  printf 'unknown target unexpectedly succeeded\n' >&2
+  exit 1
+fi
+
+if "$fixture_root/tools/agents/agent-comment" issue 1 --body-file "$missing_file" >/dev/null 2>&1; then
+  printf 'missing body file unexpectedly succeeded\n' >&2
+  exit 1
+fi
+
+if "$fixture_root/tools/agents/agent-comment" issue 1 --body-file "$empty_file" >/dev/null 2>&1; then
+  printf 'empty body file unexpectedly succeeded\n' >&2
+  exit 1
+fi
+
+if "$fixture_root/tools/agents/agent-comment" issue 2 --body-file "$body_file" >/dev/null 2>&1; then
+  printf 'issue target for PR unexpectedly succeeded\n' >&2
+  exit 1
+fi
+
+if "$fixture_root/tools/agents/agent-comment" issue 3 --body-file "$body_file" --apply >/dev/null 2>&1; then
+  printf 'failed REST write unexpectedly succeeded\n' >&2
+  exit 1
+fi
+
+printf 'agent-comment fixture checks passed\n'

--- a/tools/agents/test-batch-accept
+++ b/tools/agents/test-batch-accept
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+fixture_root="$tmp_dir/fixture-root"
+mkdir -p "$fixture_root/tools/agents"
+ln -s "$root/tools/agents/_lib.sh" "$fixture_root/tools/agents/_lib.sh"
+ln -s "$root/tools/agents/agent-batch-accept" "$fixture_root/tools/agents/agent-batch-accept"
+
+cat > "$fixture_root/tools/agents/gh-retry" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+issue_json() {
+  local number="$1"
+  local title="$2"
+  local body="$3"
+  local labels="$4"
+
+  jq -n \
+    --argjson number "$number" \
+    --arg title "$title" \
+    --arg body "$body" \
+    --arg labels "$labels" \
+    '{
+      number: $number,
+      title: $title,
+      state: "open",
+      html_url: ("https://example.test/issues/" + ($number | tostring)),
+      body: $body,
+      labels: ($labels | split(",") | map(select(length > 0) | {name: .}))
+    }'
+}
+
+contract() {
+  local handoff="${1:-batch checkpoint}"
+  printf '## Execution Contract\n\nOwner role: implementer\nReview role: reviewer\nAcceptance role: architect\nBranch strategy: epic integration branch\nBase branch: `epic/83-helper-dogfood-follow-up`\nTarget PR base: `epic/83-helper-dogfood-follow-up`\nDepends on: none\nCompletion handoff: %s\n' "$handoff"
+}
+
+case "$*" in
+  *"/issues/83"*)
+    issue_json 83 "Epic" $'## Epic Execution Contract\n\nIntegration branch: `epic/83-helper-dogfood-follow-up`\nChild PR target: `epic/83-helper-dogfood-follow-up`\n' "type:epic"
+    ;;
+  *"/issues/86/comments"*|*"/issues/87/comments"*)
+    printf '[]\n'
+    ;;
+  *"/issues/86"*)
+    issue_json 86 "Comment helper" "$(contract)" "type:task"
+    ;;
+  *"/issues/87"*)
+    issue_json 87 "Batch helper" "$(contract)" "type:task"
+    ;;
+  *"/pulls"*"state=open"*)
+    jq -n '[{
+      number: 101,
+      title: "[#86] Add agent-comment",
+      body: "Closes #86",
+      state: "open",
+      draft: false,
+      html_url: "https://example.test/pull/101",
+      base: {ref: "epic/83-helper-dogfood-follow-up"},
+      head: {ref: "agent/86-comment", sha: "abc123"}
+    }]'
+    ;;
+  *"/pulls/101/files"*)
+    jq -n '[{status:"added",filename:"tools/agents/agent-comment",additions:120,deletions:0}]'
+    ;;
+  *"/commits/abc123/status"*)
+    jq -n '{state:"success",total_count:1}'
+    ;;
+  *"/pulls/101"*)
+    jq -n '{
+      number: 101,
+      title: "[#86] Add agent-comment",
+      body: "Closes #86",
+      state: "open",
+      draft: false,
+      html_url: "https://example.test/pull/101",
+      base: {ref: "epic/83-helper-dogfood-follow-up"},
+      head: {ref: "agent/86-comment", sha: "abc123"}
+    }'
+    ;;
+  *)
+    printf 'unexpected fake gh call: %s\n' "$*" >&2
+    exit 21
+    ;;
+esac
+SH
+chmod +x "$fixture_root/tools/agents/gh-retry"
+
+batch_output="$("$fixture_root/tools/agents/agent-batch-accept" --epic 83 --issue 86 --issue 87)"
+grep -Fq "Mode: dry-run" <<< "$batch_output"
+grep -Fq "Integration branch: epic/83-helper-dogfood-follow-up" <<< "$batch_output"
+grep -Fq "Final main integration: separate Architect/user-gated decision" <<< "$batch_output"
+grep -Fq "Issue #86 Comment helper" <<< "$batch_output"
+grep -Fq "open PR candidate: #101" <<< "$batch_output"
+grep -Fq "Issue #87 Batch helper" <<< "$batch_output"
+grep -Fq "open PR candidate: none detected" <<< "$batch_output"
+grep -Fq "PR #101 [#86] Add agent-comment" <<< "$batch_output"
+grep -Fq "base: epic/83-helper-dogfood-follow-up; head: agent/86-comment" <<< "$batch_output"
+grep -Fq "linked issues: #86" <<< "$batch_output"
+grep -Fq "added tools/agents/agent-comment +120/-0" <<< "$batch_output"
+grep -Fq "check/status hint: success (1 contexts)" <<< "$batch_output"
+grep -Fq "merge accepted child PRs into the Epic integration branch only" <<< "$batch_output"
+grep -Fq "Batch acceptance checkpoint" <<< "$batch_output"
+
+pr_output="$("$fixture_root/tools/agents/agent-batch-accept" --epic 83 --pr 101)"
+grep -Fq "Pull requests:" <<< "$pr_output"
+grep -Fq "PR #101 [#86] Add agent-comment" <<< "$pr_output"
+
+if "$fixture_root/tools/agents/agent-batch-accept" --epic 83 --issue 86 --apply >/dev/null 2>&1; then
+  printf 'apply unexpectedly succeeded\n' >&2
+  exit 1
+fi
+
+if "$fixture_root/tools/agents/agent-batch-accept" --epic 83 >/dev/null 2>&1; then
+  printf 'empty batch unexpectedly succeeded\n' >&2
+  exit 1
+fi
+
+if "$fixture_root/tools/agents/agent-batch-accept" --epic x --issue 86 >/dev/null 2>&1; then
+  printf 'non-numeric epic unexpectedly succeeded\n' >&2
+  exit 1
+fi
+
+printf 'batch-accept fixture checks passed\n'

--- a/tools/agents/test-batch-accept
+++ b/tools/agents/test-batch-accept
@@ -57,7 +57,7 @@ case "$*" in
     jq -n '[{
       number: 101,
       title: "[#86] Add agent-comment",
-      body: "Closes #86",
+      body: "Refs #83 and closes #86. Follow-up from PR #101.",
       state: "open",
       draft: false,
       html_url: "https://example.test/pull/101",
@@ -75,7 +75,7 @@ case "$*" in
     jq -n '{
       number: 101,
       title: "[#86] Add agent-comment",
-      body: "Closes #86",
+      body: "Refs #83 and closes #86. Follow-up from PR #101.",
       state: "open",
       draft: false,
       html_url: "https://example.test/pull/101",
@@ -101,7 +101,8 @@ grep -Fq "Issue #87 Batch helper" <<< "$batch_output"
 grep -Fq "open PR candidate: none detected" <<< "$batch_output"
 grep -Fq "PR #101 [#86] Add agent-comment" <<< "$batch_output"
 grep -Fq "base: epic/83-helper-dogfood-follow-up; head: agent/86-comment" <<< "$batch_output"
-grep -Fq "linked issues: #86" <<< "$batch_output"
+grep -Fq "linked issues: #83, #86" <<< "$batch_output"
+! grep -Fq "linked issues: #83, #86, #101" <<< "$batch_output"
 grep -Fq "added tools/agents/agent-comment +120/-0" <<< "$batch_output"
 grep -Fq "check/status hint: success (1 contexts)" <<< "$batch_output"
 grep -Fq "merge accepted child PRs into the Epic integration branch only" <<< "$batch_output"

--- a/tools/agents/test-dogfood-report
+++ b/tools/agents/test-dogfood-report
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+report="$("$root/tools/agents/agent-dogfood-report" \
+  --helper "agent-inbox implementer: #89/#90" \
+  --verification "tools/agents/test-release-queue: passed" \
+  --durable "PR #91" \
+  --dispatch "source thread ping only" \
+  --fallback "none" \
+  --manual-step "release comments and labels planned together" \
+  --risk "Project sync remains manual")"
+
+grep -Fq "## Dogfood report" <<< "$report"
+grep -Fq "Helper commands used:" <<< "$report"
+grep -Fq "agent-inbox implementer: #89/#90" <<< "$report"
+grep -Fq "Verification:" <<< "$report"
+grep -Fq "Durable GitHub state:" <<< "$report"
+grep -Fq "Direct-thread dispatch:" <<< "$report"
+grep -Fq "Fallback / manual steps:" <<< "$report"
+grep -Fq "Manual steps reduced:" <<< "$report"
+grep -Fq "Residual risks:" <<< "$report"
+grep -Fq "Project sync remains manual" <<< "$report"
+
+minimal="$("$root/tools/agents/agent-dogfood-report" \
+  --helper "agent-audit: clean" \
+  --verification "bash -n: passed" \
+  --durable "issue #90")"
+grep -Fq "Direct-thread dispatch:" <<< "$minimal"
+grep -Fq -- "- none" <<< "$minimal"
+grep -Fq "Residual risks:" <<< "$minimal"
+
+if "$root/tools/agents/agent-dogfood-report" --helper "x" --durable "issue #90" >/dev/null 2>&1; then
+  printf 'missing verification unexpectedly succeeded\n' >&2
+  exit 1
+fi
+
+if "$root/tools/agents/agent-dogfood-report" --verification "x" --durable "issue #90" >/dev/null 2>&1; then
+  printf 'missing helper unexpectedly succeeded\n' >&2
+  exit 1
+fi
+
+if "$root/tools/agents/agent-dogfood-report" --helper "x" --verification "x" >/dev/null 2>&1; then
+  printf 'missing durable state unexpectedly succeeded\n' >&2
+  exit 1
+fi
+
+printf 'dogfood-report fixture checks passed\n'

--- a/tools/agents/test-release-queue
+++ b/tools/agents/test-release-queue
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+fixture_root="$tmp_dir/fixture-root"
+mkdir -p "$fixture_root/tools/agents"
+ln -s "$root/tools/agents/_lib.sh" "$fixture_root/tools/agents/_lib.sh"
+ln -s "$root/tools/agents/agent-release-queue" "$fixture_root/tools/agents/agent-release-queue"
+ln -s "$root/tools/agents/role-routing.conf" "$fixture_root/tools/agents/role-routing.conf"
+
+cat > "$fixture_root/tools/agents/gh-retry" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+issue_json() {
+  local number="$1"
+  local title="$2"
+  local state="$3"
+  local body="$4"
+  local labels="$5"
+
+  jq -n \
+    --argjson number "$number" \
+    --arg title "$title" \
+    --arg state "$state" \
+    --arg body "$body" \
+    --arg labels "$labels" \
+    '{
+      number: $number,
+      title: $title,
+      state: $state,
+      html_url: ("https://example.test/issues/" + ($number | tostring)),
+      body: $body,
+      labels: ($labels | split(",") | map(select(length > 0) | {name: .}))
+    }'
+}
+
+contract() {
+  local depends="$1"
+  printf '## Execution Contract\n\nOwner role: implementer\nReview role: reviewer\nAcceptance role: architect\nBranch strategy: epic integration branch\nBase branch: `epic/83-helper-dogfood-follow-up`\nTarget PR base: `epic/83-helper-dogfood-follow-up`\nDepends on: %s\nCompletion handoff: batch checkpoint\n' "$depends"
+}
+
+case "$*" in
+  *"/issues/83"*)
+    issue_json 83 "Epic" open $'Integration branch: `epic/83-helper-dogfood-follow-up`\n' "type:epic"
+    ;;
+  *"/issues/86"*"--jq .state"*|*"/issues/87"*"--jq .state"*)
+    printf 'closed\n'
+    ;;
+  *"/issues/88"*"--jq .state"*)
+    printf 'open\n'
+    ;;
+  *"/issues/89/comments"*|*"/issues/90/comments"*|*"/issues/91/comments"*)
+    printf '[]\n'
+    ;;
+  *"/issues/89"*)
+    issue_json 89 "Release helper" open "$(contract "#86, #87, PR #88 merged into Epic branch")" "type:task"
+    ;;
+  *"/issues/90"*)
+    issue_json 90 "Already routed" open "$(contract none)" "type:task,needs:implementer"
+    ;;
+  *"/issues/91"*)
+    issue_json 91 "Blocked helper" open "$(contract "#88")" "type:task"
+    ;;
+  *"/pulls/88"*)
+    jq -n '{number:88,state:"closed",merged:true,base:{ref:"epic/83-helper-dogfood-follow-up"}}'
+    ;;
+  *)
+    printf 'unexpected fake gh call: %s\n' "$*" >&2
+    exit 21
+    ;;
+esac
+SH
+chmod +x "$fixture_root/tools/agents/gh-retry"
+
+release_output="$("$fixture_root/tools/agents/agent-release-queue" --epic 83 --role implementer --issue 89 --issue 90)"
+grep -Fq "Mode: dry-run" <<< "$release_output"
+grep -Fq "Release role: implementer (needs:implementer)" <<< "$release_output"
+grep -Fq "Issue #89 Release helper" <<< "$release_output"
+grep -Fq "gate: startable" <<< "$release_output"
+grep -Fq "add needs:implementer" <<< "$release_output"
+grep -Fq "Issue #90 Already routed" <<< "$release_output"
+grep -Fq "keep needs:implementer" <<< "$release_output"
+grep -Fq "Project v2 sync is secondary" <<< "$release_output"
+grep -Fq "Release comment template:" <<< "$release_output"
+
+blocked_output="$("$fixture_root/tools/agents/agent-release-queue" --epic 83 --role implementer --issue 91)"
+grep -Fq "Issue #91 Blocked helper" <<< "$blocked_output"
+grep -Fq "gate: hold: #88 open" <<< "$blocked_output"
+grep -Fq "no label changes while held" <<< "$blocked_output"
+
+if "$fixture_root/tools/agents/agent-release-queue" --epic 83 --role ghost --issue 89 >/dev/null 2>&1; then
+  printf 'unknown role unexpectedly succeeded\n' >&2
+  exit 1
+fi
+
+if "$fixture_root/tools/agents/agent-release-queue" --epic 83 --role implementer --issue 89 --apply >/dev/null 2>&1; then
+  printf 'apply unexpectedly succeeded\n' >&2
+  exit 1
+fi
+
+if "$fixture_root/tools/agents/agent-release-queue" --epic 83 --role implementer >/dev/null 2>&1; then
+  printf 'empty release unexpectedly succeeded\n' >&2
+  exit 1
+fi
+
+printf 'release-queue fixture checks passed\n'


### PR DESCRIPTION
## Summary

- Integrate #83 helper dogfood tooling into `main`.
- Add REST-first agent comment, batch acceptance, release queue, dogfood report, and delegated permission smoke helpers.
- Add fixture tests and update multi-agent workflow / development docs.

## Verification

Architect final checkpoint re-run on `origin/epic/83-helper-dogfood-follow-up`:

- `tools/agents/test-agent-comment`: passed
- `tools/agents/test-batch-accept`: passed
- `tools/agents/test-release-queue`: passed
- `tools/agents/test-dogfood-report`: passed
- `bash -n tools/agents/agent-permission-smoke`: passed
- `tools/agents/agent-permission-smoke`: passed
- `git diff --check origin/main...origin/epic/83-helper-dogfood-follow-up`: passed
- `tools/agents/agent-audit`: clean
- leftover `.git/codex-permission-smoke.*` probes: none

## Durable Evidence

- Epic: #83
- Final checkpoint: https://github.com/farmerhunter/tiny-ipa/issues/83#issuecomment-4701432874
- #93 follow-up closure: https://github.com/farmerhunter/tiny-ipa/issues/93#issuecomment-4701428398

## Boundaries

- This PR targets `main`, but final merge remains explicitly gated.
- P2 / harvest follow-up is not released in this PR.
- Project state is not mutated by this PR.

## Residual Risks

- `agent-batch-accept` reports REST status contexts only, not full Checks API check-runs.
- `agent-release-queue` remains dry-run oriented for release/Project mutation safety.
