### PR TITLE
test: decouple core-300 session-id from today's date

### DIFF
--- a/backend/tests/test_today_persistence.py
+++ b/backend/tests/test_today_persistence.py
@@ -329,11 +329,14 @@ class TestCore300TodayReadiness:
         import app.db as db_mod
 
         conn = get_connection(db_mod.DEFAULT_DB_PATH)
-        core_300_client.get("/api/today")
+        first_resp = core_300_client.get("/api/today")
+        assert first_resp.status_code == 200
+        first_data = first_resp.json()
+        session_id = first_data["session_id"]
 
         first_id = conn.execute(
             "SELECT word_id FROM session_items WHERE session_id = ? ORDER BY order_index LIMIT 1",
-            (f"{date.today().isoformat()}-default",),
+            (session_id,),
         ).fetchone()
         assert first_id is not None
 
@@ -347,11 +350,11 @@ class TestCore300TodayReadiness:
         # existing row to emulate next-day scheduling semantics.
         conn.execute(
             "DELETE FROM session_items WHERE session_id = ?",
-            (f"{date.today().isoformat()}-default",),
+            (session_id,),
         )
         conn.execute(
             "DELETE FROM daily_sessions WHERE id = ?",
-            (f"{date.today().isoformat()}-default",),
+            (session_id,),
         )
         conn.commit()
         conn.close()


### PR DESCRIPTION
Follow-up for #100/#111 runtime scheduling safety.

Reviewer noted a non-blocking risk: test_core_300_disabled_words_are_not_scheduled hardcoded a date-based session_id (). This PR decouples that test from session-id naming strategy by reading session_id from /api/today response and reusing it in DB cleanup logic.

Verification:
- uv run --project backend ruff check backend/tests/test_today_persistence.py
- uv run --project backend pytest backend/tests/test_today_persistence.py -k core_300 -q