### PR TITLE
Implement M7 P0 practice group backend

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -80,6 +80,9 @@ class DailySession:
     status: str
     created_at: str
     completed_at: Optional[str] = None
+    group_index: int = 1
+    group_type: str = "normal"
+    source_session_item_ids: List[str] = field(default_factory=list)
 
 
 @dataclass

--- a/backend/app/routes/attempts.py
+++ b/backend/app/routes/attempts.py
@@ -10,10 +10,13 @@ from fastapi import APIRouter, HTTPException, Request
 from app.db import get_db
 from app.models import Attempt
 from app.services.db_store import (
+    all_session_items_attempted,
     create_attempt,
     get_session_by_id,
     get_session_items,
     get_word_by_id,
+    mark_session_completed,
+    mark_session_item_complete,
 )
 from app.services.grading import determine_correct_answer, grade_attempt
 from app.services.progress import update_phoneme_stats
@@ -42,7 +45,8 @@ async def attempt(request: Request):
 
     if not session_item_id:
         raise HTTPException(
-            status_code=400, detail={"error": "INVALID_ATTEMPT", "detail": "Missing session_item_id"}
+            status_code=400,
+            detail={"error": "INVALID_ATTEMPT", "detail": "Missing session_item_id"},
         )
 
     with get_db() as conn:
@@ -110,6 +114,7 @@ async def attempt(request: Request):
             target_phoneme=item.target_phonemes[0] if item.target_phonemes else None,
         )
         create_attempt(conn, attempt_row)
+        mark_session_item_complete(conn, session_item_id)
 
         # Update phoneme stats.
         updated_phonemes = update_phoneme_stats(
@@ -123,6 +128,9 @@ async def attempt(request: Request):
 
         # Determine next_action.
         next_action = "next_item"
+        if all_session_items_attempted(conn, session_id):
+            mark_session_completed(conn, session_id, timestamp)
+            next_action = "group_complete"
 
         return {
             "is_correct": is_correct,

--- a/backend/app/routes/practice.py
+++ b/backend/app/routes/practice.py
@@ -3,7 +3,7 @@
 from fastapi import APIRouter
 
 from app.db import get_db
-from app.services.sessions import build_today_response
+from app.services.sessions import build_recent_mistake_review_response, build_today_response
 
 router = APIRouter()
 
@@ -17,3 +17,10 @@ def today():
     """
     with get_db() as conn:
         return build_today_response(conn)
+
+
+@router.post("/review/recent-mistakes")
+def recent_mistake_review():
+    """Create or resume a review group from recent wrong answers."""
+    with get_db() as conn:
+        return build_recent_mistake_review_response(conn)

--- a/backend/app/services/db_schema.py
+++ b/backend/app/services/db_schema.py
@@ -71,7 +71,10 @@ TABLES_DDL: List[str] = [
         primary_accent  TEXT    NOT NULL,
         status          TEXT    NOT NULL,
         created_at      TEXT    NOT NULL,
-        completed_at    TEXT
+        completed_at    TEXT,
+        group_index     INTEGER NOT NULL DEFAULT 1,
+        group_type      TEXT    NOT NULL DEFAULT 'normal',
+        source_session_item_ids TEXT NOT NULL DEFAULT '[]'
     )
     """,
     # ------------------------------------------------------------------
@@ -137,6 +140,7 @@ def init_db(conn: sqlite3.Connection) -> None:
     for ddl in TABLES_DDL:
         conn.execute(ddl)
     ensure_settings_schema(conn)
+    ensure_daily_sessions_schema(conn)
 
 
 def ensure_settings_schema(conn: sqlite3.Connection) -> None:
@@ -154,6 +158,33 @@ def ensure_settings_schema(conn: sqlite3.Connection) -> None:
     if "focus_phonemes" not in columns:
         conn.execute(
             "ALTER TABLE settings ADD COLUMN focus_phonemes TEXT NOT NULL DEFAULT '[]'"
+        )
+
+
+def ensure_daily_sessions_schema(conn: sqlite3.Connection) -> None:
+    """Apply compatibility patches for existing daily_sessions tables."""
+    table = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='daily_sessions'"
+    ).fetchone()
+    if table is None:
+        return
+
+    columns = {
+        row["name"]
+        for row in conn.execute("PRAGMA table_info(daily_sessions)").fetchall()
+    }
+    if "group_index" not in columns:
+        conn.execute(
+            "ALTER TABLE daily_sessions ADD COLUMN group_index INTEGER NOT NULL DEFAULT 1"
+        )
+    if "group_type" not in columns:
+        conn.execute(
+            "ALTER TABLE daily_sessions ADD COLUMN group_type TEXT NOT NULL DEFAULT 'normal'"
+        )
+    if "source_session_item_ids" not in columns:
+        conn.execute(
+            "ALTER TABLE daily_sessions ADD COLUMN source_session_item_ids "
+            "TEXT NOT NULL DEFAULT '[]'"
         )
 
 

--- a/backend/app/services/db_store.py
+++ b/backend/app/services/db_store.py
@@ -11,7 +11,7 @@ import sqlite3
 from typing import List, Optional
 
 from app.models import Attempt, DailySession, Phoneme, SessionItem, Settings, Word
-from app.services.db_schema import ensure_settings_schema
+from app.services.db_schema import ensure_daily_sessions_schema, ensure_settings_schema
 
 # ============================================================================
 # Serialisation helpers
@@ -254,6 +254,9 @@ def _session_from_row(row: sqlite3.Row) -> DailySession:
         status=row["status"],
         created_at=row["created_at"],
         completed_at=row["completed_at"],
+        group_index=row["group_index"],
+        group_type=row["group_type"],
+        source_session_item_ids=_parse_list(row["source_session_item_ids"]) or [],
     )
 
 
@@ -271,12 +274,15 @@ def _session_item_from_row(row: sqlite3.Row) -> SessionItem:
 
 def create_session(conn: sqlite3.Connection, session: DailySession) -> str:
     """Insert a new daily session row. Returns the session id."""
+    ensure_daily_sessions_schema(conn)
     conn.execute(
         """
         INSERT INTO daily_sessions (
-            id, user_id, session_date, primary_accent, status, created_at, completed_at
+            id, user_id, session_date, primary_accent, status, created_at, completed_at,
+            group_index, group_type, source_session_item_ids
         ) VALUES (
-            :id, :user_id, :session_date, :primary_accent, :status, :created_at, :completed_at
+            :id, :user_id, :session_date, :primary_accent, :status, :created_at,
+            :completed_at, :group_index, :group_type, :source_session_item_ids
         )
         """,
         {
@@ -287,25 +293,97 @@ def create_session(conn: sqlite3.Connection, session: DailySession) -> str:
             "status": session.status,
             "created_at": session.created_at,
             "completed_at": session.completed_at,
+            "group_index": session.group_index,
+            "group_type": session.group_type,
+            "source_session_item_ids": _to_json(session.source_session_item_ids),
         },
     )
     return session.id
+
+
+def get_active_session_for_date(
+    conn: sqlite3.Connection,
+    user_id: str,
+    session_date: str,
+    primary_accent: str,
+    group_type: str = "normal",
+) -> Optional[DailySession]:
+    """Return the active same-day group for the given type, if one exists."""
+    ensure_daily_sessions_schema(conn)
+    row = conn.execute(
+        """
+        SELECT * FROM daily_sessions
+        WHERE user_id = ?
+          AND session_date = ?
+          AND primary_accent = ?
+          AND group_type = ?
+          AND status = 'in_progress'
+        ORDER BY group_index DESC, created_at DESC
+        LIMIT 1
+        """,
+        (user_id, session_date, primary_accent, group_type),
+    ).fetchone()
+    if row is None:
+        return None
+    return _session_from_row(row)
 
 
 def get_session_for_date(
     conn: sqlite3.Connection, user_id: str, session_date: str, primary_accent: str
 ) -> Optional[DailySession]:
     """Return the daily session for the given user, date and accent, or None."""
+    ensure_daily_sessions_schema(conn)
     row = conn.execute(
         """
         SELECT * FROM daily_sessions
         WHERE user_id = ? AND session_date = ? AND primary_accent = ?
+        ORDER BY
+          CASE WHEN status = 'in_progress' AND group_type = 'normal' THEN 0 ELSE 1 END,
+          group_index DESC,
+          created_at DESC
+        LIMIT 1
         """,
         (user_id, session_date, primary_accent),
     ).fetchone()
     if row is None:
         return None
     return _session_from_row(row)
+
+
+def get_next_session_group_index(
+    conn: sqlite3.Connection,
+    user_id: str,
+    session_date: str,
+    primary_accent: str,
+) -> int:
+    """Return the next same-day practice group index for user/date/accent."""
+    ensure_daily_sessions_schema(conn)
+    row = conn.execute(
+        """
+        SELECT COALESCE(MAX(group_index), 0) AS max_group
+        FROM daily_sessions
+        WHERE user_id = ? AND session_date = ? AND primary_accent = ?
+        """,
+        (user_id, session_date, primary_accent),
+    ).fetchone()
+    return int(row["max_group"] if row else 0) + 1
+
+
+def mark_session_completed(
+    conn: sqlite3.Connection,
+    session_id: str,
+    completed_at: str,
+) -> None:
+    """Mark a practice group completed."""
+    ensure_daily_sessions_schema(conn)
+    conn.execute(
+        """
+        UPDATE daily_sessions
+        SET status = 'completed', completed_at = ?
+        WHERE id = ?
+        """,
+        (completed_at, session_id),
+    )
 
 
 def create_session_item(conn: sqlite3.Connection, item: SessionItem) -> str:
@@ -333,6 +411,7 @@ def create_session_item(conn: sqlite3.Connection, item: SessionItem) -> str:
 
 def get_session_by_id(conn: sqlite3.Connection, session_id: str) -> Optional[DailySession]:
     """Return a daily session by its primary key, or None."""
+    ensure_daily_sessions_schema(conn)
     row = conn.execute(
         "SELECT * FROM daily_sessions WHERE id = ?", (session_id,)
     ).fetchone()
@@ -350,6 +429,43 @@ def get_session_items(
         (session_id,),
     ).fetchall()
     return [_session_item_from_row(r) for r in rows]
+
+
+def get_recent_incorrect_attempt_sources(
+    conn: sqlite3.Connection,
+    *,
+    user_id: str,
+    primary_accent: str,
+    limit: int = 10,
+) -> List[dict]:
+    """Return recent wrong-answer words with their latest source session item."""
+    rows = conn.execute(
+        """
+        SELECT a.word_id, a.session_item_id, a.created_at AS last_wrong_at
+        FROM attempts a
+        JOIN words w ON w.id = a.word_id
+        WHERE a.user_id = ?
+          AND a.primary_accent = ?
+          AND a.is_correct = 0
+          AND w.content_status != 'disabled'
+        ORDER BY a.created_at DESC
+        """,
+        (user_id, primary_accent),
+    ).fetchall()
+    sources = []
+    seen_word_ids = set()
+    for row in rows:
+        if row["word_id"] in seen_word_ids:
+            continue
+        seen_word_ids.add(row["word_id"])
+        sources.append({
+            "word_id": row["word_id"],
+            "session_item_id": row["session_item_id"],
+            "last_wrong_at": row["last_wrong_at"],
+        })
+        if len(sources) >= limit:
+            break
+    return sources
 
 
 # ============================================================================
@@ -386,3 +502,29 @@ def create_attempt(conn: sqlite3.Connection, attempt: Attempt) -> str:
         },
     )
     return attempt.id
+
+
+def mark_session_item_complete(conn: sqlite3.Connection, session_item_id: str) -> None:
+    """Mark a session item complete after an attempt."""
+    conn.execute(
+        "UPDATE session_items SET status = 'complete' WHERE id = ?",
+        (session_item_id,),
+    )
+
+
+def all_session_items_attempted(conn: sqlite3.Connection, session_id: str) -> bool:
+    """Return True once every item in a session has at least one attempt."""
+    row = conn.execute(
+        """
+        SELECT
+          COUNT(*) AS total_items,
+          COUNT(DISTINCT a.session_item_id) AS attempted_items
+        FROM session_items si
+        LEFT JOIN attempts a ON a.session_item_id = si.id
+        WHERE si.session_id = ?
+        """,
+        (session_id,),
+    ).fetchone()
+    if row is None or row["total_items"] == 0:
+        return False
+    return row["attempted_items"] >= row["total_items"]

--- a/backend/app/services/progress.py
+++ b/backend/app/services/progress.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import sqlite3
 from datetime import date, timedelta
-from typing import Dict, List, Optional, Tuple
+from typing import List, Optional, Tuple
 
 # ---------------------------------------------------------------------------
 # Mastery status
@@ -218,14 +218,20 @@ def build_progress_response(
 
     # ---- today ---------------------------------------------------------------
     today_str = date.today().isoformat()
-    today_row = conn.execute(
+    today_rows = conn.execute(
         """
         SELECT status FROM daily_sessions
         WHERE user_id = ? AND session_date = ?
         """,
         (user_id, today_str),
-    ).fetchone()
-    today_status = today_row["status"] if today_row else "none"
+    ).fetchall()
+    statuses = {row["status"] for row in today_rows}
+    if "in_progress" in statuses:
+        today_status = "in_progress"
+    elif "completed" in statuses:
+        today_status = "completed"
+    else:
+        today_status = "none"
     today_completed = today_status == "completed"
 
     # ---- streak --------------------------------------------------------------

--- a/backend/app/services/sessions.py
+++ b/backend/app/services/sessions.py
@@ -8,13 +8,15 @@ from __future__ import annotations
 
 import hashlib
 from datetime import date, datetime, timezone
-from typing import List
+from typing import List, Optional
 
 from app.models import DailySession, SessionItem
 from app.services.db_store import (
     create_session,
     create_session_item,
-    get_session_for_date,
+    get_active_session_for_date,
+    get_next_session_group_index,
+    get_recent_incorrect_attempt_sources,
     get_session_items,
     get_settings,
     get_word_by_id,
@@ -36,9 +38,8 @@ def _stable_hash(s: str) -> int:
     return int(hashlib.md5(s.encode()).hexdigest(), 16) & 0x7FFFFFFF
 
 
-def _seed_from_date(session_date: str) -> int:
-    """Deterministic seed so same-date calls get the same word ordering."""
-    return _stable_hash(session_date)
+def _seed_from_group(session_date: str, group_index: int, group_type: str) -> int:
+    return _stable_hash(f"{session_date}:{group_index}:{group_type}")
 
 
 def build_today_response(
@@ -65,7 +66,7 @@ def build_today_response(
     daily_word_count = settings.daily_word_count
 
     # ---- check for existing session -----------------------------------------
-    existing = get_session_for_date(conn, user_id, session_date, accent)
+    existing = get_active_session_for_date(conn, user_id, session_date, accent, "normal")
     if existing is not None:
         items = get_session_items(conn, existing.id)
         return _build_response(
@@ -77,7 +78,8 @@ def build_today_response(
         )
 
     # ---- create new session -------------------------------------------------
-    seed = _seed_from_date(session_date)
+    group_index = get_next_session_group_index(conn, user_id, session_date, accent)
+    seed = _seed_from_group(session_date, group_index, "normal")
     words = select_daily_words(
         conn,
         daily_word_count,
@@ -94,7 +96,120 @@ def build_today_response(
             "detail": "No usable words found. Run import_words.py first.",
         }
 
-    session_id = f"{session_date}-{user_id}"
+    session, items = _create_group_from_words(
+        conn,
+        words=words,
+        user_id=user_id,
+        session_date=session_date,
+        accent=accent,
+        group_index=group_index,
+        group_type="normal",
+    )
+
+    return _build_response(
+        session=session,
+        items=items,
+        daily_word_count=daily_word_count,
+        conn=conn,
+        accent=accent,
+    )
+
+
+def build_recent_mistake_review_response(
+    conn,
+    *,
+    user_id: str = "default",
+    accent: str = "US",
+    limit: int = 10,
+) -> dict:
+    """Create or resume a same-day review group from recent wrong attempts."""
+    session_date = _today_date_str()
+    settings = get_settings(conn, user_id)
+    if settings is None:
+        return {
+            "error": "CONTENT_NOT_READY",
+            "detail": "Settings not initialised. Run import_words.py first.",
+        }
+
+    existing = get_active_session_for_date(
+        conn, user_id, session_date, accent, "mistake_review"
+    )
+    if existing is not None:
+        items = get_session_items(conn, existing.id)
+        return _build_response(
+            session=existing,
+            items=items,
+            daily_word_count=settings.daily_word_count,
+            conn=conn,
+            accent=accent,
+        )
+
+    sources = get_recent_incorrect_attempt_sources(
+        conn,
+        user_id=user_id,
+        primary_accent=accent,
+        limit=min(max(limit, 1), settings.daily_word_count),
+    )
+    if not sources:
+        return {
+            "group_type": "mistake_review",
+            "status": "empty",
+            "items": [],
+            "source_count": 0,
+            "detail": "No recent incorrect attempts are available for review.",
+        }
+
+    words = []
+    source_item_ids = []
+    for source in sources:
+        word = get_word_by_id(conn, source["word_id"])
+        if word is not None:
+            words.append(word)
+            source_item_ids.append(source["session_item_id"])
+
+    if not words:
+        return {
+            "group_type": "mistake_review",
+            "status": "empty",
+            "items": [],
+            "source_count": 0,
+            "detail": "No reviewable words are available for recent mistakes.",
+        }
+
+    group_index = get_next_session_group_index(conn, user_id, session_date, accent)
+    session, items = _create_group_from_words(
+        conn,
+        words=words,
+        user_id=user_id,
+        session_date=session_date,
+        accent=accent,
+        group_index=group_index,
+        group_type="mistake_review",
+        source_session_item_ids=source_item_ids,
+    )
+    response = _build_response(
+        session=session,
+        items=items,
+        daily_word_count=settings.daily_word_count,
+        conn=conn,
+        accent=accent,
+    )
+    response["source_count"] = len(source_item_ids)
+    return response
+
+
+def _create_group_from_words(
+    conn,
+    *,
+    words,
+    user_id: str,
+    session_date: str,
+    accent: str,
+    group_index: int,
+    group_type: str,
+    source_session_item_ids: Optional[List[str]] = None,
+) -> tuple[DailySession, List[SessionItem]]:
+    session_id = f"{session_date}-{user_id}-g{group_index:03d}-{group_type}"
     session = DailySession(
         id=session_id,
         user_id=user_id,
@@ -103,6 +218,9 @@ def build_today_response(
         status="in_progress",
         created_at=_now_iso(),
         completed_at=None,
+        group_index=group_index,
+        group_type=group_type,
+        source_session_item_ids=source_session_item_ids or [],
     )
     create_session(conn, session)
 
@@ -122,14 +240,7 @@ def build_today_response(
         )
         create_session_item(conn, item)
         items.append(item)
-
-    return _build_response(
-        session=session,
-        items=items,
-        daily_word_count=daily_word_count,
-        conn=conn,
-        accent=accent,
-    )
+    return session, items
 
 
 def _build_distractor_pool(conn, accent: str) -> List[str]:
@@ -183,9 +294,14 @@ def _build_response(
 
     return {
         "session_id": session.id,
+        "group_id": session.id,
+        "group_index": session.group_index,
+        "group_type": session.group_type,
         "date": session.session_date,
         "primary_accent": session.primary_accent,
         "daily_word_count": daily_word_count,
+        "word_count": len(item_dicts),
         "status": session.status,
+        "source_session_item_ids": session.source_session_item_ids,
         "items": item_dicts,
     }

--- a/backend/tests/test_progress_api.py
+++ b/backend/tests/test_progress_api.py
@@ -192,7 +192,12 @@ class TestStreak:
         # Completed yesterday and two days ago
         for d in [yesterday, two_days_ago]:
             conn.execute(
-                "INSERT INTO daily_sessions VALUES (?, 'default', ?, 'US', 'completed', ?, NULL)",
+                """
+                INSERT INTO daily_sessions (
+                    id, user_id, session_date, primary_accent,
+                    status, created_at, completed_at
+                ) VALUES (?, 'default', ?, 'US', 'completed', ?, NULL)
+                """,
                 (f"{d.isoformat()}-default", d.isoformat(), f"{d.isoformat()}T10:00:00Z"),
             )
         conn.commit()
@@ -220,7 +225,12 @@ class TestStreak:
         # Completed 2 days ago and 4 days ago (gap at 3 days ago)
         for d in [two_days_ago, four_days_ago]:
             conn.execute(
-                "INSERT INTO daily_sessions VALUES (?, 'default', ?, 'US', 'completed', ?, NULL)",
+                """
+                INSERT INTO daily_sessions (
+                    id, user_id, session_date, primary_accent,
+                    status, created_at, completed_at
+                ) VALUES (?, 'default', ?, 'US', 'completed', ?, NULL)
+                """,
                 (f"{d.isoformat()}-default", d.isoformat(), f"{d.isoformat()}T10:00:00Z"),
             )
         conn.commit()

--- a/backend/tests/test_today_persistence.py
+++ b/backend/tests/test_today_persistence.py
@@ -105,6 +105,11 @@ class TestTodayPersistence:
         data = resp.json()
         assert "error" not in data, data
         assert data["status"] == "in_progress"
+        assert data["group_id"] == data["session_id"]
+        assert data["group_index"] == 1
+        assert data["group_type"] == "normal"
+        assert data["word_count"] == len(data["items"])
+        assert data["source_session_item_ids"] == []
         assert data["date"] == date.today().isoformat()
         assert data["primary_accent"] == "US"
         assert data["daily_word_count"] == 10
@@ -136,6 +141,44 @@ class TestTodayPersistence:
         ).fetchone()
         conn.close()
         assert items["cnt"] == 1
+
+    def test_completed_group_allows_next_same_day_group(self, client, seeded_db):
+        first = client.get("/api/today").json()
+        conn = get_connection(seeded_db)
+        conn.execute(
+            """
+            UPDATE daily_sessions
+            SET status = 'completed', completed_at = '2026-06-16T00:00:00Z'
+            WHERE id = ?
+            """,
+            (first["session_id"],),
+        )
+        conn.commit()
+        conn.close()
+
+        second = client.get("/api/today").json()
+
+        assert second["session_id"] != first["session_id"]
+        assert second["group_index"] == 2
+        assert second["group_type"] == "normal"
+
+        conn = get_connection(seeded_db)
+        today = date.today().isoformat()
+        sessions = conn.execute(
+            """
+            SELECT id, group_index, group_type, status
+            FROM daily_sessions
+            WHERE user_id = 'default' AND session_date = ?
+            ORDER BY group_index
+            """,
+            (today,),
+        ).fetchall()
+        conn.close()
+
+        assert [(row["group_index"], row["group_type"]) for row in sessions] == [
+            (1, "normal"),
+            (2, "normal"),
+        ]
 
     def test_items_have_required_fields(self, client, seeded_db):
         resp = client.get("/api/today")
@@ -183,6 +226,85 @@ class TestTodayPersistence:
         resp = client.get("/api/today")
         data = resp.json()
         assert len(data["items"]) <= 1
+
+    def test_single_item_attempt_completes_group_and_next_today_creates_group(
+        self, client, seeded_db
+    ):
+        conn = get_connection(seeded_db)
+        conn.execute("UPDATE settings SET daily_word_count = 1 WHERE user_id = 'default'")
+        conn.commit()
+        conn.close()
+
+        first = client.get("/api/today").json()
+        item = first["items"][0]
+        attempt = client.post("/api/attempt", json={
+            "session_item_id": item["session_item_id"],
+            "selected_answer": item["display_ipa"],
+        }).json()
+
+        assert attempt["next_action"] == "group_complete"
+
+        second = client.get("/api/today").json()
+        assert second["session_id"] != first["session_id"]
+        assert second["group_index"] == 2
+
+    def test_recent_mistake_review_empty_queue_is_stable(self, client):
+        resp = client.post("/api/review/recent-mistakes")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["group_type"] == "mistake_review"
+        assert data["status"] == "empty"
+        assert data["items"] == []
+        assert data["source_count"] == 0
+
+    def test_recent_mistake_review_group_reuses_attempt_path(self, client, seeded_db):
+        today = client.get("/api/today").json()
+        missed = today["items"][0]
+        miss_resp = client.post("/api/attempt", json={
+            "session_item_id": missed["session_item_id"],
+            "selected_answer": "/wrong/",
+        })
+        assert miss_resp.status_code == 200
+        assert miss_resp.json()["is_correct"] is False
+
+        review_resp = client.post("/api/review/recent-mistakes")
+        assert review_resp.status_code == 200
+        review = review_resp.json()
+
+        assert review["group_type"] == "mistake_review"
+        assert review["group_index"] == 2
+        assert review["source_session_item_ids"] == [missed["session_item_id"]]
+        assert review["items"][0]["word_id"] == missed["word_id"]
+
+        second_review = client.post("/api/review/recent-mistakes").json()
+        assert second_review["session_id"] == review["session_id"]
+
+        review_item = review["items"][0]
+        retry = client.post("/api/attempt", json={
+            "session_item_id": review_item["session_item_id"],
+            "selected_answer": review_item["display_ipa"],
+        })
+        assert retry.status_code == 200
+        assert retry.json()["is_correct"] is True
+
+        conn = get_connection(seeded_db)
+        attempts = conn.execute(
+            "SELECT COUNT(*) AS cnt FROM attempts WHERE word_id = ?",
+            (missed["word_id"],),
+        ).fetchone()
+        stats = conn.execute(
+            """
+            SELECT attempt_count
+            FROM phoneme_stats
+            WHERE user_id = 'default' AND primary_accent = 'US'
+            ORDER BY attempt_count DESC
+            LIMIT 1
+            """
+        ).fetchone()
+        conn.close()
+
+        assert attempts["cnt"] == 2
+        assert stats["attempt_count"] == 2
 
     def test_fresh_today_uses_focus_phoneme_setting(self, client, seeded_db):
         conn = get_connection(seeded_db)

--- a/docs/05-data-api-contracts.md
+++ b/docs/05-data-api-contracts.md
@@ -94,7 +94,10 @@ daily_sessions(
   primary_accent TEXT NOT NULL,
   status TEXT NOT NULL,
   created_at TEXT NOT NULL,
-  completed_at TEXT
+  completed_at TEXT,
+  group_index INTEGER NOT NULL DEFAULT 1,
+  group_type TEXT NOT NULL DEFAULT 'normal',
+  source_session_item_ids TEXT NOT NULL DEFAULT '[]'
 )
 
 session_items(
@@ -160,15 +163,37 @@ GET /api/health
 GET /api/today
 ```
 
+创建或恢复当天的普通练习组。M7 起，Tiny IPA 将“每日练习”收窄为
+“当天可重复创建的 10 词 practice group”：
+
+- `session_id` 仍是 attempt 提交使用的持久 session id；
+- `group_id` 是 `session_id` 的语义别名，供 UI 用 group 语言表达；
+- `group_index` 是同一 `user_id`/`date`/`primary_accent` 下的递增序号；
+- `group_type` 当前实现 `normal` 和 `mistake_review`；后续弱音素入口使用
+  `weak_focus`，但仍复用同一 session_items/attempts/phoneme_stats 路径；
+- `daily_word_count` 保留为兼容字段，M7 UI 文案应理解为 words per group；
+- `word_count` 是本响应实际返回的 item 数；
+- `source_session_item_ids` 仅 review group 使用，用于追踪错题来源。
+
+重复调用 `GET /api/today` 时，如果存在当天同 accent 的 `normal`
+`in_progress` group，则恢复它；如果当天已有 completed normal group 且没有
+active normal group，则创建下一个 normal group。不同 group 共用
+`session_items`、`attempts` 和 `phoneme_stats`，不引入第二套判题或统计来源。
+
 返回领域摘要，不返回原始调度内部状态：
 
 ```json
 {
-  "session_id": "2026-06-06-default",
+  "session_id": "2026-06-06-default-g001-normal",
+  "group_id": "2026-06-06-default-g001-normal",
+  "group_index": 1,
+  "group_type": "normal",
   "date": "2026-06-06",
   "primary_accent": "US",
   "daily_word_count": 10,
+  "word_count": 10,
   "status": "in_progress",
+  "source_session_item_ids": [],
   "items": [
     {
       "session_item_id": "item_001",
@@ -189,6 +214,54 @@ GET /api/today
 ```
 
 推荐服务端判题，不在生产响应中返回 `answer`。
+
+### Recent mistake review group
+
+```http
+POST /api/review/recent-mistakes
+```
+
+显式创建或恢复当天的 recent mistake review group。该 API 从最近的错误
+attempt 查询错词，去重后映射回 `words`/`session_items`，并创建
+`group_type = "mistake_review"` 的普通 session_items。之后前端继续用
+`POST /api/attempt` 提交答案，`phoneme_stats` 仍是复习强度和弱项判断的唯一
+统计来源。
+
+空队列是稳定非错误状态：
+
+```json
+{
+  "group_type": "mistake_review",
+  "status": "empty",
+  "items": [],
+  "source_count": 0,
+  "detail": "No recent incorrect attempts are available for review."
+}
+```
+
+有错题时返回与 `/api/today` 相同的 group response，并额外包含
+`source_count`。同一天重复调用会恢复 active `mistake_review` group，而不是
+创建重复 active work。
+
+### Weak phoneme focused group
+
+M7 P1 的 Progress 入口可以创建 `group_type = "weak_focus"` 的 practice group。
+它应接收用户选择的 phoneme symbols/ids，并调用现有 scheduler focus weighting；
+不应新建复习统计表，也不应绕开 `phoneme_stats`。若当天已有 active
+`weak_focus` group，API 应恢复该 group；完成后下一次显式 action 才创建新
+focused group。
+
+### M7 minimum smoke path
+
+M7 的用户可见 smoke path 至少覆盖：
+
+1. Learner loads `/api/today`, completes one `normal` group through
+   `POST /api/attempt`, then requests another same-day `normal` group.
+2. Learner answers at least one item incorrectly, starts
+   `POST /api/review/recent-mistakes`, and submits the review item through the
+   same `POST /api/attempt` path.
+3. Progress continues to derive weak/strong phonemes from `phoneme_stats`; no
+   review-specific correctness store is introduced.
 
 ### Attempt
 
@@ -274,13 +347,13 @@ MVP 默认：
 后端负责：
 
 ```text
-选择今日词
-创建或恢复当天 session
+选择每组练习词
+创建或恢复当天 practice group
 生成 question choices
 判题
 更新 phoneme_stats
 计算 weak/strong/mastered
-根据 settings 影响 daily_word_count 和调度
+根据 settings 影响 words per group 和调度
 ```
 
 前端负责：


### PR DESCRIPTION
## Scope completed

Linked issues: #114, #115, #116, #121

- #115: documented the M7 practice group / review-loop contract in `docs/05-data-api-contracts.md`, including group identity, group type, repeatability rules, aggregate progress semantics, backward compatibility, recent-mistake review, future weak-focus hook, and M7 smoke path.
- #116: added backend support for multiple same-day practice groups using `daily_sessions.group_index`, `group_type`, and `source_session_item_ids` with compatibility schema patches for existing DBs.
- #116: changed `/api/today` to resume an active normal group or create the next same-day normal group after completion, while preserving existing scheduler weighting and `phoneme_stats` semantics.
- #121: added `POST /api/review/recent-mistakes` to create/resume a `mistake_review` group from recent incorrect attempts, with stable empty-queue response and reuse of the existing `/api/attempt` grading/stats path.
- Added group completion handling after all session items have attempts, returning `next_action: group_complete` for the last item.
- Added focused backend tests for group response shape, next same-day normal group, single-item group completion, empty review queue, recent mistake review group reuse, and review attempts updating attempts/phoneme stats.

## Dependency gate evidence

The corrected gate order is #115 -> #116 -> #121. This PR includes the accepted #115 contract first in docs, then implements #116 and #121 against that contract in the same branch. No #117/#118/#119/#120 UI work is included.

## Verification

- `tools/agents/agent-ready-queue --role implementer` -> #115 startable; #116 waits on #115; #121 waits on #115/#116.
- `tools/agents/agent-permission-smoke` -> passed after one transient GitHub API EOF retry.
- `python3 -m py_compile backend/app/models.py backend/app/services/db_schema.py backend/app/services/db_store.py backend/app/services/sessions.py backend/app/routes/practice.py backend/app/routes/attempts.py backend/app/services/progress.py backend/tests/test_today_persistence.py backend/tests/test_progress_api.py` -> passed.
- `uv run --project backend ruff check backend/app/models.py backend/app/routes/attempts.py backend/app/routes/practice.py backend/app/services/db_schema.py backend/app/services/db_store.py backend/app/services/progress.py backend/app/services/sessions.py backend/tests/test_today_persistence.py backend/tests/test_progress_api.py` -> passed.
- `uv run --project backend pytest backend/tests/test_today_persistence.py backend/tests/test_attempts.py backend/tests/test_progress_api.py backend/tests/test_import_words.py` -> 70 passed, 1 existing StarletteDeprecationWarning.
- `uv run --project backend pytest` -> 157 passed, 1 existing StarletteDeprecationWarning.
- `git diff --check` -> passed.
- `tools/agents/agent-audit` -> passed with no drift findings.

## Residual risks

- This PR adds compatibility columns to `daily_sessions`; existing DBs are patched lazily via `init_db`/session repository paths, but production rollout should still treat DB backup as prudent.
- The weak-phoneme focused group is contract-only here; #118 owns the user-facing Progress action and any explicit weak-focus API wiring.
- Frontend UI still uses existing `/api/today` flow; user-facing multi-group/review buttons belong to later M7 UI issues.
- Concurrent creation of same-day groups is not locked beyond SQLite primary keys and current single-user MVP assumptions.