### PR TITLE
Define M7 v2 learner workflow contract

### DIFF
--- a/docs/05-data-api-contracts.md
+++ b/docs/05-data-api-contracts.md
@@ -157,6 +157,90 @@ GET /api/health
 }
 ```
 
+## M7 v2 learner workflow contract
+
+M7 v2 defines the practice loop from the learner's point of view before adding
+more endpoints or UI buttons. The app should make the next action obvious:
+
+```text
+Start normal group
+-> answer all items
+-> read current group result
+-> choose next normal group, review current misses, review recent mistakes,
+   choose focus, or stop
+```
+
+The learner goal is to complete multiple short groups in one sitting, use wrong
+answers immediately, and optionally focus a weak sound without typing raw IPA.
+The backend may still use `session_items`, `attempts`, and `phoneme_stats` as
+the source of truth; the UI and API must expose enough group metadata to explain
+why the learner is seeing a group.
+
+### User-facing states
+
+| State | Meaning | Primary visible actions |
+| --- | --- | --- |
+| Entry/home | No active card is being answered. The app can resume an active group or start today's first normal group. | Start/resume practice, Progress, Settings |
+| Active normal group | Learner is answering a standard 10-word group. | Answer item, listen/replay where available |
+| Group completed | All items in the current group are answered. Current-group results remain visible while follow-up actions run. | Start next 10-word group, review misses from this group, review recent mistakes, choose focus, stop |
+| Current-group review | Learner is reviewing words missed in the just-finished group. | Answer review items, return to summary when done |
+| Recent-mistake review | Learner is reviewing recent missed words across earlier groups. | Answer review items, handle empty queue |
+| Choose focus | Learner selects a weak phoneme from Progress or another guided list. | Start focused group, clear focus, return |
+| Focused group | Learner practices words weighted toward selected phoneme(s). | Answer items, clear focus after completion |
+| Stopped/returning | Learner intentionally leaves practice. Returning should resume an active group or show a clear start action. | Resume group, start next group, Progress |
+| Empty review | No reviewable mistakes exist for the selected review scope. | Return to summary, start next group |
+| Error/retry | A backend or network action failed. The previous meaningful state stays visible. | Retry action, return, start next group if safe |
+
+### Action semantics
+
+| Action | Scope | Required behavior | Copy obligation |
+| --- | --- | --- | --- |
+| Start/resume practice | Active normal group or first normal group for today | Resume an unfinished normal group; otherwise create the first normal group. | Say whether the learner is resuming or starting. |
+| Start next 10-word group | Next normal group after a completed normal group | Create the next normal group if no active normal group exists; if one exists, resume it and say so. | Do not label this only as `Continue`; name it as next group/resume. |
+| Review misses from this group | Current completed group | Create a review group from the current group's wrong answers only. Empty state is non-error. | Label as current-group review, not global review. |
+| Review recent mistakes | Global recent history | Create a review group from recent wrong attempts across groups. Empty state is non-error. | Label as recent mistakes and keep it distinct from current-group misses. |
+| Focus weak phoneme | Selected phoneme(s) | Store or pass the selected focus and offer focused practice. M7 v2 primary behavior is to start a dedicated focused group from this action. | Explain which phoneme is selected and that the next group focuses on it. |
+| Start focused group | Selected focus | Create or resume a `weak_focus` group using scheduler focus weighting. | Name the group as focused and show focus chips. |
+| Clear focus | Current selected focus | Remove selected focus and return future practice to normal weighting. | Make return to normal practice explicit. |
+| Stop | Current known state | Leave practice without losing a resumable active group. | Prefer `Back to Progress` or `Return home` over generic `Stop` when possible. |
+| Settings | User preferences | Keep raw IPA focus input out of the primary learner path; if retained, mark it advanced/debug. | Words count is `words per group`, not words per day. |
+
+### State transition table
+
+| Current UI state | Domain state | User action | Command/query | Next domain state | Next UI state | User-facing copy | Failure/empty state |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Entry/home | No active group or unknown | Start practice | `GET /api/today` or future explicit start query | Active normal group | Active normal group | `Group 1`, `10 words` | Show setup/import error with retry |
+| Entry/home | Active normal group exists | Resume practice | `GET /api/today` | Same active normal group | Active normal group | `Resume Group N` | Keep entry/home actions visible |
+| Active normal group | Pending items remain | Submit answer | `POST /api/attempt` | Attempt recorded; next item pending | Active normal group | Feedback on current answer | Keep item visible with retry |
+| Active normal group | Last item answered | Submit answer | `POST /api/attempt` | Group completed | Group completed | Score, current misses, target sounds, next choices | Keep summary if follow-up load fails |
+| Group completed | Completed normal group with misses | Review this group | #136 current-group review action | Review group sourced from current group | Current-group review | `Review misses from Group N` | `No misses in this group` |
+| Group completed | Completed normal group | Review recent mistakes | `POST /api/review/recent-mistakes` or #136 replacement | Recent-mistake review group | Recent-mistake review | `Review recent mistakes` | `No recent mistakes ready` |
+| Group completed | Completed normal group | Start next group | #136 next-normal action | Next normal group or resumed intended active group | Active normal group | `Start Group N+1` or `Resume Group N+1` | Keep completion summary with retry |
+| Group completed or Progress | Weak phoneme selected | Start focused practice | #136 focus action | Active `weak_focus` group | Focused group | `Focused group: /.../` | Keep focus choice visible with retry |
+| Focused group completed | Focus remains selected | Clear focus | #136 clear-focus action or settings update | No active focus | Group completed or Progress | `Back to normal practice` | Show clear failure without losing summary |
+| Any review/focused group | Learner leaves practice | Stop/return | UI navigation only | Active group may remain resumable | Progress or home | `Return to Progress` / `Resume later` | N/A |
+| Any action state | Request fails | Retry | Same command/query | Prior domain state preserved | Prior meaningful UI state | Inline failure near action | Do not replace summary with generic unavailable state |
+
+### Walkthrough scenarios for M7 v2
+
+#135 must automate these scenarios with Playwright in a mobile viewport:
+
+1. Start a normal group, answer all items, and reach a completion summary that
+   names the group, score, current misses, and next actions.
+2. Start the next normal group from the summary and verify the UI shows a new or
+   explicitly resumed intended group, not an ambiguous repeat.
+3. Miss at least one answer, choose current-group review, and verify the review
+   items come from that completed group.
+4. Choose recent-mistake review and verify it is labeled separately from
+   current-group review, including the empty state.
+5. Select a weak phoneme without raw IPA typing, start a focused group, verify
+   focus visibility, then clear focus and return to normal practice.
+6. Trigger a follow-up action failure in a controlled fixture and verify the
+   completion summary remains visible with an inline retry/error message.
+
+The final M7 v2 readiness review (#139) must prove these walkthroughs pass
+against the M7 v2 integration branch, not only route-mocked fixtures.
+
 ### Today
 
 ```http

--- a/docs/06-epic-roadmap.md
+++ b/docs/06-epic-roadmap.md
@@ -227,28 +227,33 @@ Dependency model:
 
 Goal: turn the current daily quiz into a repeatable learning loop with multiple short practice groups, visible mistake follow-up, and user-understandable weak-phoneme practice.
 
-Expected child issue areas:
+M7 v1 implemented the first backend and UI slices, but hands-on trial showed
+the product workflow was not complete. M7 v2 uses scenario-first delivery:
+the learner workflow contract and Playwright walkthrough gate must exist before
+additional API/UI implementation is released.
+
+Expected child issue areas for M7 v2:
 
 ```text
-practice group model and same-day multi-group flow
-continue with another 10-word group after completion
-recent mistake review queue
-wrong-word and weak-phoneme summary after each group
-lightweight answer explanation for missed items
-Progress page actions for weak phonemes
-focus_phonemes UX replacement with selectable chips/actions
-settings wording: words per group rather than words per day
+end-to-end learner workflow contract with state transition table
+Playwright mobile walkthrough harness for the accepted contract
+explicit next-group, current-group review, recent-review, and focus API semantics
+Today practice workflow UI rebuilt around scoped actions and clear copy
+Progress/Settings focus workflow without raw IPA typing in the primary path
+scenario readiness review with browser evidence
 ```
 
 Acceptance:
 
 ```text
+learner can understand the loop without external docs
 learner can complete multiple 10-word groups in one day
-completed group summary shows wrong words and implicated phonemes
-learner can start a review group from recent mistakes
+completed group summary distinguishes current-group misses from broader review suggestions
+learner can review current-group misses and recent/global mistakes as separate concepts
 weak phonemes can be selected from Progress without typing raw IPA text
-focus_phonemes behavior is visible in the next generated group
+focused practice entry and clear-focus behavior are visible and testable
 existing phoneme_stats and scheduler weighting remain the source of review behavior
+Playwright walkthrough passes in a mobile viewport before M7 v2 acceptance
 ```
 
 ## M8：Level-based Content Expansion and Core 1000 Rebalance


### PR DESCRIPTION
## Scope

Closes #134.

Defines the M7 v2 learner workflow contract before further API/UI implementation:

- adds `M7 v2 learner workflow contract` to `docs/05-data-api-contracts.md`;
- names user-facing states, action semantics, state transition table, and Playwright walkthrough scenarios;
- updates `docs/06-epic-roadmap.md` so M7 is explicitly scenario-first and walkthrough-gated.

## Contract decisions

- `Continue` is replaced at the contract level by explicit next/resume group semantics.
- Current-group review and recent/global mistake review are separate concepts.
- Focus primary behavior is explicit focused practice, not hidden settings-only weighting.
- Manual raw IPA focus entry is out of the primary learner path.
- Follow-up action failures must keep the prior meaningful UI state visible.

## Verification

- `git diff --check`
- `tools/agents/agent-audit`

## Residual risks

- This is docs/contract only. #135 must turn the contract into Playwright walkthrough evidence before #136-#138 implementation proceeds.
- API endpoint shapes remain open to #136 as long as they satisfy the contract semantics and response metadata requirements.