### PR TITLE
Add M7 walkthrough harness

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -9,6 +9,8 @@ lerna-debug.log*
 
 node_modules
 dist
+playwright-report
+test-results
 dist-ssr
 *.local
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -2,6 +2,18 @@
 
 This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
 
+## M7 Walkthrough
+
+Run the M7 v2 learner workflow harness from this directory:
+
+```bash
+pnpm test:e2e:m7
+```
+
+The harness uses `@playwright/test`, Chromium, a mobile viewport, and route-mocked disposable API data. It does not connect to the local backend or mutate `backend/tiny_ipa.sqlite`. Failure screenshots, traces, and videos are written under `test-results/m7-walkthrough`; the HTML report is written under `playwright-report/m7`.
+
+Some contract assertions are marked as expected failures until the later M7 v2 implementation issues add the scoped next-group, current-group review, recent-review, and focused-practice behavior. Tooling/bootstrap failures are still surfaced by the passing smoke and summary tests.
+
 Currently, two official plugins are available:
 
 - [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Oxc](https://oxc.rs)

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test:e2e:m7": "playwright test -c playwright.m7.config.ts"
   },
   "dependencies": {
     "react": "^19.2.6",
@@ -15,6 +16,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@playwright/test": "^1.60.0",
     "@types/node": "^24.12.3",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/frontend/playwright.m7.config.ts
+++ b/frontend/playwright.m7.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  outputDir: "./test-results/m7-walkthrough",
+  reporter: [["list"], ["html", { open: "never", outputFolder: "playwright-report/m7" }]],
+  fullyParallel: false,
+  use: {
+    baseURL: "http://127.0.0.1:5177",
+    screenshot: "only-on-failure",
+    trace: "retain-on-failure",
+    video: "retain-on-failure",
+  },
+  projects: [
+    {
+      name: "m7-mobile-chromium",
+      use: {
+        ...devices["Pixel 5"],
+        browserName: "chromium",
+      },
+    },
+  ],
+  webServer: {
+    command: "pnpm exec vite --host 127.0.0.1 --port 5177 --strictPort",
+    url: "http://127.0.0.1:5177",
+    reuseExistingServer: false,
+    timeout: 120_000,
+  },
+});

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -18,6 +18,9 @@ importers:
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.5.0)
+      '@playwright/test':
+        specifier: ^1.60.0
+        version: 1.60.0
       '@types/node':
         specifier: ^24.12.3
         version: 24.13.2
@@ -213,6 +216,11 @@ packages:
 
   '@oxc-project/types@0.133.0':
     resolution: {integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==}
+
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@rolldown/binding-android-arm64@1.0.3':
     resolution: {integrity: sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==}
@@ -564,6 +572,11 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -765,6 +778,16 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss@8.5.15:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
@@ -1121,6 +1144,10 @@ snapshots:
 
   '@oxc-project/types@0.133.0': {}
 
+  '@playwright/test@1.60.0':
+    dependencies:
+      playwright: 1.60.0
+
   '@rolldown/binding-android-arm64@1.0.3':
     optional: true
 
@@ -1451,6 +1478,9 @@ snapshots:
 
   flatted@3.4.2: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -1596,6 +1626,14 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@4.0.4: {}
+
+  playwright-core@1.60.0: {}
+
+  playwright@1.60.0:
+    dependencies:
+      playwright-core: 1.60.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss@8.5.15:
     dependencies:

--- a/frontend/tests/e2e/m7-walkthrough.spec.ts
+++ b/frontend/tests/e2e/m7-walkthrough.spec.ts
@@ -1,0 +1,387 @@
+import { expect, type Page, type Route, test } from "@playwright/test";
+
+type GroupType = "normal" | "mistake_review" | "weak_focus";
+
+interface MockItem {
+  session_item_id: string;
+  word_id: string;
+  display_ipa: string;
+  word: string;
+  meaning_zh: string;
+  target_phonemes: string[];
+  choices: string[];
+}
+
+interface MockGroup {
+  session_id: string;
+  group_id: string;
+  group_index: number;
+  group_type: GroupType;
+  primary_accent: string;
+  items: MockItem[];
+}
+
+const groups: Record<string, MockGroup> = {
+  group1: {
+    session_id: "session-group-1",
+    group_id: "group-1",
+    group_index: 1,
+    group_type: "normal",
+    primary_accent: "US",
+    items: [
+      {
+        session_item_id: "group-1-item-1",
+        word_id: "ship",
+        display_ipa: "/ʃɪp/",
+        word: "ship",
+        meaning_zh: "船",
+        target_phonemes: ["/ʃ/"],
+        choices: ["/sɪp/", "/ʃɪp/"],
+      },
+      {
+        session_item_id: "group-1-item-2",
+        word_id: "thin",
+        display_ipa: "/θɪn/",
+        word: "thin",
+        meaning_zh: "薄的",
+        target_phonemes: ["/θ/"],
+        choices: ["/θɪn/", "/sɪn/"],
+      },
+    ],
+  },
+  group2: {
+    session_id: "session-group-2",
+    group_id: "group-2",
+    group_index: 2,
+    group_type: "normal",
+    primary_accent: "US",
+    items: [
+      {
+        session_item_id: "group-2-item-1",
+        word_id: "cheese",
+        display_ipa: "/tʃiːz/",
+        word: "cheese",
+        meaning_zh: "奶酪",
+        target_phonemes: ["/tʃ/"],
+        choices: ["/tʃiːz/", "/ʃiːz/"],
+      },
+    ],
+  },
+  recentReview: {
+    session_id: "session-recent-review",
+    group_id: "recent-review",
+    group_index: 3,
+    group_type: "mistake_review",
+    primary_accent: "US",
+    items: [
+      {
+        session_item_id: "review-item-1",
+        word_id: "ship",
+        display_ipa: "/ʃɪp/",
+        word: "ship",
+        meaning_zh: "船",
+        target_phonemes: ["/ʃ/"],
+        choices: ["/sɪp/", "/ʃɪp/"],
+      },
+    ],
+  },
+  focused: {
+    session_id: "session-focused",
+    group_id: "focused-sh",
+    group_index: 4,
+    group_type: "weak_focus",
+    primary_accent: "US",
+    items: [
+      {
+        session_item_id: "focus-item-1",
+        word_id: "shoe",
+        display_ipa: "/ʃuː/",
+        word: "shoe",
+        meaning_zh: "鞋",
+        target_phonemes: ["/ʃ/"],
+        choices: ["/suː/", "/ʃuː/"],
+      },
+    ],
+  },
+};
+
+interface MockState {
+  activeGroup: keyof typeof groups;
+  completedGroups: Set<string>;
+  focusPhonemes: string[];
+  failRecentReview: boolean;
+}
+
+function toTodayResponse(group: MockGroup) {
+  return {
+    session_id: group.session_id,
+    group_id: group.group_id,
+    group_index: group.group_index,
+    group_type: group.group_type,
+    date: "2026-06-17",
+    primary_accent: group.primary_accent,
+    daily_word_count: group.items.length,
+    word_count: group.items.length,
+    status: "active",
+    source_session_item_ids:
+      group.group_type === "mistake_review" ? ["group-1-item-1"] : [],
+    source_count: group.group_type === "mistake_review" ? 1 : 0,
+    items: group.items.map((item) => ({
+      session_item_id: item.session_item_id,
+      word_id: item.word_id,
+      display_ipa: item.display_ipa,
+      word: item.word,
+      meaning_zh: item.meaning_zh,
+      audio_url: `/audio/us/${item.word}.mp3`,
+      target_phonemes: item.target_phonemes,
+      question: {
+        type: "ipa_choice",
+        prompt: "Pick the matching IPA",
+        choices: item.choices,
+      },
+    })),
+  };
+}
+
+function settingsResponse(state: MockState) {
+  return {
+    primary_accent: "US",
+    daily_word_count: 2,
+    show_translation: true,
+    show_accent_compare: false,
+    practice_mode: "adaptive",
+    review_strength: "normal",
+    focus_phonemes: state.focusPhonemes,
+  };
+}
+
+function progressResponse() {
+  return {
+    today_completed: false,
+    today_status: "active",
+    streak_days: 2,
+    total_attempts: 8,
+    total_sessions: 2,
+    weak_phonemes: [
+      {
+        phoneme: "/ʃ/",
+        accuracy: 0.25,
+        attempt_count: 4,
+        correct_count: 1,
+        mastery_status: "weak",
+      },
+    ],
+    strong_phonemes: [
+      {
+        phoneme: "/θ/",
+        accuracy: 0.9,
+        attempt_count: 4,
+        correct_count: 3,
+        mastery_status: "strong",
+      },
+    ],
+  };
+}
+
+async function setupMockApi(
+  page: Page,
+  options: Partial<Pick<MockState, "failRecentReview">> = {},
+): Promise<MockState> {
+  const state: MockState = {
+    activeGroup: "group1",
+    completedGroups: new Set(),
+    focusPhonemes: [],
+    failRecentReview: options.failRecentReview ?? false,
+  };
+
+  await page.route("**/api/**", async (route) => {
+    await routeMock(route, state);
+  });
+
+  return state;
+}
+
+async function routeMock(route: Route, state: MockState) {
+  const request = route.request();
+  const url = new URL(request.url());
+  const path = url.pathname.replace(/^\/api/, "");
+
+  if (path === "/health") {
+    await route.fulfill({
+      json: { status: "ok", content_version: "m7-walkthrough", db_ready: true },
+    });
+    return;
+  }
+
+  if (path === "/settings") {
+    if (request.method() === "PUT") {
+      const body = request.postDataJSON() as { focus_phonemes?: string[] };
+      if (Array.isArray(body.focus_phonemes)) {
+        state.focusPhonemes = body.focus_phonemes;
+      }
+    }
+    await route.fulfill({ json: settingsResponse(state) });
+    return;
+  }
+
+  if (path === "/progress") {
+    await route.fulfill({ json: progressResponse() });
+    return;
+  }
+
+  if (path === "/today") {
+    if (state.focusPhonemes.length > 0) {
+      state.activeGroup = "focused";
+    } else if (state.completedGroups.has("group1")) {
+      state.activeGroup = "group2";
+    }
+    await route.fulfill({ json: toTodayResponse(groups[state.activeGroup]) });
+    return;
+  }
+
+  if (path === "/attempt") {
+    const body = request.postDataJSON() as {
+      session_item_id: string;
+      selected_answer: string;
+    };
+    const item = Object.values(groups)
+      .flatMap((group) => group.items)
+      .find((candidate) => candidate.session_item_id === body.session_item_id);
+
+    if (!item) {
+      await route.fulfill({ status: 404, json: { detail: "Unknown item" } });
+      return;
+    }
+
+    const currentGroup = groups[state.activeGroup];
+    const lastItem = currentGroup.items.at(-1);
+    if (lastItem?.session_item_id === body.session_item_id) {
+      state.completedGroups.add(state.activeGroup);
+    }
+
+    await route.fulfill({
+      json: {
+        is_correct: body.selected_answer === item.display_ipa,
+        correct_answer: item.display_ipa,
+        updated_phonemes: item.target_phonemes.map((phoneme) => ({
+          phoneme,
+          attempt_count: 1,
+          correct_count: body.selected_answer === item.display_ipa ? 1 : 0,
+          mastery_status: body.selected_answer === item.display_ipa ? "strong" : "weak",
+        })),
+        next_action: "continue",
+      },
+    });
+    return;
+  }
+
+  if (path === "/review/recent-mistakes") {
+    if (state.failRecentReview) {
+      await route.fulfill({
+        status: 500,
+        json: { detail: { error: "REVIEW_FAILED", detail: "Review unavailable" } },
+      });
+      return;
+    }
+    state.activeGroup = "recentReview";
+    await route.fulfill({ json: toTodayResponse(groups.recentReview) });
+    return;
+  }
+
+  await route.fallback();
+}
+
+async function openWalkthrough(page: Page) {
+  await page.goto("/");
+  await expect(page.getByText("Group 1: 1 / 2")).toBeVisible();
+}
+
+async function answerVisibleItem(page: Page, choice: string) {
+  await page.getByRole("button", { name: `Select ${choice}` }).click();
+}
+
+async function completeFirstGroupWithOneMiss(page: Page) {
+  await answerVisibleItem(page, "/sɪp/");
+  await expect(page.getByText("Not quite")).toBeVisible();
+  await expect(page.getByText("Target sound")).toBeVisible();
+  await page.getByText("Focus on /ʃ/ before choosing.").waitFor();
+  await expect(page.getByText("thin")).toBeVisible({ timeout: 4_000 });
+
+  await answerVisibleItem(page, "/θɪn/");
+  await expect(page.getByRole("heading", { name: "Group 1 complete" })).toBeVisible({
+    timeout: 4_000,
+  });
+}
+
+test.describe("M7 v2 learner workflow walkthrough", () => {
+  test("1-2 normal group start and completion summary expose current result and next actions", async ({ page }) => {
+    await setupMockApi(page);
+    await test.step("1. normal group start", async () => {
+      await openWalkthrough(page);
+    });
+
+    await test.step("2. completion summary with current group result and next action choices", async () => {
+      await completeFirstGroupWithOneMiss(page);
+      await expect(page.getByText("1 / 2 correct")).toBeVisible();
+      await expect(page.getByText("ship")).toBeVisible();
+      await expect(page.getByText("picked")).toBeVisible();
+      await expect(page.getByText("Target sound: /ʃ/")).toBeVisible();
+      await expect(page.getByRole("button", { name: "Continue" })).toBeVisible();
+      await expect(page.getByRole("button", { name: "Review mistakes" })).toBeVisible();
+      await expect(page.getByRole("button", { name: "Stop" })).toBeVisible();
+    });
+  });
+
+  test("3. next normal group action is visibly new/resumed, not an ambiguous repeat", async ({ page }) => {
+    await setupMockApi(page);
+    await openWalkthrough(page);
+    await completeFirstGroupWithOneMiss(page);
+
+    test.fail(true, "Pending #136: next-normal action copy should name the intended group.");
+    await expect(page.getByRole("button", { name: "Start Group 2" })).toBeVisible();
+  });
+
+  test("4. current-group review and recent/global review are distinguishable", async ({ page }) => {
+    await setupMockApi(page);
+    await openWalkthrough(page);
+    await completeFirstGroupWithOneMiss(page);
+
+    test.fail(true, "Pending #136: current-group review and recent review need separate actions/copy.");
+    await expect(page.getByRole("button", { name: "Review misses from Group 1" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Review recent mistakes" })).toBeVisible();
+  });
+
+  test("5-6. focus can be selected without raw IPA typing and launches focused practice", async ({ page }) => {
+    await setupMockApi(page);
+    await openWalkthrough(page);
+    await page.getByRole("button", { name: "Progress" }).click();
+    await expect(page.getByRole("heading", { name: "Progress" })).toBeVisible();
+    await page.getByRole("button", { name: "Focus" }).click();
+
+    test.fail(true, "Pending #136/#138: selected focus should start a named weak-focus group and expose clear-focus in flow.");
+    await expect(page.getByText("Focused group: /ʃ/")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Clear focus" })).toBeVisible();
+  });
+
+  test("7. stop/return leaves the learner in a known meaningful state", async ({ page }) => {
+    await setupMockApi(page);
+    await openWalkthrough(page);
+    await completeFirstGroupWithOneMiss(page);
+    await page.getByRole("button", { name: "Stop" }).click();
+
+    await expect(page.getByRole("heading", { name: "Progress" })).toBeVisible();
+    await expect(page.getByText("Needs practice")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Today", exact: true })).toBeVisible();
+  });
+
+  test("follow-up failure keeps completion summary visible with inline error", async ({ page }) => {
+    await setupMockApi(page, { failRecentReview: true });
+    await openWalkthrough(page);
+    await completeFirstGroupWithOneMiss(page);
+    await page.getByRole("button", { name: "Review mistakes" }).click();
+
+    await expect(page.getByRole("heading", { name: "Group 1 complete" })).toBeVisible();
+    await expect(page.getByText("REVIEW_FAILED: Review unavailable")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Review mistakes" })).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Scope completed

- Adds #135 M7 v2 Playwright walkthrough harness under `frontend/tests/e2e/m7-walkthrough.spec.ts`.
- Adds `@playwright/test` and `pnpm test:e2e:m7`.
- Adds `frontend/playwright.m7.config.ts` with:
  - Chromium project
  - mobile viewport via Pixel 5 device profile
  - dedicated owned Vite server on `127.0.0.1:5177 --strictPort`
  - `reuseExistingServer: false` to avoid stale developer server attachment
  - screenshots, traces, and videos retained on failure
- Uses route-mocked disposable API fixtures; does not connect to backend or mutate `backend/tiny_ipa.sqlite`.
- Documents command/prereqs in `frontend/README.md` and ignores generated Playwright reports/results.

Linked issues: #114, #135

## Fixture strategy

The walkthrough mocks `/api/health`, `/api/today`, `/api/attempt`, `/api/progress`, `/api/settings`, and `/api/review/recent-mistakes` in Playwright. Fixture state tracks normal groups, completed groups, selected focus phonemes, recent-review behavior, and a controlled review failure path. This keeps the harness deterministic and disposable while expressing the #134 scenario contract.

## Command and status

Command:

```bash
cd frontend && pnpm test:e2e:m7
```

Current status:

- Command completed successfully: `6 passed`.
- Three tests are intentionally marked with Playwright `test.fail(...)` for pending #136/#137/#138 product semantics:
  - next normal group action copy should name the intended group;
  - current-group review and recent/global review need separate actions/copy;
  - selected focus should start a named weak-focus group and expose clear-focus in the flow.
- Baseline harness/tooling paths pass, including normal group completion, stop/return known state, and follow-up failure keeping completion summary visible.

## Verification

- `cd frontend && pnpm install --frozen-lockfile` passed
- `cd frontend && pnpm exec playwright --version` -> `Version 1.60.0`
- `cd frontend && pnpm test:e2e:m7` passed (`6 passed`, with expected-fail product-pending assertions)
- `cd frontend && pnpm run lint` passed
- `cd frontend && pnpm exec tsc --noEmit` passed
- `cd frontend && pnpm run build` passed
- `git diff --check` passed
- `tools/agents/agent-audit` passed after one transient GitHub TLS retry

Backend tests were not run because this PR does not change backend code or real DB behavior.

## Residual risks

- The walkthrough currently uses route-mocked fixtures, not a real disposable SQLite backend. #139 should prove M7 v2 against the integration branch with full browser evidence.
- Expected-fail assertions must be revisited when #136/#137/#138 implement the corresponding product behavior.
- The #135 issue body originally had a stale base/depends field; Architect corrected durable issue state before this PR was opened.