### PR TITLE
frontend: extract normalizeApiError helper in api.ts

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -5,6 +5,31 @@
 
 const API_BASE = import.meta.env.VITE_API_BASE ?? "/api";
 
+/**
+ * Normalises FastAPI structured errors into a user-friendly string.
+ * Handles { detail: string | { error, detail } } and bare string bodies,
+ * falling back to `Request failed (HTTP <status>)` on parse failure.
+ */
+async function normalizeApiError(res: Response): Promise<string> {
+  let message = `Request failed (HTTP ${res.status})`;
+  try {
+    const body = await res.json();
+    // FastAPI wraps HTTPException detail at top-level "detail"
+    const inner = body.detail ?? body;
+    if (typeof inner === "object" && inner !== null) {
+      // Prefer {error, detail} shape → "ERROR_CODE: detail"
+      const code = inner.error ?? "";
+      const text = inner.detail ?? JSON.stringify(inner);
+      message = code ? `${code}: ${text}` : String(text);
+    } else if (typeof inner === "string") {
+      message = inner;
+    }
+  } catch {
+    // Fall through with the default message.
+  }
+  return message;
+}
+
 // ---------------------------------------------------------------------------
 // Health
 // ---------------------------------------------------------------------------
@@ -126,24 +151,7 @@ export async function submitAttempt(
     }),
   });
   if (!res.ok) {
-    // Normalise FastAPI structured errors into a user-friendly string.
-    let message = `Request failed (HTTP ${res.status})`;
-    try {
-      const body = await res.json();
-      // FastAPI wraps HTTPException detail at top-level "detail"
-      const inner = body.detail ?? body;
-      if (typeof inner === "object" && inner !== null) {
-        // Prefer {error, detail} shape → "ERROR_CODE: detail"
-        const code = inner.error ?? "";
-        const text = inner.detail ?? JSON.stringify(inner);
-        message = code ? `${code}: ${text}` : String(text);
-      } else if (typeof inner === "string") {
-        message = inner;
-      }
-    } catch {
-      // Fall through with the default message.
-    }
-    throw new Error(message);
+    throw new Error(await normalizeApiError(res));
   }
   return res.json();
 }
@@ -179,21 +187,7 @@ export async function saveSettings(
     body: JSON.stringify(data),
   });
   if (!res.ok) {
-    let message = `Request failed (HTTP ${res.status})`;
-    try {
-      const body = await res.json();
-      const inner = body.detail ?? body;
-      if (typeof inner === "object" && inner !== null) {
-        const code = inner.error ?? "";
-        const text = inner.detail ?? JSON.stringify(inner);
-        message = code ? `${code}: ${text}` : String(text);
-      } else if (typeof inner === "string") {
-        message = inner;
-      }
-    } catch {
-      // Fall through with the default message.
-    }
-    throw new Error(message);
+    throw new Error(await normalizeApiError(res));
   }
   return res.json();
 }


### PR DESCRIPTION
## Summary

Deduplicates the FastAPI error normalization block that was copy-pasted in `submitAttempt` and `saveSettings` of `frontend/src/api.ts`, by extracting it into a shared private helper `normalizeApiError`.

- `frontend/src/api.ts`: **+27 / -33** (net -6 lines)
- Single-file change; no component, type, or backend-contract changes
- No new dependencies; `package-lock.json` untouched

## Scope completed

- [x] Added `normalizeApiError(res: Response): Promise<string>` helper near the `API_BASE` constant. Logic is copied verbatim from the original `submitAttempt` block (including comments and edge cases), so it is byte-for-byte equivalent to the previous in-place normalization.
- [x] `submitAttempt` and `saveSettings` each replace their 15-line error block with a single line: `throw new Error(await normalizeApiError(res));`
- [x] Other API functions (`fetchHealth`, `fetchToday`, `fetchProgress`, `fetchSettings`) intentionally untouched — they use a simpler `throw new Error(\`... ${res.status}\`)` pattern that was not part of this issue.

## Verification

- `npm run build` (frontend) → **exit 0** — `tsc -b && vite build` both clean; 22 modules transformed; `built in 413ms`.
- `npm run lint` (frontend) → **exit 0** — no warnings.
- 8-case equivalence test driving the helper through the same code paths as the pre-refactor inline block:
  1. `{detail: {error, detail}}` → `"ERROR: detail"` ✓
  2. `{detail: "string"}` → `"string"` ✓
  3. `{detail: {msg: ...}}` (no `error`) → JSON-stringified ✓
  4. Bare object body → JSON-stringified ✓
  5. `{detail: "string"}` (bare) → string ✓
  6. Empty object body → `"{}"` ✓
  7. `null` body → default fallback ✓
  8. Malformed JSON (throws) → default fallback ✓
- `git diff --stat` shows exactly 1 file, +27/-33.

## Behavioural diff vs. `main`

**None.** The helper is the original block, copy-pasted verbatim (with the JSDoc header added). Both call sites still throw the same `Error` with the same message string for every reachable response shape.

## Manual QA

Not applicable: the change is an internal refactor with no observable UI or API change. Existing practice-flow and settings-flow tests in `backend/tests/test_attempts.py` and `test_settings_api.py` exercise the API contract that this client calls; both remain valid.

## Residual risks

- Low. The helper introduces an `await` in the `!res.ok` branch, which the original code already did inside the `try` block, so semantics are unchanged.
- If the project later adopts a unit-test framework (vitest), the helper is now trivially unit-testable in isolation.

## Merge

Per project rule, **no auto-merge to `main`** — awaiting user review and approval.

Closes #104
