### PR TITLE
test: add Core 300 runtime scheduling safety coverage

### DIFF
--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import json
 from datetime import datetime, timezone
 from pathlib import Path
+from sys import path as _python_path
 from typing import List, Optional
 
 import pytest
@@ -13,6 +15,15 @@ from app.models import DailySession, SessionItem
 from app.services.db_schema import init_db
 from app.services.db_store import create_session, create_session_item
 from app.services.scheduler import select_daily_words
+
+_SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+if str(_SCRIPTS) not in _python_path:
+    _python_path.insert(0, str(_SCRIPTS))
+
+from import_words import import_words  # noqa: E402
+
+CORE_300_PATH = Path(__file__).resolve().parent.parent.parent / "content" / "core_300_words.json"
+PHONEMES_PATH = Path(__file__).resolve().parent.parent.parent / "content" / "phonemes.json"
 
 
 @pytest.fixture(name="conn")
@@ -212,3 +223,59 @@ def test_selection_is_deterministic_for_same_seed(conn):
 
     assert _ids(first) == _ids(second)
     assert _ids(first) != _ids(different_seed)
+
+
+def test_core_300_scheduling_remains_stable(tmp_path: Path):
+    db_path = str(tmp_path / "core300.sqlite")
+    import_words(
+        source_path=CORE_300_PATH,
+        phonemes_path=PHONEMES_PATH,
+        db_path=db_path,
+    )
+
+    conn = get_connection(db_path)
+    rows = conn.execute(
+        "SELECT id, phoneme_tags_us FROM words WHERE content_status != 'disabled'"
+    ).fetchall()
+    focus_word = None
+    for row in rows:
+        tags = row["phoneme_tags_us"]
+        if tags:
+            parsed = json.loads(tags)
+            if "/ʌ/" in parsed:
+                focus_word = row["id"]
+                break
+
+    if focus_word is None:
+        conn.close()
+        pytest.skip("No /ʌ/ word available in current core_300 fixture")
+
+    selected = select_daily_words(
+        conn,
+        daily_word_count=10,
+        accent="US",
+        seed=777,
+        focus_phonemes=["/ʌ/"],
+    )
+    selected_ids = [w.id for w in selected]
+
+    assert len(selected_ids) == 10
+    assert focus_word in selected_ids
+
+    conn.execute(
+        "UPDATE words SET content_status = 'disabled' WHERE id = ?",
+        (selected_ids[0],),
+    )
+    conn.commit()
+
+    selected_after = select_daily_words(
+        conn,
+        daily_word_count=10,
+        accent="US",
+        seed=777,
+        focus_phonemes=["/ʌ/"],
+    )
+    conn.close()
+
+    assert len(selected_after) <= 10
+    assert selected_ids[0] not in [w.id for w in selected_after]

--- a/backend/tests/test_today_persistence.py
+++ b/backend/tests/test_today_persistence.py
@@ -36,6 +36,7 @@ from app.services.db_store import (  # noqa: E402
 FIXTURES = Path(__file__).resolve().parent / "fixtures"
 CONTENT_SAMPLE = FIXTURES / "content_sample.json"
 PHONEMES_PATH = Path(__file__).resolve().parent.parent.parent / "content" / "phonemes.json"
+CORE_300_PATH = Path(__file__).resolve().parent.parent.parent / "content" / "core_300_words.json"
 
 
 # ---------------------------------------------------------------------------
@@ -63,6 +64,30 @@ def seeded_db_fixture(tmp_path: Path) -> str:
 
 @pytest.fixture(name="client")
 def client_fixture(seeded_db: str) -> TestClient:
+    return TestClient(app)
+
+
+@pytest.fixture(name="seeded_db_core_300")
+def seeded_db_core_300_fixture(tmp_path: Path) -> str:
+    """Create a database pre-loaded with the full Core 300 runtime content."""
+    db_path = str(tmp_path / "core300.sqlite")
+    import_words(
+        source_path=CORE_300_PATH,
+        phonemes_path=PHONEMES_PATH,
+        db_path=db_path,
+    )
+
+    # Monkey-patch the default DB path so the TestClient uses this DB.
+    import app.db as db_mod
+
+    orig = db_mod.DEFAULT_DB_PATH
+    db_mod.DEFAULT_DB_PATH = db_path
+    yield db_path
+    db_mod.DEFAULT_DB_PATH = orig
+
+
+@pytest.fixture(name="core_300_client")
+def core_300_client_fixture(seeded_db_core_300: str) -> TestClient:
     return TestClient(app)
 
 
@@ -286,6 +311,86 @@ class TestTodayPersistence:
             assert data["error"] == "CONTENT_NOT_READY"
         finally:
             db_mod.DEFAULT_DB_PATH = orig
+
+
+class TestCore300TodayReadiness:
+    """Regression coverage for the full Core 300 runtime content path."""
+
+    def test_core_300_today_keeps_daily_count_to_settings(self, core_300_client):
+        resp = core_300_client.get("/api/today")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "error" not in data, data
+        assert data["daily_word_count"] == 10
+        assert len(data["items"]) == 10
+
+    def test_core_300_disabled_words_are_not_scheduled(self, core_300_client):
+        # Disable one of the scheduled candidates and confirm it's filtered.
+        import app.db as db_mod
+
+        conn = get_connection(db_mod.DEFAULT_DB_PATH)
+        core_300_client.get("/api/today")
+
+        first_id = conn.execute(
+            "SELECT word_id FROM session_items WHERE session_id = ? ORDER BY order_index LIMIT 1",
+            (f"{date.today().isoformat()}-default",),
+        ).fetchone()
+        assert first_id is not None
+
+        conn.execute(
+            "UPDATE words SET content_status = 'disabled' WHERE id = ?",
+            (first_id[0],),
+        )
+        conn.commit()
+
+        # Existing session should still be stable; create a fresh one by deleting the
+        # existing row to emulate next-day scheduling semantics.
+        conn.execute(
+            "DELETE FROM session_items WHERE session_id = ?",
+            (f"{date.today().isoformat()}-default",),
+        )
+        conn.execute(
+            "DELETE FROM daily_sessions WHERE id = ?",
+            (f"{date.today().isoformat()}-default",),
+        )
+        conn.commit()
+        conn.close()
+
+        resp = core_300_client.get("/api/today")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "error" not in data, data
+        assert first_id[0] not in {item["word_id"] for item in data["items"]}
+
+    def test_core_300_focus_phonemes_continue_to_work(self, core_300_client):
+        import app.db as db_mod
+
+        conn = get_connection(db_mod.DEFAULT_DB_PATH)
+        focus_id = conn.execute(
+            """
+            SELECT id
+            FROM words
+            WHERE content_status != 'disabled'
+              AND phoneme_tags_us LIKE '%/ʌ/%'
+            LIMIT 1
+            """,
+        ).fetchone()
+        if focus_id is None:
+            conn.close()
+            pytest.skip("No /ʌ/ word available in current core_300 fixture")
+
+        conn.execute(
+            "UPDATE settings SET focus_phonemes = ? WHERE user_id = 'default'",
+            (json.dumps(["/ʌ/"]),),
+        )
+        conn.commit()
+        conn.close()
+
+        resp = core_300_client.get("/api/today")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "error" not in data, data
+        assert focus_id[0] in {item["word_id"] for item in data["items"]}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #100

## Scope
- Add focused backend coverage for Core 300 runtime import and daily practice scheduling.
- Verify `/api/today` remains bounded by settings (10 words) with Core 300 dataset.
- Verify disabled words are not re-scheduled and focus phonemes still apply.
- Verify `select_daily_words` remains stable over full Core 300 + disabled-word edge case.

## Verification
- `UV_CACHE_DIR=/tmp/uv-cache uv run --project backend ruff check backend/tests/test_today_persistence.py backend/tests/test_scheduler.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run --project backend pytest backend/tests/test_today_persistence.py backend/tests/test_scheduler.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run --project backend pytest`
- `bash tools/agents/agent-audit`
