### PR TITLE
Implement M7 practice loop UI actions

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,7 @@ function App() {
   const [backendReady, setBackendReady] = useState<boolean>(false);
   const [checking, setChecking] = useState(true);
   const [page, setPage] = useState<"today" | "progress" | "settings">("today");
+  const [focusPhonemes, setFocusPhonemes] = useState<string[]>([]);
 
   useEffect(() => {
     fetchHealth()
@@ -47,10 +48,18 @@ function App() {
           onClick={() => setPage("settings")}>Settings</button>
       </nav>
       {page === "progress"
-        ? <ProgressPage onBack={() => setPage("today")} />
+        ? <ProgressPage
+            onBack={() => setPage("today")}
+            focusPhonemes={focusPhonemes}
+            onFocusChange={setFocusPhonemes}
+          />
         : page === "settings"
         ? <SettingsPage onBack={() => setPage("today")} />
-        : <TodayPractice />
+        : <TodayPractice
+            focusPhonemes={focusPhonemes}
+            onFocusChange={setFocusPhonemes}
+            onOpenProgress={() => setPage("progress")}
+          />
       }
     </div>
   );

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -69,11 +69,17 @@ export interface TodayItem {
 
 export interface TodayResponse {
   session_id: string;
+  group_id?: string;
+  group_index?: number;
+  group_type?: string;
   date: string;
   primary_accent: string;
   daily_word_count: number;
+  word_count?: number;
   status: string;
+  source_session_item_ids?: string[];
   items: TodayItem[];
+  source_count?: number;
   error?: string;
   detail?: string;
 }
@@ -82,6 +88,16 @@ export async function fetchToday(): Promise<TodayResponse> {
   const res = await fetch(`${API_BASE}/today`);
   if (!res.ok) {
     throw new Error(`GET /api/today failed: ${res.status}`);
+  }
+  return res.json();
+}
+
+export async function startRecentMistakeReview(): Promise<TodayResponse> {
+  const res = await fetch(`${API_BASE}/review/recent-mistakes`, {
+    method: "POST",
+  });
+  if (!res.ok) {
+    throw new Error(await normalizeApiError(res));
   }
   return res.json();
 }

--- a/frontend/src/components/ChoiceQuestion.tsx
+++ b/frontend/src/components/ChoiceQuestion.tsx
@@ -50,7 +50,7 @@ export function ChoiceQuestion({ item, onResult }: Props) {
         isCorrect: result.is_correct,
         correctAnswer: result.correct_answer,
       });
-    } catch (err: any) {
+    } catch (err: unknown) {
       // submitAttempt normalises errors into Error with .message
       const message = err instanceof Error ? err.message : String(err);
       setError(message);

--- a/frontend/src/pages/ProgressPage.tsx
+++ b/frontend/src/pages/ProgressPage.tsx
@@ -5,27 +5,64 @@
  */
 
 import { useEffect, useState } from "react";
-import type { ProgressResponse } from "../api";
-import { fetchProgress } from "../api";
+import type { ProgressResponse, SettingsData } from "../api";
+import { fetchProgress, fetchSettings, saveSettings } from "../api";
 
 interface Props {
   onBack: () => void;
+  focusPhonemes: string[];
+  onFocusChange: (focusPhonemes: string[]) => void;
 }
 
-export default function ProgressPage({ onBack }: Props) {
+export default function ProgressPage({
+  onBack,
+  focusPhonemes,
+  onFocusChange,
+}: Props) {
   const [data, setData] = useState<ProgressResponse | null>(null);
+  const [settings, setSettings] = useState<SettingsData | null>(null);
   const [loading, setLoading] = useState(true);
+  const [savingFocus, setSavingFocus] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const activeFocus = settings?.focus_phonemes ?? focusPhonemes;
 
   useEffect(() => {
-    fetchProgress()
-      .then(setData)
+    Promise.all([fetchProgress(), fetchSettings()])
+      .then(([progressData, settingsData]) => {
+        setData(progressData);
+        setSettings(settingsData);
+        onFocusChange(settingsData.focus_phonemes);
+      })
       .catch((e) => setError(e.message))
       .finally(() => setLoading(false));
-  }, []);
+  }, [onFocusChange]);
+
+  const updateFocus = async (nextFocus: string[], navigateAfter = false) => {
+    setSavingFocus(nextFocus.join(",") || "clear");
+    setError(null);
+    try {
+      const updated = await saveSettings({ focus_phonemes: nextFocus });
+      setSettings(updated);
+      onFocusChange(updated.focus_phonemes);
+      if (navigateAfter) onBack();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to update focus");
+    } finally {
+      setSavingFocus(null);
+    }
+  };
+
+  const focusOne = (phoneme: string) => {
+    const next = [phoneme, ...activeFocus.filter((item) => item !== phoneme)];
+    void updateFocus(next, true);
+  };
+
+  const clearFocus = () => {
+    void updateFocus([]);
+  };
 
   if (loading) return <main className="practice-container"><p>Loading progress…</p></main>;
-  if (error) return <main className="practice-container"><p className="error">Failed: {error}</p></main>;
+  if (error && !data) return <main className="practice-container"><p className="error">Failed: {error}</p></main>;
   if (!data) return null;
 
   return (
@@ -34,6 +71,25 @@ export default function ProgressPage({ onBack }: Props) {
         <button className="back-btn" onClick={onBack}>← Today</button>
         <h1>Progress</h1>
       </div>
+      {error && <p className="save-error">{error}</p>}
+
+      {activeFocus.length > 0 && (
+        <div className="focus-panel">
+          <span className="focus-panel-label">Next group focus</span>
+          <div className="phoneme-chip-list">
+            {activeFocus.map((phoneme) => (
+              <span className="phoneme-chip" key={phoneme}>{phoneme}</span>
+            ))}
+          </div>
+          <button
+            className="secondary-action-btn compact"
+            onClick={clearFocus}
+            disabled={savingFocus !== null}
+          >
+            Clear focus
+          </button>
+        </div>
+      )}
 
       <div className="progress-stats">
         <div className="stat-card">
@@ -59,6 +115,13 @@ export default function ProgressPage({ onBack }: Props) {
                 <span className="phoneme-symbol">{p.phoneme}</span>
                 <span className="phoneme-acc">{Math.round(p.accuracy * 100)}%</span>
                 <span className="phoneme-count">{p.attempt_count} att.</span>
+                <button
+                  className="focus-action-btn"
+                  onClick={() => focusOne(p.phoneme)}
+                  disabled={savingFocus !== null}
+                >
+                  {activeFocus.includes(p.phoneme) ? "Focused" : "Focus"}
+                </button>
               </li>
             ))}
           </ul>

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -60,6 +60,16 @@ export default function SettingsPage({ onBack }: Props) {
     void update({ focus_phonemes });
   };
 
+  const removeFocusPhoneme = (phoneme: string) => {
+    void update({
+      focus_phonemes: settings.focus_phonemes.filter((item) => item !== phoneme),
+    });
+  };
+
+  const clearFocusPhonemes = () => {
+    void update({ focus_phonemes: [] });
+  };
+
   return (
     <main className="practice-container">
       <div className="page-header">
@@ -74,7 +84,7 @@ export default function SettingsPage({ onBack }: Props) {
         {/* ---- MVP-supported controls ---- */}
 
         <label className="setting-row">
-          <span>Words per day</span>
+          <span>Words per group</span>
           <input type="number" min={1} max={50} value={settings.daily_word_count}
             onChange={e => update({ daily_word_count: Number(e.target.value) })} />
         </label>
@@ -96,7 +106,7 @@ export default function SettingsPage({ onBack }: Props) {
         </label>
 
         <label className="setting-row setting-row-stacked">
-          <span>Focus phonemes</span>
+          <span>Manual focus entry</span>
           <input
             className="focus-input"
             type="text"
@@ -113,10 +123,27 @@ export default function SettingsPage({ onBack }: Props) {
         </label>
 
         {settings.focus_phonemes.length > 0 && (
-          <div className="phoneme-chip-list">
-            {settings.focus_phonemes.map((phoneme) => (
-              <span className="phoneme-chip" key={phoneme}>{phoneme}</span>
-            ))}
+          <div className="settings-focus-panel">
+            <span className="focus-panel-label">Next group focus</span>
+            <div className="phoneme-chip-list">
+              {settings.focus_phonemes.map((phoneme) => (
+                <button
+                  className="phoneme-chip removable"
+                  key={phoneme}
+                  onClick={() => removeFocusPhoneme(phoneme)}
+                  type="button"
+                >
+                  {phoneme} ×
+                </button>
+              ))}
+            </div>
+            <button
+              className="secondary-action-btn compact"
+              onClick={clearFocusPhonemes}
+              type="button"
+            >
+              Clear focus
+            </button>
           </div>
         )}
 

--- a/frontend/src/pages/TodayPractice.tsx
+++ b/frontend/src/pages/TodayPractice.tsx
@@ -6,45 +6,82 @@
  * refresh-safe: reloading on the same date resumes the same session.
  */
 
-import { useEffect, useState } from "react";
-import type { TodayItem, TodayResponse } from "../api";
-import { fetchToday } from "../api";
+import { useCallback, useEffect, useState } from "react";
+import type { SettingsData, TodayItem, TodayResponse } from "../api";
+import { fetchSettings, fetchToday, startRecentMistakeReview } from "../api";
 import type { ChoiceResult } from "../components/ChoiceQuestion";
 import { ChoiceQuestion } from "../components/ChoiceQuestion";
+
+interface Props {
+  focusPhonemes: string[];
+  onFocusChange: (focusPhonemes: string[]) => void;
+  onOpenProgress: () => void;
+}
 
 interface PracticeResult {
   sessionItemId: string;
   wordId: string;
   word: string;
+  targetPhonemes: string[];
   selectedAnswer: string;
   correctAnswer: string;
   isCorrect: boolean;
 }
 
-export default function TodayPractice() {
+function groupLabel(session: TodayResponse): string {
+  if (session.group_type === "mistake_review") return "Mistake review";
+  return `Group ${session.group_index ?? 1}`;
+}
+
+export default function TodayPractice({
+  focusPhonemes,
+  onFocusChange,
+  onOpenProgress,
+}: Props) {
   const [session, setSession] = useState<TodayResponse | null>(null);
   const [loading, setLoading] = useState(true);
+  const [actionLoading, setActionLoading] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
   const [currentIndex, setCurrentIndex] = useState(0);
   const [results, setResults] = useState<PracticeResult[]>([]);
   const [finished, setFinished] = useState(false);
 
+  const resetPractice = useCallback((data: TodayResponse, settings?: SettingsData) => {
+    if (data.error) {
+      setError(data.detail ?? data.error);
+      return;
+    }
+    setSession(data);
+    setCurrentIndex(0);
+    setResults([]);
+    setFinished(data.items.length === 0);
+    setNotice(null);
+    if (settings) onFocusChange(settings.focus_phonemes);
+  }, [onFocusChange]);
+
   // Load today's session on mount.
   useEffect(() => {
-    fetchToday()
-      .then((data) => {
-        if (data.error) {
-          setError(data.detail ?? data.error);
-        } else {
-          setSession(data);
-        }
-        setLoading(false);
+    let cancelled = false;
+    Promise.all([fetchToday(), fetchSettings()])
+      .then(([today, settings]) => {
+        if (cancelled) return;
+        setError(null);
+        resetPractice(today, settings);
       })
       .catch((err) => {
-        setError(err.message);
-        setLoading(false);
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : "Failed to load practice");
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
       });
-  }, []);
+
+    return () => {
+      cancelled = true;
+    };
+  }, [resetPractice]);
 
   const handleResult = (item: TodayItem, result: ChoiceResult) => {
     setResults((prev) => [
@@ -53,6 +90,7 @@ export default function TodayPractice() {
         sessionItemId: result.sessionItemId,
         wordId: item.word_id,
         word: item.word,
+        targetPhonemes: item.target_phonemes,
         selectedAnswer: result.selectedAnswer,
         correctAnswer: result.correctAnswer,
         isCorrect: result.isCorrect,
@@ -67,6 +105,36 @@ export default function TodayPractice() {
       setFinished(true);
     } else {
       setCurrentIndex(nextIndex);
+    }
+  };
+
+  const handleContinue = async () => {
+    setActionLoading("continue");
+    setError(null);
+    try {
+      const data = await fetchToday();
+      resetPractice(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load another group");
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  const handleMistakeReview = async () => {
+    setActionLoading("review");
+    setError(null);
+    try {
+      const data = await startRecentMistakeReview();
+      if (data.status === "empty" || data.items.length === 0) {
+        setNotice(data.detail ?? "No recent mistakes are ready for review.");
+      } else {
+        resetPractice(data);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to start review");
+    } finally {
+      setActionLoading(null);
     }
   };
 
@@ -99,22 +167,59 @@ export default function TodayPractice() {
   if (finished) {
     const correctCount = results.filter((r) => r.isCorrect).length;
     const total = results.length;
+    const wrongResults = results.filter((r) => !r.isCorrect);
+    const hasMistakes = wrongResults.length > 0;
     return (
       <main className="practice-container">
         <div className="practice-summary">
-          <h2>Practice complete!</h2>
+          <h2>{groupLabel(session)} complete</h2>
           <p className="summary-score">
             {correctCount} / {total} correct
           </p>
-          <ul className="summary-list">
-            {results.map((r, i) => (
-              <li key={i} className={r.isCorrect ? "summary-correct" : "summary-wrong"}>
-                <strong>{r.word}</strong> — you picked{" "}
-                <code>{r.selectedAnswer}</code>
-                {r.isCorrect ? " ✅" : ` ❌ (correct: ${r.correctAnswer})`}
-              </li>
-            ))}
-          </ul>
+          {wrongResults.length > 0 ? (
+            <section className="summary-section">
+              <h3>Review these</h3>
+              <ul className="summary-list">
+                {wrongResults.map((r) => (
+                  <li key={r.sessionItemId} className="summary-wrong">
+                    <span>
+                      <strong>{r.word}</strong>
+                      <span className="summary-answer">
+                        picked <code>{r.selectedAnswer}</code>, correct{" "}
+                        <code>{r.correctAnswer}</code>
+                      </span>
+                    </span>
+                    <span className="summary-phonemes">
+                      {r.targetPhonemes.join(" ")}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          ) : (
+            <p className="summary-perfect">No misses in this group.</p>
+          )}
+          {error && <p className="save-error">{error}</p>}
+          {notice && <p className="empty-hint">{notice}</p>}
+          <div className="summary-actions">
+            <button
+              className="primary-action-btn"
+              onClick={handleContinue}
+              disabled={actionLoading !== null}
+            >
+              {actionLoading === "continue" ? "Loading…" : "Continue"}
+            </button>
+            <button
+              className="secondary-action-btn"
+              onClick={handleMistakeReview}
+              disabled={!hasMistakes || actionLoading !== null}
+            >
+              {actionLoading === "review" ? "Loading…" : "Review mistakes"}
+            </button>
+            <button className="secondary-action-btn" onClick={onOpenProgress}>
+              Stop
+            </button>
+          </div>
         </div>
       </main>
     );
@@ -127,9 +232,17 @@ export default function TodayPractice() {
   return (
     <main className="practice-container">
       <div className="practice-header">
-        <span className="progress-label">Progress: {progress}</span>
-        <span className="accent-label">{session.primary_accent} practice</span>
+        <span className="progress-label">{groupLabel(session)}: {progress}</span>
+        <span className="accent-label">{session.primary_accent}</span>
       </div>
+      {focusPhonemes.length > 0 && (
+        <div className="active-focus-banner">
+          <span>Focus</span>
+          {focusPhonemes.map((phoneme) => (
+            <span className="phoneme-chip" key={phoneme}>{phoneme}</span>
+          ))}
+        </div>
+      )}
 
       <ChoiceQuestion
         key={currentItem.session_item_id}

--- a/frontend/src/pages/TodayPractice.tsx
+++ b/frontend/src/pages/TodayPractice.tsx
@@ -148,7 +148,22 @@ export default function TodayPractice({
   }
 
   // Error state
-  if (error || !session || session.error) {
+  if (!session) {
+    return (
+      <main className="practice-container">
+        <div className="practice-error">
+          <h2>Practice unavailable</h2>
+          <p>{error || "Unknown error"}</p>
+          <p className="hint">
+            Make sure you've run <code>import_words.py</code> and the backend
+            is running.
+          </p>
+        </div>
+      </main>
+    );
+  }
+
+  if (!finished && (error || session.error)) {
     return (
       <main className="practice-container">
         <div className="practice-error">
@@ -168,7 +183,6 @@ export default function TodayPractice({
     const correctCount = results.filter((r) => r.isCorrect).length;
     const total = results.length;
     const wrongResults = results.filter((r) => !r.isCorrect);
-    const hasMistakes = wrongResults.length > 0;
     return (
       <main className="practice-container">
         <div className="practice-summary">
@@ -212,7 +226,7 @@ export default function TodayPractice({
             <button
               className="secondary-action-btn"
               onClick={handleMistakeReview}
-              disabled={!hasMistakes || actionLoading !== null}
+              disabled={actionLoading !== null}
             >
               {actionLoading === "review" ? "Loading…" : "Review mistakes"}
             </button>

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -249,7 +249,22 @@ button {
 .summary-score {
   font-size: 1.5rem;
   font-weight: 700;
-  margin-bottom: 20px;
+  margin-bottom: 16px;
+}
+
+.summary-section {
+  margin: 16px 0;
+  text-align: left;
+}
+
+.summary-section h3 {
+  font-size: 1rem;
+  margin-bottom: 8px;
+}
+
+.summary-perfect {
+  color: #2e7d32;
+  margin: 16px 0;
 }
 
 .summary-list {
@@ -259,7 +274,10 @@ button {
 }
 
 .summary-list li {
-  padding: 8px 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 10px 0;
   border-bottom: 1px solid #eee;
   font-size: 0.95rem;
 }
@@ -270,6 +288,90 @@ button {
 
 .summary-wrong {
   color: #c62828;
+}
+
+.summary-answer {
+  display: block;
+  color: #555;
+  font-size: 0.85rem;
+  margin-top: 2px;
+}
+
+.summary-phonemes {
+  color: #174ea6;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.summary-actions {
+  display: grid;
+  gap: 8px;
+  margin-top: 20px;
+}
+
+.primary-action-btn,
+.secondary-action-btn,
+.focus-action-btn {
+  border-radius: 6px;
+  font-weight: 600;
+  min-height: 40px;
+  padding: 9px 12px;
+}
+
+.primary-action-btn {
+  background: #174ea6;
+  border: 1px solid #174ea6;
+  color: #fff;
+}
+
+.secondary-action-btn {
+  background: #f5f7fb;
+  border: 1px solid #d6e4ff;
+  color: #174ea6;
+}
+
+.secondary-action-btn.compact {
+  align-self: flex-start;
+  font-size: 0.85rem;
+  min-height: 34px;
+  padding: 6px 10px;
+}
+
+.primary-action-btn:disabled,
+.secondary-action-btn:disabled,
+.focus-action-btn:disabled {
+  cursor: default;
+  opacity: 0.55;
+}
+
+.active-focus-banner,
+.focus-panel,
+.settings-focus-panel {
+  align-items: center;
+  background: #f8fbff;
+  border: 1px solid #d6e4ff;
+  border-radius: 8px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 16px;
+  padding: 10px;
+}
+
+.active-focus-banner {
+  font-size: 0.85rem;
+}
+
+.focus-panel,
+.settings-focus-panel {
+  align-items: flex-start;
+  flex-direction: column;
+}
+
+.focus-panel-label {
+  color: #555;
+  font-size: 0.85rem;
+  font-weight: 700;
 }
 
 /* ---------------------------------------------------------------------------
@@ -398,6 +500,16 @@ button {
   margin-left: auto;
 }
 
+.focus-action-btn {
+  background: #fff7ed;
+  border: 1px solid #ffcc80;
+  color: #b45309;
+  font-size: 0.8rem;
+  margin-left: 4px;
+  min-height: 32px;
+  padding: 5px 8px;
+}
+
 .phoneme-item.weak .phoneme-symbol {
   color: #e65100;
 }
@@ -480,6 +592,11 @@ button {
   font-size: 0.85rem;
   line-height: 1;
   padding: 5px 7px;
+}
+
+.phoneme-chip.removable {
+  background: #fff;
+  cursor: pointer;
 }
 
 .save-confirm {


### PR DESCRIPTION
## Scope completed

- Implements TodayPractice group-completion summary/action flow for #117:
  - group-based completion wording
  - wrong-word review summary with target phonemes
  - continue another group, start recent mistake review, and stop/return actions
- Implements Progress weak phoneme actionability for #118:
  - weak phoneme Focus actions
  - selected focus visible before/while practicing the next group
  - clear-focus path
- Updates Settings focus display/removal wording so manual IPA entry is no longer the primary path.
- Adds frontend API client support for M7 group metadata and `POST /api/review/recent-mistakes`.

Linked issues: #114, #117, #118

## Verification

- `cd frontend && pnpm run lint` passed
- `cd frontend && pnpm exec tsc --noEmit` passed
- `cd frontend && pnpm run build` passed
- `git diff --check` passed
- `tools/agents/agent-audit` passed; one transient GitHub TLS timeout occurred and helper retry completed cleanly

## Browser smoke

- Attempted route-mocked Playwright smoke covering completion actions, recent mistake review, Progress focus selection, and clear-focus behavior.
- Blocked by local browser environment:
  - bundled Playwright Chromium cache was missing
  - fallback local Google Chrome headless launch aborted with `SIGABRT` / `kill EPERM`
- Per flow update, browser smoke is documented as a residual verification blocker rather than continuing to repair the local browser environment in this implementer pass.

## Residual risks

- Interactive desktop/mobile browser smoke remains unverified in this local environment.
- Recent mistake review action is wired to the M7 backend endpoint from #121; live end-to-end behavior should be confirmed by reviewer/Architect in an environment with a working browser runtime.
- This PR does not implement #119 detailed review explanations or #120 final M7 integration QA/readiness.