### PR TITLE
Add lightweight missed-answer explanations

### DIFF
--- a/frontend/src/components/ChoiceQuestion.tsx
+++ b/frontend/src/components/ChoiceQuestion.tsx
@@ -18,6 +18,13 @@ export interface ChoiceResult {
   correctAnswer: string;
 }
 
+function buildFocusHint(targetPhonemes: string[]): string {
+  if (targetPhonemes.length === 0) {
+    return "Focus on the IPA difference, then listen again.";
+  }
+  return `Focus on ${targetPhonemes.join(" ")} before choosing.`;
+}
+
 interface Props {
   item: TodayItem;
   onResult: (result: ChoiceResult) => void;
@@ -28,6 +35,7 @@ export function ChoiceQuestion({ item, onResult }: Props) {
   const [submitting, setSubmitting] = useState(false);
   const [feedback, setFeedback] = useState<{
     isCorrect: boolean;
+    selectedAnswer: string;
     correctAnswer: string;
   } | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -42,6 +50,7 @@ export function ChoiceQuestion({ item, onResult }: Props) {
       const result = await submitAttempt(item.session_item_id, choice);
       setFeedback({
         isCorrect: result.is_correct,
+        selectedAnswer: choice,
         correctAnswer: result.correct_answer,
       });
       onResult({
@@ -118,10 +127,18 @@ export function ChoiceQuestion({ item, onResult }: Props) {
           {feedback.isCorrect ? (
             <p>✅ Correct!</p>
           ) : (
-            <p>
-              ❌ Not quite — the correct answer is{" "}
-              <strong>{feedback.correctAnswer}</strong>
-            </p>
+            <div className="missed-answer-explanation">
+              <p>❌ Not quite.</p>
+              <div className="explanation-grid">
+                <span>You picked</span>
+                <code>{feedback.selectedAnswer}</code>
+                <span>Correct IPA</span>
+                <code>{feedback.correctAnswer}</code>
+                <span>Target sound</span>
+                <strong>{item.target_phonemes.join(" ") || "IPA contrast"}</strong>
+              </div>
+              <p className="focus-hint">{buildFocusHint(item.target_phonemes)}</p>
+            </div>
           )}
         </div>
       )}

--- a/frontend/src/pages/TodayPractice.tsx
+++ b/frontend/src/pages/TodayPractice.tsx
@@ -33,6 +33,13 @@ function groupLabel(session: TodayResponse): string {
   return `Group ${session.group_index ?? 1}`;
 }
 
+function buildFocusHint(targetPhonemes: string[]): string {
+  if (targetPhonemes.length === 0) {
+    return "Focus on the IPA difference, then listen again.";
+  }
+  return `Focus on ${targetPhonemes.join(" ")} before choosing.`;
+}
+
 export default function TodayPractice({
   focusPhonemes,
   onFocusChange,
@@ -204,7 +211,10 @@ export default function TodayPractice({
                       </span>
                     </span>
                     <span className="summary-phonemes">
-                      {r.targetPhonemes.join(" ")}
+                      Target sound: {r.targetPhonemes.join(" ") || "IPA contrast"}
+                    </span>
+                    <span className="summary-hint">
+                      {buildFocusHint(r.targetPhonemes)}
                     </span>
                   </li>
                 ))}

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -234,6 +234,35 @@ button {
   border: 1px solid #ef9a9a;
 }
 
+.missed-answer-explanation {
+  display: grid;
+  gap: 8px;
+}
+
+.missed-answer-explanation p {
+  margin: 0;
+}
+
+.explanation-grid {
+  align-items: center;
+  display: grid;
+  gap: 6px 10px;
+  grid-template-columns: minmax(84px, max-content) minmax(0, 1fr);
+  text-align: left;
+}
+
+.explanation-grid span {
+  color: #555;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.focus-hint,
+.summary-hint {
+  color: #555;
+  font-size: 0.85rem;
+}
+
 /* ---------------------------------------------------------------------------
  * Summary
  * --------------------------------------------------------------------------- */
@@ -301,6 +330,10 @@ button {
   color: #174ea6;
   font-size: 0.85rem;
   font-weight: 600;
+}
+
+.summary-hint {
+  display: block;
 }
 
 .summary-actions {


### PR DESCRIPTION
## Scope completed

- Adds lightweight missed-answer explanations for #119 in the existing practice card feedback.
- Incorrect answers now show:
  - selected IPA
  - correct IPA
  - target sound / target phoneme(s)
  - a short beginner-friendly `Focus on ...` hint
- Adds the same concise focus hint to the completion summary for missed words.
- Reuses existing `TodayItem.target_phonemes` and answer data; no new authored lesson system, backend schema, or scheduler changes.
- Preserves the existing audio replay affordance on the practice card.

Linked issues: #114, #119

## Verification

- `cd frontend && pnpm run lint` passed
- `cd frontend && pnpm exec tsc --noEmit` passed
- `cd frontend && pnpm run build` passed
- `git diff --check` passed
- `tools/agents/agent-audit` passed after one transient GitHub TLS retry

## Browser / Mobile Smoke

- Attempted to verify the local browser runtime for a mobile wrong-answer smoke.
- Blocked by local browser environment:
  - bundled Playwright Chromium executable is missing from `~/Library/Caches/ms-playwright/...`
  - local Google Chrome headless launch aborts with `SIGABRT` / permission-limited headless process

## Residual risks

- Mobile viewport wrong-answer smoke remains unverified locally because the browser runtime is blocked.
- Copy is intentionally lightweight and generic; richer contrast/lesson explanations remain out of scope for #119.