### PR TITLE
tools: add agent-dispatch-note helper

### DIFF
--- a/tools/agents/README.md
+++ b/tools/agents/README.md
@@ -28,6 +28,8 @@ tools/agents/agent-comment issue 86 --body-file /tmp/comment.md
 tools/agents/agent-batch-accept --epic 83 --issue 86 --issue 87
 tools/agents/agent-release-queue --epic 83 --role implementer --issue 89 --issue 90
 tools/agents/agent-dogfood-report --helper "agent-audit: clean" --verification "tests passed" --durable "PR #91"
+tools/agents/agent-dispatch-note --issue 89 --from implementer --to reviewer
+tools/agents/agent-dispatch-note --batch --epic 83 --to architect --child 89 --child 90 --from implementer
 tools/agents/agent-audit
 ```
 
@@ -110,6 +112,11 @@ Project v2, issues, PRs, or `main`.
 sections for helper commands used, verification, durable GitHub state,
 direct-thread dispatch, fallback/manual work, manual steps reduced, and residual
 risks. It deliberately does not parse arbitrary terminal logs or infer success.
+
+`agent-dispatch-note` is explicit-input only. It prints a bounded dispatch note
+for direct-thread acceleration only. It resolves roles/labels through role routing,
+fetches durable context (subject title/state/link) from GitHub REST, and emits a
+copy/paste thread note that must not be used as the source of truth.
 
 `agent-audit` is a read-only consistency check. It looks for common workflow
 drift without touching GitHub Project v2:

--- a/tools/agents/agent-dispatch-note
+++ b/tools/agents/agent-dispatch-note
@@ -1,0 +1,241 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo="${GH_REPO:-farmerhunter/tiny-ipa}"
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+gh_retry="$root/tools/agents/gh-retry"
+source "$root/tools/agents/_lib.sh"
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  tools/agents/agent-dispatch-note --issue <issue> --to <role|label> [--from <role|label>] [--reason <text>]
+  tools/agents/agent-dispatch-note --pr <pr> --to <role|label> [--from <role|label>] [--reason <text>]
+  tools/agents/agent-dispatch-note --batch --epic <issue> --to <role|label> [--child <issue>...] [--from <role|label>] [--reason <text>]
+
+Generates a bounded dispatch prompt for direct-thread acceleration. This helper only
+prints the durable-boundary note and does not call thread APIs.
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" || $# -eq 0 ]]; then
+  usage
+  exit 0
+fi
+
+target_type=""
+target_ref=""
+epic=""
+to_target=""
+from_target=""
+reason="handoff to next role"
+children=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --issue)
+      if [[ -z "${2:-}" ]]; then
+        printf '%s\n' '--issue requires an issue number' >&2
+        exit 2
+      fi
+      if [[ "$target_type" == "pr" || "$target_type" == "batch" ]]; then
+        printf '%s\n' 'Use --issue alone, or use --batch with --child for multiple durable references' >&2
+        exit 2
+      fi
+      target_type="issue"
+      target_ref="$2"
+      require_number "$target_ref" "Issue"
+      shift 2
+      ;;
+    --pr)
+      if [[ -z "${2:-}" ]]; then
+        printf '%s\n' '--pr requires a pull request number' >&2
+        exit 2
+      fi
+      if [[ "$target_type" == "issue" || "$target_type" == "batch" ]]; then
+        printf '%s\n' 'Use --pr alone, or use --batch with --child for multiple durable references' >&2
+        exit 2
+      fi
+      target_type="pr"
+      target_ref="$2"
+      require_number "$target_ref" "Pull request"
+      shift 2
+      ;;
+    --batch)
+      if [[ -n "$target_type" && "$target_type" != "batch" ]]; then
+        printf '%s\n' 'Do not mix --batch with --issue or --pr' >&2
+        exit 2
+      fi
+      target_type="batch"
+      shift
+      ;;
+    --epic)
+      if [[ -z "${2:-}" ]]; then
+        printf '%s\n' '--epic requires an issue number' >&2
+        exit 2
+      fi
+      epic="$2"
+      require_number "$epic" "Epic"
+      shift 2
+      ;;
+    --child)
+      if [[ -z "${2:-}" ]]; then
+        printf '%s\n' '--child requires an issue number' >&2
+        exit 2
+      fi
+      children+=("$2")
+      require_number "$2" "Child issue"
+      shift 2
+      ;;
+    --to)
+      if [[ -z "${2:-}" ]]; then
+        printf '%s\n' '--to requires a role or label' >&2
+        exit 2
+      fi
+      to_target="$2"
+      shift 2
+      ;;
+    --from)
+      if [[ -z "${2:-}" ]]; then
+        printf '%s\n' '--from requires a role or label' >&2
+        exit 2
+      fi
+      from_target="$2"
+      shift 2
+      ;;
+    --reason)
+      if [[ -z "${2:-}" ]]; then
+        printf '%s\n' '--reason requires text' >&2
+        exit 2
+      fi
+      reason="$2"
+      shift 2
+      ;;
+    *)
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$target_type" ]]; then
+  printf '%s\n' 'One of --issue, --pr, or --batch is required' >&2
+  exit 2
+fi
+
+if [[ -z "$to_target" ]]; then
+  printf '%s\n' '--to is required' >&2
+  exit 2
+fi
+
+to_label="$(agent_label_for_inbox_target "$to_target")" || exit 2
+if [[ -n "$from_target" ]]; then
+  from_label="$(agent_label_for_inbox_target "$from_target")" || exit 2
+fi
+
+format_dispatch_payload() {
+  local from_display="$1"
+  local to_display="$2"
+  local subject_type="$3"
+  local subject_ref="$4"
+  local subject_title="$5"
+  local subject_url="$6"
+  local summary="$7"
+  local durable_text="$8"
+  shift 8
+  local context_lines=("$@")
+
+  cat <<EOF
+## Direct-thread dispatch (acceleration note only)
+
+Do not use this as the durable source of truth.
+Use durable GitHub issue/PR/Project state for state transitions.
+
+Bounded dispatch:
+- Subject: $subject_type #$subject_ref
+- Durable artifact: $subject_url
+- Subject title: $subject_title
+- From: $from_display
+- To: $to_display
+- Reason: $reason
+- Expected result: $summary
+
+Copy/paste thread note:
+\`\`\`
+Dispatching boundedly for durable artifact: $durable_text
+- From: $from_display
+- To: $to_display
+- Reason: $reason
+EOF
+if (( ${#context_lines[@]} > 0 )); then
+  printf '%s\n' "- Context:"
+  printf '  %s\n' "${context_lines[@]/#/ - }"
+fi
+cat <<'EOF'
+- Durable confirm:
+  open this artifact in GitHub and process to the target role's queue
+- Non-goal:
+  this note is only for acceleration, not for durable state
+\`\`\`
+
+EOF
+}
+
+context_lines=()
+
+case "$target_type" in
+  issue)
+    issue_json="$("$gh_retry" gh api "$(repo_api_path "$repo")/issues/$target_ref")"
+    title="$(jq -r '.title' <<< "$issue_json")"
+    url="$(jq -r '.html_url' <<< "$issue_json")"
+    state="$(jq -r '.state' <<< "$issue_json")"
+    context_lines=(
+      "Title: $title"
+      "State: $state"
+      "Link: $url"
+    )
+    format_dispatch_payload "${from_label:-${from_target:-<not set>}}" "$to_label" "issue" "$target_ref" "$title" "$url" "release next-step to $to_label" "Issue #$target_ref" "${context_lines[@]}"
+    ;;
+  pr)
+    pr_json="$("$gh_retry" gh api "$(repo_api_path "$repo")/pulls/$target_ref")"
+    title="$(jq -r '.title' <<< "$pr_json")"
+    url="$(jq -r '.html_url' <<< "$pr_json")"
+    state="$(jq -r '.state' <<< "$pr_json")"
+    draft="$(jq -r '.draft' <<< "$pr_json")"
+    context_lines=(
+      "Title: $title"
+      "State: $state"
+      "Draft: $draft"
+      "Link: $url"
+    )
+    format_dispatch_payload "${from_label:-${from_target:-<not set>}}" "$to_label" "PR" "$target_ref" "$title" "$url" "handoff PR work to $to_label" "PR #$target_ref" "${context_lines[@]}"
+    ;;
+  batch)
+    if [[ -z "$epic" ]]; then
+      printf '%s\n' '--epic is required when using --batch' >&2
+      exit 2
+    fi
+    if (( ${#children[@]} == 0 )); then
+      printf '%s\n' '--batch requires at least one --child' >&2
+      exit 2
+    fi
+    epic_json="$("$gh_retry" gh api "$(repo_api_path "$repo")/issues/$epic")"
+    epic_title="$(jq -r '.title' <<< "$epic_json")"
+    epic_url="$(jq -r '.html_url' <<< "$epic_json")"
+    context_lines=(
+      "Epic: #$epic $epic_title"
+      "Epic URL: $epic_url"
+    )
+    child_refs=()
+    for child in "${children[@]}"; do
+      child_json="$("$gh_retry" gh api "$(repo_api_path "$repo")/issues/$child")"
+      child_title="$(jq -r '.title' <<< "$child_json")"
+      child_state="$(jq -r '.state' <<< "$child_json")"
+      child_url="$(jq -r '.html_url' <<< "$child_json")"
+      child_refs+=("#$child")
+      context_lines+=("Child: #$child $child_title ($child_state) -> $child_url")
+    done
+    context_lines+=( "Child set: $(printf '%s ' "${child_refs[@]}")")
+    format_dispatch_payload "${from_label:-${from_target:-<not set>}}" "$to_label" "batch checkpoint" "$epic" "$epic_title" "$epic_url" "advance the batch to next role in one bounded handoff" "Epic checkpoint #$epic" "${context_lines[@]}"
+    ;;
+esac

--- a/tools/agents/test-dispatch-note
+++ b/tools/agents/test-dispatch-note
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+fixture_root="$tmp_dir/fixture-root"
+mkdir -p "$fixture_root/tools/agents"
+ln -s "$root/tools/agents/_lib.sh" "$fixture_root/tools/agents/_lib.sh"
+ln -s "$root/tools/agents/agent-dispatch-note" "$fixture_root/tools/agents/agent-dispatch-note"
+
+cat > "$fixture_root/tools/agents/gh-retry" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "$*" in
+  *"/issues/101"*)
+    jq -n '{title:"Issue note",state:"open",html_url:"https://example.test/issues/101"}'
+    ;;
+  *"/pulls/202"*)
+    jq -n '{number:202,title:"PR note",state:"open",draft:false,html_url:"https://example.test/pull/202"}'
+    ;;
+  *"/issues/203"*)
+    jq -n '{title:"Batch epic",state:"open",html_url:"https://example.test/issues/203"}'
+    ;;
+  *"/issues/11"*)
+    jq -n '{title:"Child one",state:"closed",html_url:"https://example.test/issues/11"}'
+    ;;
+  *"/issues/22"*)
+    jq -n '{title:"Child two",state:"open",html_url:"https://example.test/issues/22"}'
+    ;;
+  *)
+    printf 'unexpected fake gh call: %s\n' "$*" >&2
+    exit 21
+    ;;
+esac
+SH
+chmod +x "$fixture_root/tools/agents/gh-retry"
+
+issue_output="$("$fixture_root/tools/agents/agent-dispatch-note" --issue 101 --from architect --to reviewer)"
+grep -Fq "Bounded dispatch:" <<< "$issue_output"
+grep -Fq "Subject: issue #101" <<< "$issue_output"
+grep -Fq "From: needs:architect" <<< "$issue_output"
+grep -Fq "To: needs:reviewer" <<< "$issue_output"
+grep -Fq -- "- Context:" <<< "$issue_output"
+grep -Fq "Title: Issue note" <<< "$issue_output"
+grep -Fq "Expected result: release next-step to needs:reviewer" <<< "$issue_output"
+grep -Fq "Dispatching boundedly for durable artifact: Issue #101" <<< "$issue_output"
+
+pr_output="$("$fixture_root/tools/agents/agent-dispatch-note" --pr 202 --from implementer --to reviewer)"
+grep -Fq "Subject: PR #202" <<< "$pr_output"
+grep -Fq "From: needs:implementer" <<< "$pr_output"
+grep -Fq "Expected result: handoff PR work to needs:reviewer" <<< "$pr_output"
+
+batch_output="$("$fixture_root/tools/agents/agent-dispatch-note" --batch --epic 203 --to architect --child 11 --child 22)"
+grep -Fq "Subject: batch checkpoint #203" <<< "$batch_output"
+grep -Fq "To: needs:architect" <<< "$batch_output"
+grep -Fq "Epic: #203 Batch epic" <<< "$batch_output"
+grep -Fq "Child: #11 Child one" <<< "$batch_output"
+grep -Fq "Child: #22 Child two" <<< "$batch_output"
+grep -Fq "Child set: #11 #22" <<< "$batch_output"
+
+if "$fixture_root/tools/agents/agent-dispatch-note" --batch --epic 203 --to reviewer >/dev/null 2>&1; then
+  printf 'batch without child unexpectedly succeeded\n' >&2
+  exit 1
+fi
+
+if "$fixture_root/tools/agents/agent-dispatch-note" --issue 101 --to unknown-role >/dev/null 2>&1; then
+  printf 'unknown target unexpectedly succeeded\n' >&2
+  exit 1
+fi
+
+if "$fixture_root/tools/agents/agent-dispatch-note" --issue 101 >/dev/null 2>&1; then
+  printf '--to missing unexpectedly succeeded\n' >&2
+  exit 1
+fi
+
+printf 'agent-dispatch-note fixture checks passed\n'


### PR DESCRIPTION
## 变更说明\n- 新增 tools/agents/agent-dispatch-note：生成 bounded direct-thread acceleration note，支持 --issue/--pr/--batch\n- 新增 tools/agents/test-dispatch-note：回归测试覆盖 issue/pr/batch、错误路径\n- 更新 tools/agents/README.md：补充使用示例与工具说明\n\n## 验证\n- bash -n tools/agents/agent-dispatch-note tools/agents/test-dispatch-note\n- tools/agents/test-agent-comment\n- tools/agents/test-batch-accept\n- tools/agents/test-handoff\n- tools/agents/test-pickup\n- tools/agents/test-ready-queue\n- tools/agents/test-release-queue\n- tools/agents/test-dogfood-report\n- tools/agents/test-dispatch-note\n- tools/agents/test-agent-audit