### PR TITLE
[#136] Repair M7 practice action API semantics

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -83,6 +83,9 @@ class DailySession:
     group_index: int = 1
     group_type: str = "normal"
     source_session_item_ids: List[str] = field(default_factory=list)
+    source_scope: Optional[str] = None
+    source_group_id: Optional[str] = None
+    focus_phonemes: List[str] = field(default_factory=list)
 
 
 @dataclass

--- a/backend/app/routes/practice.py
+++ b/backend/app/routes/practice.py
@@ -1,9 +1,16 @@
-"""Practice endpoints — daily session and attempt submission."""
+"""Practice endpoints — daily session and action-specific group starts."""
 
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException, Request
 
 from app.db import get_db
-from app.services.sessions import build_recent_mistake_review_response, build_today_response
+from app.services.sessions import (
+    build_clear_focus_response,
+    build_current_group_review_response,
+    build_focused_group_response,
+    build_next_normal_group_response,
+    build_recent_mistake_review_response,
+    build_today_response,
+)
 
 router = APIRouter()
 
@@ -19,8 +26,66 @@ def today():
         return build_today_response(conn)
 
 
+@router.post("/practice/next-normal")
+def next_normal_group():
+    """Resume the active normal group or create the next normal group."""
+    with get_db() as conn:
+        return build_next_normal_group_response(conn)
+
+
 @router.post("/review/recent-mistakes")
 def recent_mistake_review():
     """Create or resume a review group from recent wrong answers."""
     with get_db() as conn:
         return build_recent_mistake_review_response(conn)
+
+
+@router.post("/review/current-group")
+async def current_group_review(request: Request):
+    """Create a review group from wrong answers in one completed/current group."""
+    body = await request.json()
+    group_id = body.get("group_id") or body.get("source_group_id")
+    if not isinstance(group_id, str) or not group_id.strip():
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": "INVALID_REVIEW_SOURCE",
+                "detail": "group_id is required for current-group review.",
+            },
+        )
+    with get_db() as conn:
+        response = build_current_group_review_response(
+            conn, source_group_id=group_id.strip()
+        )
+    if response.get("error") == "GROUP_NOT_FOUND":
+        raise HTTPException(status_code=404, detail=response)
+    return response
+
+
+@router.post("/practice/focus")
+async def focused_group(request: Request):
+    """Select focus phonemes and start or resume focused practice."""
+    body = await request.json()
+    focus_phonemes = body.get("focus_phonemes")
+    if not isinstance(focus_phonemes, list) or any(
+        not isinstance(item, str) or not item.strip() for item in focus_phonemes
+    ):
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": "INVALID_FOCUS",
+                "detail": "focus_phonemes must be a list of non-empty strings.",
+            },
+        )
+    with get_db() as conn:
+        return build_focused_group_response(
+            conn,
+            focus_phonemes=[item.strip() for item in focus_phonemes],
+        )
+
+
+@router.post("/practice/clear-focus")
+def clear_focus():
+    """Clear focus phonemes and return normal practice state."""
+    with get_db() as conn:
+        return build_clear_focus_response(conn)

--- a/backend/app/routes/practice.py
+++ b/backend/app/routes/practice.py
@@ -67,8 +67,13 @@ async def focused_group(request: Request):
     """Select focus phonemes and start or resume focused practice."""
     body = await request.json()
     focus_phonemes = body.get("focus_phonemes")
-    if not isinstance(focus_phonemes, list) or any(
-        not isinstance(item, str) or not item.strip() for item in focus_phonemes
+    if (
+        not isinstance(focus_phonemes, list)
+        or not focus_phonemes
+        or any(
+            not isinstance(item, str) or not item.strip()
+            for item in focus_phonemes
+        )
     ):
         raise HTTPException(
             status_code=400,

--- a/backend/app/services/db_schema.py
+++ b/backend/app/services/db_schema.py
@@ -74,7 +74,10 @@ TABLES_DDL: List[str] = [
         completed_at    TEXT,
         group_index     INTEGER NOT NULL DEFAULT 1,
         group_type      TEXT    NOT NULL DEFAULT 'normal',
-        source_session_item_ids TEXT NOT NULL DEFAULT '[]'
+        source_session_item_ids TEXT NOT NULL DEFAULT '[]',
+        source_scope     TEXT,
+        source_group_id  TEXT,
+        focus_phonemes   TEXT NOT NULL DEFAULT '[]'
     )
     """,
     # ------------------------------------------------------------------
@@ -184,6 +187,15 @@ def ensure_daily_sessions_schema(conn: sqlite3.Connection) -> None:
     if "source_session_item_ids" not in columns:
         conn.execute(
             "ALTER TABLE daily_sessions ADD COLUMN source_session_item_ids "
+            "TEXT NOT NULL DEFAULT '[]'"
+        )
+    if "source_scope" not in columns:
+        conn.execute("ALTER TABLE daily_sessions ADD COLUMN source_scope TEXT")
+    if "source_group_id" not in columns:
+        conn.execute("ALTER TABLE daily_sessions ADD COLUMN source_group_id TEXT")
+    if "focus_phonemes" not in columns:
+        conn.execute(
+            "ALTER TABLE daily_sessions ADD COLUMN focus_phonemes "
             "TEXT NOT NULL DEFAULT '[]'"
         )
 

--- a/backend/app/services/db_store.py
+++ b/backend/app/services/db_store.py
@@ -257,6 +257,9 @@ def _session_from_row(row: sqlite3.Row) -> DailySession:
         group_index=row["group_index"],
         group_type=row["group_type"],
         source_session_item_ids=_parse_list(row["source_session_item_ids"]) or [],
+        source_scope=row["source_scope"],
+        source_group_id=row["source_group_id"],
+        focus_phonemes=_parse_list(row["focus_phonemes"]) or [],
     )
 
 
@@ -279,10 +282,12 @@ def create_session(conn: sqlite3.Connection, session: DailySession) -> str:
         """
         INSERT INTO daily_sessions (
             id, user_id, session_date, primary_accent, status, created_at, completed_at,
-            group_index, group_type, source_session_item_ids
+            group_index, group_type, source_session_item_ids,
+            source_scope, source_group_id, focus_phonemes
         ) VALUES (
             :id, :user_id, :session_date, :primary_accent, :status, :created_at,
-            :completed_at, :group_index, :group_type, :source_session_item_ids
+            :completed_at, :group_index, :group_type, :source_session_item_ids,
+            :source_scope, :source_group_id, :focus_phonemes
         )
         """,
         {
@@ -296,6 +301,9 @@ def create_session(conn: sqlite3.Connection, session: DailySession) -> str:
             "group_index": session.group_index,
             "group_type": session.group_type,
             "source_session_item_ids": _to_json(session.source_session_item_ids),
+            "source_scope": session.source_scope,
+            "source_group_id": session.source_group_id,
+            "focus_phonemes": _to_json(session.focus_phonemes),
         },
     )
     return session.id
@@ -307,21 +315,37 @@ def get_active_session_for_date(
     session_date: str,
     primary_accent: str,
     group_type: str = "normal",
+    source_scope: Optional[str] = None,
+    source_group_id: Optional[str] = None,
+    focus_phonemes: Optional[List[str]] = None,
 ) -> Optional[DailySession]:
     """Return the active same-day group for the given type, if one exists."""
     ensure_daily_sessions_schema(conn)
+    filters = [
+        "user_id = ?",
+        "session_date = ?",
+        "primary_accent = ?",
+        "group_type = ?",
+        "status = 'in_progress'",
+    ]
+    params: list = [user_id, session_date, primary_accent, group_type]
+    if source_scope is not None:
+        filters.append("source_scope = ?")
+        params.append(source_scope)
+    if source_group_id is not None:
+        filters.append("source_group_id = ?")
+        params.append(source_group_id)
+    if focus_phonemes is not None:
+        filters.append("focus_phonemes = ?")
+        params.append(_to_json(focus_phonemes))
     row = conn.execute(
-        """
+        f"""
         SELECT * FROM daily_sessions
-        WHERE user_id = ?
-          AND session_date = ?
-          AND primary_accent = ?
-          AND group_type = ?
-          AND status = 'in_progress'
+        WHERE {" AND ".join(filters)}
         ORDER BY group_index DESC, created_at DESC
         LIMIT 1
         """,
-        (user_id, session_date, primary_accent, group_type),
+        params,
     ).fetchone()
     if row is None:
         return None
@@ -451,6 +475,46 @@ def get_recent_incorrect_attempt_sources(
         ORDER BY a.created_at DESC
         """,
         (user_id, primary_accent),
+    ).fetchall()
+    sources = []
+    seen_word_ids = set()
+    for row in rows:
+        if row["word_id"] in seen_word_ids:
+            continue
+        seen_word_ids.add(row["word_id"])
+        sources.append({
+            "word_id": row["word_id"],
+            "session_item_id": row["session_item_id"],
+            "last_wrong_at": row["last_wrong_at"],
+        })
+        if len(sources) >= limit:
+            break
+    return sources
+
+
+def get_session_incorrect_attempt_sources(
+    conn: sqlite3.Connection,
+    *,
+    user_id: str,
+    primary_accent: str,
+    session_id: str,
+    limit: int = 10,
+) -> List[dict]:
+    """Return wrong-answer words sourced from one practice group."""
+    rows = conn.execute(
+        """
+        SELECT a.word_id, a.session_item_id, a.created_at AS last_wrong_at
+        FROM attempts a
+        JOIN session_items si ON si.id = a.session_item_id
+        JOIN words w ON w.id = a.word_id
+        WHERE a.user_id = ?
+          AND a.primary_accent = ?
+          AND si.session_id = ?
+          AND a.is_correct = 0
+          AND w.content_status != 'disabled'
+        ORDER BY a.created_at DESC
+        """,
+        (user_id, primary_accent, session_id),
     ).fetchall()
     sources = []
     seen_word_ids = set()

--- a/backend/app/services/sessions.py
+++ b/backend/app/services/sessions.py
@@ -17,9 +17,12 @@ from app.services.db_store import (
     get_active_session_for_date,
     get_next_session_group_index,
     get_recent_incorrect_attempt_sources,
+    get_session_by_id,
+    get_session_incorrect_attempt_sources,
     get_session_items,
     get_settings,
     get_word_by_id,
+    upsert_settings,
 )
 from app.services.questions import generate_question
 from app.services.scheduler import select_daily_words
@@ -75,6 +78,10 @@ def build_today_response(
             daily_word_count=daily_word_count,
             conn=conn,
             accent=accent,
+            origin="normal_resume",
+            source_scope="normal_current",
+            focus_phonemes=settings.focus_phonemes,
+            action_label=f"Resume Group {existing.group_index}",
         )
 
     # ---- create new session -------------------------------------------------
@@ -112,7 +119,29 @@ def build_today_response(
         daily_word_count=daily_word_count,
         conn=conn,
         accent=accent,
+        origin="normal_start",
+        source_scope="normal_current",
+        focus_phonemes=settings.focus_phonemes,
+        action_label=f"Start Group {session.group_index}",
     )
+
+
+def build_next_normal_group_response(
+    conn,
+    *,
+    user_id: str = "default",
+    accent: str = "US",
+) -> dict:
+    """Resume the active normal group or create the next normal same-day group."""
+    response = build_today_response(conn, user_id=user_id, accent=accent)
+    if "error" in response:
+        return response
+    if response.get("origin") == "normal_start":
+        response["origin"] = "normal_next"
+    response["source_scope"] = "normal_next"
+    if response.get("origin") == "normal_next":
+        response["action_label"] = f"Start Group {response['group_index']}"
+    return response
 
 
 def build_recent_mistake_review_response(
@@ -132,7 +161,12 @@ def build_recent_mistake_review_response(
         }
 
     existing = get_active_session_for_date(
-        conn, user_id, session_date, accent, "mistake_review"
+        conn,
+        user_id,
+        session_date,
+        accent,
+        "mistake_review",
+        source_scope="recent_global",
     )
     if existing is not None:
         items = get_session_items(conn, existing.id)
@@ -142,6 +176,9 @@ def build_recent_mistake_review_response(
             daily_word_count=settings.daily_word_count,
             conn=conn,
             accent=accent,
+            origin="recent_review_resume",
+            source_scope="recent_global",
+            action_label=f"Resume Review Group {existing.group_index}",
         )
 
     sources = get_recent_incorrect_attempt_sources(
@@ -156,6 +193,8 @@ def build_recent_mistake_review_response(
             "status": "empty",
             "items": [],
             "source_count": 0,
+            "origin": "recent_review_empty",
+            "source_scope": "recent_global",
             "detail": "No recent incorrect attempts are available for review.",
         }
 
@@ -173,6 +212,8 @@ def build_recent_mistake_review_response(
             "status": "empty",
             "items": [],
             "source_count": 0,
+            "origin": "recent_review_empty",
+            "source_scope": "recent_global",
             "detail": "No reviewable words are available for recent mistakes.",
         }
 
@@ -186,6 +227,7 @@ def build_recent_mistake_review_response(
         group_index=group_index,
         group_type="mistake_review",
         source_session_item_ids=source_item_ids,
+        source_scope="recent_global",
     )
     response = _build_response(
         session=session,
@@ -193,8 +235,236 @@ def build_recent_mistake_review_response(
         daily_word_count=settings.daily_word_count,
         conn=conn,
         accent=accent,
+        origin="recent_review_start",
+        source_scope="recent_global",
+        action_label=f"Start Recent Review Group {session.group_index}",
     )
     response["source_count"] = len(source_item_ids)
+    return response
+
+
+def build_current_group_review_response(
+    conn,
+    *,
+    source_group_id: str,
+    user_id: str = "default",
+    accent: str = "US",
+    limit: int = 10,
+) -> dict:
+    """Create a review group from wrong answers in one source group."""
+    session_date = _today_date_str()
+    settings = get_settings(conn, user_id)
+    if settings is None:
+        return {
+            "error": "CONTENT_NOT_READY",
+            "detail": "Settings not initialised. Run import_words.py first.",
+        }
+
+    source_session = get_session_by_id(conn, source_group_id)
+    if source_session is None:
+        return {
+            "error": "GROUP_NOT_FOUND",
+            "detail": f"No practice group found for {source_group_id}.",
+        }
+
+    sources = get_session_incorrect_attempt_sources(
+        conn,
+        user_id=user_id,
+        primary_accent=accent,
+        session_id=source_group_id,
+        limit=min(max(limit, 1), settings.daily_word_count),
+    )
+    if not sources:
+        return {
+            "group_type": "mistake_review",
+            "status": "empty",
+            "items": [],
+            "source_count": 0,
+            "origin": "current_group_review_empty",
+            "source_scope": "current_group",
+            "source_group_id": source_group_id,
+            "detail": "No incorrect answers are available for this group.",
+        }
+
+    words = []
+    source_item_ids = []
+    for source in sources:
+        word = get_word_by_id(conn, source["word_id"])
+        if word is not None:
+            words.append(word)
+            source_item_ids.append(source["session_item_id"])
+
+    if not words:
+        return {
+            "group_type": "mistake_review",
+            "status": "empty",
+            "items": [],
+            "source_count": 0,
+            "origin": "current_group_review_empty",
+            "source_scope": "current_group",
+            "source_group_id": source_group_id,
+            "detail": "No reviewable words are available for this group.",
+        }
+
+    group_index = get_next_session_group_index(conn, user_id, session_date, accent)
+    existing = get_active_session_for_date(
+        conn,
+        user_id,
+        session_date,
+        accent,
+        "mistake_review",
+        source_scope="current_group",
+        source_group_id=source_group_id,
+    )
+    if existing is not None:
+        items = get_session_items(conn, existing.id)
+        response = _build_response(
+            session=existing,
+            items=items,
+            daily_word_count=settings.daily_word_count,
+            conn=conn,
+            accent=accent,
+            origin="current_group_review_resume",
+            source_scope="current_group",
+            source_group_id=source_group_id,
+            action_label=f"Resume Group {source_session.group_index} review",
+        )
+        response["source_count"] = len(existing.source_session_item_ids)
+        return response
+
+    session, items = _create_group_from_words(
+        conn,
+        words=words,
+        user_id=user_id,
+        session_date=session_date,
+        accent=accent,
+        group_index=group_index,
+        group_type="mistake_review",
+        source_session_item_ids=source_item_ids,
+        source_scope="current_group",
+        source_group_id=source_group_id,
+    )
+    response = _build_response(
+        session=session,
+        items=items,
+        daily_word_count=settings.daily_word_count,
+        conn=conn,
+        accent=accent,
+        origin="current_group_review_start",
+        source_scope="current_group",
+        source_group_id=source_group_id,
+        action_label=f"Review Group {source_session.group_index} misses",
+    )
+    response["source_count"] = len(source_item_ids)
+    return response
+
+
+def build_focused_group_response(
+    conn,
+    *,
+    focus_phonemes: List[str],
+    user_id: str = "default",
+    accent: str = "US",
+) -> dict:
+    """Save focus selection and create/resume a weak-focus practice group."""
+    session_date = _today_date_str()
+    settings = get_settings(conn, user_id)
+    if settings is None:
+        return {
+            "error": "CONTENT_NOT_READY",
+            "detail": "Settings not initialised. Run import_words.py first.",
+        }
+    settings.focus_phonemes = focus_phonemes
+    settings.updated_at = _now_iso()
+    upsert_settings(conn, settings)
+
+    existing = get_active_session_for_date(
+        conn,
+        user_id,
+        session_date,
+        accent,
+        "weak_focus",
+        source_scope="focus_selection",
+        focus_phonemes=focus_phonemes,
+    )
+    if existing is not None:
+        items = get_session_items(conn, existing.id)
+        return _build_response(
+            session=existing,
+            items=items,
+            daily_word_count=settings.daily_word_count,
+            conn=conn,
+            accent=accent,
+            origin="focus_resume",
+            source_scope="focus_selection",
+            focus_phonemes=focus_phonemes,
+            action_label=f"Resume Focus Group {existing.group_index}",
+        )
+
+    group_index = get_next_session_group_index(conn, user_id, session_date, accent)
+    seed = _seed_from_group(session_date, group_index, "weak_focus")
+    words = select_daily_words(
+        conn,
+        settings.daily_word_count,
+        accent,
+        seed=seed,
+        user_id=user_id,
+        review_strength=settings.review_strength,
+        focus_phonemes=focus_phonemes,
+    )
+    if not words:
+        return {
+            "error": "CONTENT_NOT_READY",
+            "detail": "No usable words found. Run import_words.py first.",
+        }
+
+    session, items = _create_group_from_words(
+        conn,
+        words=words,
+        user_id=user_id,
+        session_date=session_date,
+        accent=accent,
+        group_index=group_index,
+        group_type="weak_focus",
+        source_scope="focus_selection",
+        focus_phonemes=focus_phonemes,
+    )
+    return _build_response(
+        session=session,
+        items=items,
+        daily_word_count=settings.daily_word_count,
+        conn=conn,
+        accent=accent,
+        origin="focus_start",
+        source_scope="focus_selection",
+        focus_phonemes=focus_phonemes,
+        action_label=f"Start Focus Group {session.group_index}",
+    )
+
+
+def build_clear_focus_response(
+    conn,
+    *,
+    user_id: str = "default",
+    accent: str = "US",
+) -> dict:
+    """Clear focus selection and return the current normal practice group."""
+    settings = get_settings(conn, user_id)
+    if settings is None:
+        return {
+            "error": "CONTENT_NOT_READY",
+            "detail": "Settings not initialised. Run import_words.py first.",
+        }
+    settings.focus_phonemes = []
+    settings.updated_at = _now_iso()
+    upsert_settings(conn, settings)
+
+    response = build_today_response(conn, user_id=user_id, accent=accent)
+    if "error" not in response:
+        response["origin"] = "focus_clear"
+        response["source_scope"] = "normal_current"
+        response["focus_phonemes"] = []
+        response["detail"] = "Focus selection cleared."
     return response
 
 
@@ -208,6 +478,9 @@ def _create_group_from_words(
     group_index: int,
     group_type: str,
     source_session_item_ids: Optional[List[str]] = None,
+    source_scope: Optional[str] = None,
+    source_group_id: Optional[str] = None,
+    focus_phonemes: Optional[List[str]] = None,
 ) -> tuple[DailySession, List[SessionItem]]:
     session_id = f"{session_date}-{user_id}-g{group_index:03d}-{group_type}"
     session = DailySession(
@@ -221,6 +494,9 @@ def _create_group_from_words(
         group_index=group_index,
         group_type=group_type,
         source_session_item_ids=source_session_item_ids or [],
+        source_scope=source_scope,
+        source_group_id=source_group_id,
+        focus_phonemes=focus_phonemes or [],
     )
     create_session(conn, session)
 
@@ -263,6 +539,11 @@ def _build_response(
     daily_word_count: int,
     conn,
     accent: str,
+    origin: Optional[str] = None,
+    source_scope: Optional[str] = None,
+    source_group_id: Optional[str] = None,
+    focus_phonemes: Optional[List[str]] = None,
+    action_label: Optional[str] = None,
 ) -> dict:
     """Assemble the /api/today JSON response from session + items."""
     distractor_pool = _build_distractor_pool(conn, accent)
@@ -292,7 +573,7 @@ def _build_response(
             }
         )
 
-    return {
+    response = {
         "session_id": session.id,
         "group_id": session.id,
         "group_index": session.group_index,
@@ -305,3 +586,21 @@ def _build_response(
         "source_session_item_ids": session.source_session_item_ids,
         "items": item_dicts,
     }
+    if origin is not None:
+        response["origin"] = origin
+    response_source_scope = source_scope if source_scope is not None else session.source_scope
+    response_source_group_id = (
+        source_group_id if source_group_id is not None else session.source_group_id
+    )
+    response_focus_phonemes = focus_phonemes
+    if response_focus_phonemes is None and session.focus_phonemes:
+        response_focus_phonemes = session.focus_phonemes
+    if response_source_scope is not None:
+        response["source_scope"] = response_source_scope
+    if response_source_group_id is not None:
+        response["source_group_id"] = response_source_group_id
+    if response_focus_phonemes is not None:
+        response["focus_phonemes"] = response_focus_phonemes
+    if action_label is not None:
+        response["action_label"] = action_label
+    return response

--- a/backend/tests/test_today_persistence.py
+++ b/backend/tests/test_today_persistence.py
@@ -248,6 +248,30 @@ class TestTodayPersistence:
         assert second["session_id"] != first["session_id"]
         assert second["group_index"] == 2
 
+    def test_next_normal_action_reports_intended_group(self, client, seeded_db):
+        conn = get_connection(seeded_db)
+        conn.execute("UPDATE settings SET daily_word_count = 1 WHERE user_id = 'default'")
+        conn.commit()
+        conn.close()
+
+        first = client.get("/api/today").json()
+        item = first["items"][0]
+        client.post("/api/attempt", json={
+            "session_item_id": item["session_item_id"],
+            "selected_answer": item["display_ipa"],
+        })
+
+        resp = client.post("/api/practice/next-normal")
+        assert resp.status_code == 200
+        data = resp.json()
+
+        assert data["session_id"] != first["session_id"]
+        assert data["group_index"] == 2
+        assert data["group_type"] == "normal"
+        assert data["origin"] == "normal_next"
+        assert data["source_scope"] == "normal_next"
+        assert data["action_label"] == "Start Group 2"
+
     def test_recent_mistake_review_empty_queue_is_stable(self, client):
         resp = client.post("/api/review/recent-mistakes")
         assert resp.status_code == 200
@@ -256,6 +280,7 @@ class TestTodayPersistence:
         assert data["status"] == "empty"
         assert data["items"] == []
         assert data["source_count"] == 0
+        assert data["source_scope"] == "recent_global"
 
     def test_recent_mistake_review_group_reuses_attempt_path(self, client, seeded_db):
         today = client.get("/api/today").json()
@@ -273,6 +298,7 @@ class TestTodayPersistence:
 
         assert review["group_type"] == "mistake_review"
         assert review["group_index"] == 2
+        assert review["source_scope"] == "recent_global"
         assert review["source_session_item_ids"] == [missed["session_item_id"]]
         assert review["items"][0]["word_id"] == missed["word_id"]
 
@@ -305,6 +331,137 @@ class TestTodayPersistence:
 
         assert attempts["cnt"] == 2
         assert stats["attempt_count"] == 2
+
+    def test_current_group_review_uses_only_source_group_misses(self, client, seeded_db):
+        today = client.get("/api/today").json()
+        missed = today["items"][0]
+        client.post("/api/attempt", json={
+            "session_item_id": missed["session_item_id"],
+            "selected_answer": "/wrong/",
+        })
+
+        resp = client.post("/api/review/current-group", json={
+            "group_id": today["group_id"],
+        })
+        assert resp.status_code == 200
+        review = resp.json()
+
+        assert review["group_type"] == "mistake_review"
+        assert review["source_scope"] == "current_group"
+        assert review["source_group_id"] == today["group_id"]
+        assert review["source_session_item_ids"] == [missed["session_item_id"]]
+        assert review["items"][0]["word_id"] == missed["word_id"]
+
+    def test_current_group_review_empty_queue_is_non_error(self, client, seeded_db):
+        today = client.get("/api/today").json()
+        resp = client.post("/api/review/current-group", json={
+            "group_id": today["group_id"],
+        })
+        assert resp.status_code == 200
+        data = resp.json()
+
+        assert data["group_type"] == "mistake_review"
+        assert data["status"] == "empty"
+        assert data["source_scope"] == "current_group"
+        assert data["source_group_id"] == today["group_id"]
+        assert data["source_count"] == 0
+
+    def test_current_group_review_rejects_unknown_group(self, client):
+        resp = client.post("/api/review/current-group", json={
+            "group_id": "missing-group",
+        })
+        assert resp.status_code == 404
+        assert resp.json()["detail"]["error"] == "GROUP_NOT_FOUND"
+
+    def test_current_group_review_rejects_missing_group_id(self, client):
+        resp = client.post("/api/review/current-group", json={})
+        assert resp.status_code == 400
+        assert resp.json()["detail"]["error"] == "INVALID_REVIEW_SOURCE"
+
+    def test_current_and_recent_review_scopes_do_not_reuse_each_other(
+        self, client, seeded_db
+    ):
+        today = client.get("/api/today").json()
+        missed = today["items"][0]
+        client.post("/api/attempt", json={
+            "session_item_id": missed["session_item_id"],
+            "selected_answer": "/wrong/",
+        })
+
+        current = client.post("/api/review/current-group", json={
+            "group_id": today["group_id"],
+        }).json()
+        recent = client.post("/api/review/recent-mistakes").json()
+
+        assert current["session_id"] != recent["session_id"]
+        assert current["source_scope"] == "current_group"
+        assert current["source_group_id"] == today["group_id"]
+        assert recent["source_scope"] == "recent_global"
+        assert "source_group_id" not in recent
+
+    def test_focus_action_starts_weak_focus_group_and_clear_returns_normal(
+        self, client, seeded_db
+    ):
+        conn = get_connection(seeded_db)
+        conn.execute("UPDATE settings SET daily_word_count = 1 WHERE user_id = 'default'")
+        conn.commit()
+        conn.close()
+
+        resp = client.post("/api/practice/focus", json={
+            "focus_phonemes": ["/æ/"],
+        })
+        assert resp.status_code == 200
+        focused = resp.json()
+
+        assert focused["group_type"] == "weak_focus"
+        assert focused["source_scope"] == "focus_selection"
+        assert focused["focus_phonemes"] == ["/æ/"]
+        assert [item["word_id"] for item in focused["items"]] == ["cat"]
+
+        clear_resp = client.post("/api/practice/clear-focus")
+        assert clear_resp.status_code == 200
+        cleared = clear_resp.json()
+
+        assert cleared["group_type"] == "normal"
+        assert cleared["origin"] == "focus_clear"
+        assert cleared["source_scope"] == "normal_current"
+        assert cleared["focus_phonemes"] == []
+
+    def test_focus_action_resumes_active_weak_focus_group(self, client, seeded_db):
+        first = client.post("/api/practice/focus", json={
+            "focus_phonemes": ["/æ/"],
+        }).json()
+        second = client.post("/api/practice/focus", json={
+            "focus_phonemes": ["/æ/"],
+        }).json()
+
+        assert second["session_id"] == first["session_id"]
+        assert second["origin"] == "focus_resume"
+        assert second["source_scope"] == "focus_selection"
+        assert second["focus_phonemes"] == ["/æ/"]
+
+    def test_different_focus_selection_creates_new_weak_focus_group(
+        self, client, seeded_db
+    ):
+        first = client.post("/api/practice/focus", json={
+            "focus_phonemes": ["/æ/"],
+        }).json()
+        second = client.post("/api/practice/focus", json={
+            "focus_phonemes": ["/ʃ/"],
+        }).json()
+
+        assert second["session_id"] != first["session_id"]
+        assert second["group_type"] == "weak_focus"
+        assert second["origin"] == "focus_start"
+        assert second["source_scope"] == "focus_selection"
+        assert second["focus_phonemes"] == ["/ʃ/"]
+
+    def test_focus_action_rejects_invalid_focus_payload(self, client):
+        resp = client.post("/api/practice/focus", json={
+            "focus_phonemes": [""],
+        })
+        assert resp.status_code == 400
+        assert resp.json()["detail"]["error"] == "INVALID_FOCUS"
 
     def test_fresh_today_uses_focus_phoneme_setting(self, client, seeded_db):
         conn = get_connection(seeded_db)

--- a/backend/tests/test_today_persistence.py
+++ b/backend/tests/test_today_persistence.py
@@ -463,6 +463,13 @@ class TestTodayPersistence:
         assert resp.status_code == 400
         assert resp.json()["detail"]["error"] == "INVALID_FOCUS"
 
+    def test_focus_action_rejects_empty_focus_payload(self, client):
+        resp = client.post("/api/practice/focus", json={
+            "focus_phonemes": [],
+        })
+        assert resp.status_code == 400
+        assert resp.json()["detail"]["error"] == "INVALID_FOCUS"
+
     def test_fresh_today_uses_focus_phoneme_setting(self, client, seeded_db):
         conn = get_connection(seeded_db)
         conn.execute(

--- a/docs/05-data-api-contracts.md
+++ b/docs/05-data-api-contracts.md
@@ -253,8 +253,16 @@ GET /api/today
 - `session_id` 仍是 attempt 提交使用的持久 session id；
 - `group_id` 是 `session_id` 的语义别名，供 UI 用 group 语言表达；
 - `group_index` 是同一 `user_id`/`date`/`primary_accent` 下的递增序号；
-- `group_type` 当前实现 `normal` 和 `mistake_review`；后续弱音素入口使用
-  `weak_focus`，但仍复用同一 session_items/attempts/phoneme_stats 路径；
+- `group_type` 当前实现 `normal`、`mistake_review` 和 `weak_focus`，均复用
+  同一 session_items/attempts/phoneme_stats 路径；
+- `origin` 说明 action reason，例如 `normal_start`、`normal_resume`、
+  `normal_next`、`current_group_review_start`、`recent_review_start`、
+  `focus_start`、`focus_clear`；
+- `source_scope` 说明数据来源范围，例如 `normal_current`、`normal_next`、
+  `current_group`、`recent_global`、`focus_selection`；
+- `source_group_id` 仅 current-group review 使用，指向被复习的 source group；
+- `focus_phonemes` 在 focus 影响选词或清除 focus 时返回；
+- `action_label` 是后端状态驱动的短文案提示，前端可按产品语气改写；
 - `daily_word_count` 保留为兼容字段，M7 UI 文案应理解为 words per group；
 - `word_count` 是本响应实际返回的 item 数；
 - `source_session_item_ids` 仅 review group 使用，用于追踪错题来源。
@@ -274,6 +282,9 @@ active normal group，则创建下一个 normal group。不同 group 共用
   "group_type": "normal",
   "date": "2026-06-06",
   "primary_accent": "US",
+  "origin": "normal_start",
+  "source_scope": "normal_current",
+  "action_label": "Start Group 1",
   "daily_word_count": 10,
   "word_count": 10,
   "status": "in_progress",
@@ -299,6 +310,32 @@ active normal group，则创建下一个 normal group。不同 group 共用
 
 推荐服务端判题，不在生产响应中返回 `answer`。
 
+### Next normal group
+
+```http
+POST /api/practice/next-normal
+```
+
+显式从完成摘要进入下一个 normal group。若当天已经有 active normal group，
+返回该 group 并标记 `origin = "normal_resume"`；否则创建递增
+`group_index` 的 normal group 并标记 `origin = "normal_next"`、
+`source_scope = "normal_next"`。该 endpoint 用于避免 UI 把“继续”误解为重复
+当前 group。
+
+### Current-group review
+
+```http
+POST /api/review/current-group
+Content-Type: application/json
+
+{"group_id": "2026-06-06-default-g001-normal"}
+```
+
+从指定 source group 中的 wrong attempts 创建 `mistake_review` group。它只使用
+该 group 的错题，返回 `source_scope = "current_group"`、
+`source_group_id = <group_id>` 和 `source_session_item_ids`。没有错题时返回
+stable empty response，不视为错误；未知 group id 返回 `GROUP_NOT_FOUND`。
+
 ### Recent mistake review group
 
 ```http
@@ -319,6 +356,8 @@ attempt 查询错词，去重后映射回 `words`/`session_items`，并创建
   "status": "empty",
   "items": [],
   "source_count": 0,
+  "origin": "recent_review_empty",
+  "source_scope": "recent_global",
   "detail": "No recent incorrect attempts are available for review."
 }
 ```
@@ -330,10 +369,14 @@ attempt 查询错词，去重后映射回 `words`/`session_items`，并创建
 ### Weak phoneme focused group
 
 M7 P1 的 Progress 入口可以创建 `group_type = "weak_focus"` 的 practice group。
-它应接收用户选择的 phoneme symbols/ids，并调用现有 scheduler focus weighting；
+`POST /api/practice/focus` 接收 `{"focus_phonemes": [...]}`，保存 focus selection
+并调用现有 scheduler focus weighting；
 不应新建复习统计表，也不应绕开 `phoneme_stats`。若当天已有 active
-`weak_focus` group，API 应恢复该 group；完成后下一次显式 action 才创建新
-focused group。
+`weak_focus` group 且 focus selection 相同，API 应恢复该 group；不同 focus
+selection 会创建新的 clearly scoped `weak_focus` group，避免把旧 focus group
+误报成新的 selection。完成后下一次显式 action 才创建新 focused group。
+`POST /api/practice/clear-focus` 清空 selection，并返回当前 normal practice
+state，标记 `origin = "focus_clear"`、`focus_phonemes = []`。
 
 ### M7 minimum smoke path
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -72,6 +72,11 @@ export interface TodayResponse {
   group_id?: string;
   group_index?: number;
   group_type?: string;
+  origin?: string;
+  source_scope?: string;
+  source_group_id?: string;
+  focus_phonemes?: string[];
+  action_label?: string;
   date: string;
   primary_accent: string;
   daily_word_count: number;
@@ -92,8 +97,56 @@ export async function fetchToday(): Promise<TodayResponse> {
   return res.json();
 }
 
+export async function startNextNormalGroup(): Promise<TodayResponse> {
+  const res = await fetch(`${API_BASE}/practice/next-normal`, {
+    method: "POST",
+  });
+  if (!res.ok) {
+    throw new Error(await normalizeApiError(res));
+  }
+  return res.json();
+}
+
+export async function startCurrentGroupReview(
+  groupId: string,
+): Promise<TodayResponse> {
+  const res = await fetch(`${API_BASE}/review/current-group`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ group_id: groupId }),
+  });
+  if (!res.ok) {
+    throw new Error(await normalizeApiError(res));
+  }
+  return res.json();
+}
+
 export async function startRecentMistakeReview(): Promise<TodayResponse> {
   const res = await fetch(`${API_BASE}/review/recent-mistakes`, {
+    method: "POST",
+  });
+  if (!res.ok) {
+    throw new Error(await normalizeApiError(res));
+  }
+  return res.json();
+}
+
+export async function startFocusedPractice(
+  focusPhonemes: string[],
+): Promise<TodayResponse> {
+  const res = await fetch(`${API_BASE}/practice/focus`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ focus_phonemes: focusPhonemes }),
+  });
+  if (!res.ok) {
+    throw new Error(await normalizeApiError(res));
+  }
+  return res.json();
+}
+
+export async function clearPracticeFocus(): Promise<TodayResponse> {
+  const res = await fetch(`${API_BASE}/practice/clear-focus`, {
     method: "POST",
   });
   if (!res.ok) {


### PR DESCRIPTION
## Scope completed
- Added explicit M7 action endpoints for next normal group, current-group review, focused practice, and clear focus.
- Added response metadata for `origin`, `source_scope`, `source_group_id`, `focus_phonemes`, and `action_label` while preserving existing `/api/today` and recent mistake review compatibility.
- Persisted session action metadata on `daily_sessions` so current-group review, recent/global review, and focused practice resume without scope ambiguity.
- Added minimal frontend API client types/functions for #137/#138 to consume later.
- Updated `docs/05-data-api-contracts.md` with concrete endpoint names and metadata semantics.

Linked issues: #114, #136

## API transition evidence
- `POST /api/practice/next-normal` creates/resumes intended normal group with `source_scope: normal_next`.
- `POST /api/review/current-group` uses only wrong attempts from the provided source group and returns empty state as non-error.
- `POST /api/review/recent-mistakes` remains recent/global scoped via `source_scope: recent_global`.
- `POST /api/practice/focus` resumes only matching focus selections; a different focus selection creates a new `weak_focus` group.
- `POST /api/practice/clear-focus` clears focus and returns normal practice state.

## Verification
- `uv run --project backend pytest backend/tests/test_today_persistence.py` -> 32 passed
- `uv run --project backend pytest` -> 167 passed
- `uv run --project backend ruff check backend/app/models.py backend/app/routes/practice.py backend/app/services/db_schema.py backend/app/services/db_store.py backend/app/services/sessions.py backend/tests/test_today_persistence.py` -> passed
- `cd frontend && pnpm exec tsc --noEmit` -> passed
- `cd frontend && pnpm run lint` -> passed
- `cd frontend && pnpm run build` -> passed
- `cd frontend && pnpm test:e2e:m7` -> 6 passed; three product-pending assertions remain expected-fail for #137/#138 UI workflow
- `tools/agents/agent-audit` -> clean
- `git diff --check` -> clean

Note: full `uv run --project backend ruff check` still reports pre-existing findings in unrelated files not touched by this PR; scoped ruff on touched Python files passed.

## #135 walkthrough impact
- Backend/API semantics needed by the #135 route-mocked walkthrough are now concrete.
- Expected-fail assertions for visible next-normal UI, current-vs-recent review UI, and focus UI remain pending for #137/#138 because this PR intentionally avoids Today/Progress/Settings UI redesign.
- No #135 harness changes were required in this PR.

## Residual risks
- Session metadata columns are lightweight compatibility additions; no destructive migration is included.
- Current-group review creates scoped review groups from existing attempts/session_items and does not add a separate review correctness store.
- UI integration still needs #137/#138 to wire the new API client functions into learner-facing actions.