### PR TITLE
[#137/#138] Rebuild M7 practice and focus workflow UI

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { fetchHealth } from "./api";
+import { fetchHealth, type TodayResponse } from "./api";
 import { useEffect, useState } from "react";
 import TodayPractice from "./pages/TodayPractice";
 import ProgressPage from "./pages/ProgressPage";
@@ -9,6 +9,7 @@ function App() {
   const [checking, setChecking] = useState(true);
   const [page, setPage] = useState<"today" | "progress" | "settings">("today");
   const [focusPhonemes, setFocusPhonemes] = useState<string[]>([]);
+  const [practiceSession, setPracticeSession] = useState<TodayResponse | null>(null);
 
   useEffect(() => {
     fetchHealth()
@@ -52,13 +53,26 @@ function App() {
             onBack={() => setPage("today")}
             focusPhonemes={focusPhonemes}
             onFocusChange={setFocusPhonemes}
+            onStartPractice={(session) => {
+              setPracticeSession(session);
+              setPage("today");
+            }}
           />
         : page === "settings"
-        ? <SettingsPage onBack={() => setPage("today")} />
+        ? <SettingsPage
+            onBack={() => setPage("today")}
+            onFocusChange={setFocusPhonemes}
+            onStartPractice={(session) => {
+              setPracticeSession(session);
+              setPage("today");
+            }}
+          />
         : <TodayPractice
             focusPhonemes={focusPhonemes}
             onFocusChange={setFocusPhonemes}
             onOpenProgress={() => setPage("progress")}
+            initialSession={practiceSession}
+            onInitialSessionConsumed={() => setPracticeSession(null)}
           />
       }
     </div>

--- a/frontend/src/pages/ProgressPage.tsx
+++ b/frontend/src/pages/ProgressPage.tsx
@@ -5,19 +5,26 @@
  */
 
 import { useEffect, useState } from "react";
-import type { ProgressResponse, SettingsData } from "../api";
-import { fetchProgress, fetchSettings, saveSettings } from "../api";
+import type { ProgressResponse, SettingsData, TodayResponse } from "../api";
+import {
+  clearPracticeFocus,
+  fetchProgress,
+  fetchSettings,
+  startFocusedPractice,
+} from "../api";
 
 interface Props {
   onBack: () => void;
   focusPhonemes: string[];
   onFocusChange: (focusPhonemes: string[]) => void;
+  onStartPractice: (session: TodayResponse) => void;
 }
 
 export default function ProgressPage({
   onBack,
   focusPhonemes,
   onFocusChange,
+  onStartPractice,
 }: Props) {
   const [data, setData] = useState<ProgressResponse | null>(null);
   const [settings, setSettings] = useState<SettingsData | null>(null);
@@ -37,28 +44,41 @@ export default function ProgressPage({
       .finally(() => setLoading(false));
   }, [onFocusChange]);
 
-  const updateFocus = async (nextFocus: string[], navigateAfter = false) => {
+  const canonicalFocus = (nextFocus: string[]) =>
+    Array.from(new Set(nextFocus.map((item) => item.trim()).filter(Boolean))).sort();
+
+  const startFocus = async (nextFocus: string[]) => {
+    const focus = canonicalFocus(nextFocus);
     setSavingFocus(nextFocus.join(",") || "clear");
     setError(null);
     try {
-      const updated = await saveSettings({ focus_phonemes: nextFocus });
-      setSettings(updated);
-      onFocusChange(updated.focus_phonemes);
-      if (navigateAfter) onBack();
+      const focusedSession = await startFocusedPractice(focus);
+      const appliedFocus = focusedSession.focus_phonemes ?? focus;
+      setSettings((prev) => prev ? { ...prev, focus_phonemes: appliedFocus } : prev);
+      onFocusChange(appliedFocus);
+      onStartPractice(focusedSession);
     } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to update focus");
+      setError(e instanceof Error ? e.message : "Failed to start focused practice");
     } finally {
       setSavingFocus(null);
     }
   };
 
   const focusOne = (phoneme: string) => {
-    const next = [phoneme, ...activeFocus.filter((item) => item !== phoneme)];
-    void updateFocus(next, true);
+    void startFocus([phoneme]);
   };
 
   const clearFocus = () => {
-    void updateFocus([]);
+    setSavingFocus("clear");
+    setError(null);
+    clearPracticeFocus()
+      .then((normalSession) => {
+        setSettings((prev) => prev ? { ...prev, focus_phonemes: [] } : prev);
+        onFocusChange([]);
+        onStartPractice(normalSession);
+      })
+      .catch((e) => setError(e instanceof Error ? e.message : "Failed to clear focus"))
+      .finally(() => setSavingFocus(null));
   };
 
   if (loading) return <main className="practice-container"><p>Loading progress…</p></main>;
@@ -75,7 +95,10 @@ export default function ProgressPage({
 
       {activeFocus.length > 0 && (
         <div className="focus-panel">
-          <span className="focus-panel-label">Next group focus</span>
+          <span className="focus-panel-label">Current focus</span>
+          <p className="section-copy">
+            Focus changes the next focused practice group. Clear it to return to normal practice.
+          </p>
           <div className="phoneme-chip-list">
             {activeFocus.map((phoneme) => (
               <span className="phoneme-chip" key={phoneme}>{phoneme}</span>
@@ -109,19 +132,29 @@ export default function ProgressPage({
       {data.weak_phonemes.length > 0 && (
         <section className="phoneme-section">
           <h2>Needs practice</h2>
+          <p className="section-copy">
+            Start focused practice from a weak sound. No IPA typing needed.
+          </p>
           <ul className="phoneme-list">
             {data.weak_phonemes.map((p) => (
               <li key={p.phoneme} className="phoneme-item weak">
                 <span className="phoneme-symbol">{p.phoneme}</span>
-                <span className="phoneme-acc">{Math.round(p.accuracy * 100)}%</span>
-                <span className="phoneme-count">{p.attempt_count} att.</span>
+                <span className="phoneme-acc">
+                  {Math.round(p.accuracy * 100)}% accuracy
+                </span>
+                <span className="phoneme-count">
+                  {p.attempt_count} attempts
+                </span>
                 <button
                   className="focus-action-btn"
                   onClick={() => focusOne(p.phoneme)}
                   disabled={savingFocus !== null}
                 >
-                  {activeFocus.includes(p.phoneme) ? "Focused" : "Focus"}
+                  {activeFocus.includes(p.phoneme) ? "Resume focus" : `Focus ${p.phoneme}`}
                 </button>
+                <span className="phoneme-help">
+                  Focused practice will choose words weighted toward {p.phoneme}.
+                </span>
               </li>
             ))}
           </ul>

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -9,15 +9,30 @@
 import { useEffect, useState } from "react";
 import {
   type SettingsData,
+  type TodayResponse,
+  clearPracticeFocus,
   fetchSettings,
   saveSettings,
+  startFocusedPractice,
 } from "../api";
 
 interface Props {
   onBack: () => void;
+  onFocusChange: (focusPhonemes: string[]) => void;
+  onStartPractice: (session: TodayResponse) => void;
 }
 
-export default function SettingsPage({ onBack }: Props) {
+const COMMON_FOCUS = ["/ʃ/", "/θ/", "/æ/", "/ɪ/", "/tʃ/", "/ʌ/"];
+
+function canonicalFocus(phonemes: string[]): string[] {
+  return Array.from(new Set(phonemes.map((item) => item.trim()).filter(Boolean))).sort();
+}
+
+export default function SettingsPage({
+  onBack,
+  onFocusChange,
+  onStartPractice,
+}: Props) {
   const [settings, setSettings] = useState<SettingsData | null>(null);
   const [focusInput, setFocusInput] = useState("");
   const [loading, setLoading] = useState(true);
@@ -45,6 +60,7 @@ export default function SettingsPage({ onBack }: Props) {
       const updated = await saveSettings(patch);
       setSettings(updated);
       setFocusInput(updated.focus_phonemes.join(", "));
+      onFocusChange(updated.focus_phonemes);
       setSaved(true);
       setTimeout(() => setSaved(false), 2000);
     } catch (e: unknown) {
@@ -53,11 +69,23 @@ export default function SettingsPage({ onBack }: Props) {
   };
 
   const saveFocusPhonemes = () => {
-    const focus_phonemes = focusInput
-      .split(",")
-      .map((item) => item.trim())
-      .filter(Boolean);
+    const focus_phonemes = canonicalFocus(focusInput.split(","));
     void update({ focus_phonemes });
+  };
+
+  const startFocus = async (phoneme: string) => {
+    setError(null);
+    setSaved(false);
+    try {
+      const session = await startFocusedPractice([phoneme]);
+      const appliedFocus = session.focus_phonemes ?? [phoneme];
+      setSettings({ ...settings, focus_phonemes: appliedFocus });
+      setFocusInput(appliedFocus.join(", "));
+      onFocusChange(appliedFocus);
+      onStartPractice(session);
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Failed to start focused practice");
+    }
   };
 
   const removeFocusPhoneme = (phoneme: string) => {
@@ -67,7 +95,16 @@ export default function SettingsPage({ onBack }: Props) {
   };
 
   const clearFocusPhonemes = () => {
-    void update({ focus_phonemes: [] });
+    clearPracticeFocus()
+      .then((session) => {
+        setSettings({ ...settings, focus_phonemes: [] });
+        setFocusInput("");
+        onFocusChange([]);
+        onStartPractice(session);
+      })
+      .catch((e: unknown) => {
+        setError(e instanceof Error ? e.message : "Failed to clear focus");
+      });
   };
 
   return (
@@ -105,22 +142,45 @@ export default function SettingsPage({ onBack }: Props) {
           </select>
         </label>
 
-        <label className="setting-row setting-row-stacked">
-          <span>Manual focus entry</span>
-          <input
-            className="focus-input"
-            type="text"
-            value={focusInput}
-            placeholder="/ʃ/, /æ/"
-            onBlur={saveFocusPhonemes}
-            onChange={e => setFocusInput(e.target.value)}
-            onKeyDown={e => {
-              if (e.key === "Enter") {
-                e.currentTarget.blur();
-              }
-            }}
-          />
-        </label>
+        <section className="settings-panel">
+          <h2>Focus practice</h2>
+          <p className="section-copy">
+            Pick a sound to start a focused group. The scheduler will weight words
+            toward that sound until you clear focus.
+          </p>
+          <div className="phoneme-chip-list">
+            {COMMON_FOCUS.map((phoneme) => (
+              <button
+                className="phoneme-chip selectable"
+                key={phoneme}
+                onClick={() => void startFocus(phoneme)}
+                type="button"
+              >
+                Focus {phoneme}
+              </button>
+            ))}
+          </div>
+        </section>
+
+        <details className="advanced-focus">
+          <summary>Advanced/debug: manual IPA focus entry</summary>
+          <label className="setting-row setting-row-stacked">
+            <span>Comma-separated IPA symbols</span>
+            <input
+              className="focus-input"
+              type="text"
+              value={focusInput}
+              placeholder="/ʃ/, /æ/"
+              onBlur={saveFocusPhonemes}
+              onChange={e => setFocusInput(e.target.value)}
+              onKeyDown={e => {
+                if (e.key === "Enter") {
+                  e.currentTarget.blur();
+                }
+              }}
+            />
+          </label>
+        </details>
 
         {settings.focus_phonemes.length > 0 && (
           <div className="settings-focus-panel">

--- a/frontend/src/pages/TodayPractice.tsx
+++ b/frontend/src/pages/TodayPractice.tsx
@@ -8,7 +8,15 @@
 
 import { useCallback, useEffect, useState } from "react";
 import type { SettingsData, TodayItem, TodayResponse } from "../api";
-import { fetchSettings, fetchToday, startRecentMistakeReview } from "../api";
+import {
+  clearPracticeFocus,
+  fetchSettings,
+  fetchToday,
+  startCurrentGroupReview,
+  startFocusedPractice,
+  startNextNormalGroup,
+  startRecentMistakeReview,
+} from "../api";
 import type { ChoiceResult } from "../components/ChoiceQuestion";
 import { ChoiceQuestion } from "../components/ChoiceQuestion";
 
@@ -16,6 +24,8 @@ interface Props {
   focusPhonemes: string[];
   onFocusChange: (focusPhonemes: string[]) => void;
   onOpenProgress: () => void;
+  initialSession?: TodayResponse | null;
+  onInitialSessionConsumed?: () => void;
 }
 
 interface PracticeResult {
@@ -28,9 +38,36 @@ interface PracticeResult {
   isCorrect: boolean;
 }
 
+function canonicalFocus(phonemes: string[]): string[] {
+  return Array.from(new Set(phonemes.map((item) => item.trim()).filter(Boolean))).sort();
+}
+
 function groupLabel(session: TodayResponse): string {
+  if (session.group_type === "weak_focus") return "Focused group";
+  if (session.source_scope === "current_group") return `Group ${session.group_index ?? 1} review`;
+  if (session.source_scope === "recent_global") return "Recent mistake review";
   if (session.group_type === "mistake_review") return "Mistake review";
   return `Group ${session.group_index ?? 1}`;
+}
+
+function groupReason(session: TodayResponse): string {
+  if (session.group_type === "weak_focus") {
+    const focus = session.focus_phonemes?.join(" ") || "selected sounds";
+    return `Focused practice for ${focus}.`;
+  }
+  if (session.source_scope === "current_group") {
+    return "Reviewing misses from the group you just finished.";
+  }
+  if (session.source_scope === "recent_global") {
+    return "Reviewing recent mistakes from earlier practice.";
+  }
+  if (session.source_scope === "normal_next") {
+    return "A new normal practice group.";
+  }
+  if (session.origin === "normal_resume") {
+    return "Resuming your current normal group.";
+  }
+  return "Normal practice group.";
 }
 
 function buildFocusHint(targetPhonemes: string[]): string {
@@ -44,15 +81,20 @@ export default function TodayPractice({
   focusPhonemes,
   onFocusChange,
   onOpenProgress,
+  initialSession,
+  onInitialSessionConsumed,
 }: Props) {
-  const [session, setSession] = useState<TodayResponse | null>(null);
-  const [loading, setLoading] = useState(true);
+  const [session, setSession] = useState<TodayResponse | null>(() => initialSession ?? null);
+  const [loading, setLoading] = useState(() => !initialSession);
   const [actionLoading, setActionLoading] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
   const [currentIndex, setCurrentIndex] = useState(0);
   const [results, setResults] = useState<PracticeResult[]>([]);
-  const [finished, setFinished] = useState(false);
+  const [finished, setFinished] = useState(() =>
+    Boolean(initialSession && initialSession.items.length === 0),
+  );
+  const [lastSummarySession, setLastSummarySession] = useState<TodayResponse | null>(null);
 
   const resetPractice = useCallback((data: TodayResponse, settings?: SettingsData) => {
     if (data.error) {
@@ -63,12 +105,22 @@ export default function TodayPractice({
     setCurrentIndex(0);
     setResults([]);
     setFinished(data.items.length === 0);
+    setLastSummarySession(null);
     setNotice(null);
-    if (settings) onFocusChange(settings.focus_phonemes);
+    if (data.focus_phonemes) onFocusChange(data.focus_phonemes);
+    else if (settings) onFocusChange(settings.focus_phonemes);
   }, [onFocusChange]);
+
+  useEffect(() => {
+    if (initialSession) {
+      onInitialSessionConsumed?.();
+    }
+  }, [initialSession, onInitialSessionConsumed]);
 
   // Load today's session on mount.
   useEffect(() => {
+    if (initialSession) return;
+
     let cancelled = false;
     Promise.all([fetchToday(), fetchSettings()])
       .then(([today, settings]) => {
@@ -88,7 +140,7 @@ export default function TodayPractice({
     return () => {
       cancelled = true;
     };
-  }, [resetPractice]);
+  }, [initialSession, resetPractice]);
 
   const handleResult = (item: TodayItem, result: ChoiceResult) => {
     setResults((prev) => [
@@ -109,17 +161,18 @@ export default function TodayPractice({
     if (!session) return;
     const nextIndex = currentIndex + 1;
     if (nextIndex >= session.items.length) {
+      setLastSummarySession(session);
       setFinished(true);
     } else {
       setCurrentIndex(nextIndex);
     }
   };
 
-  const handleContinue = async () => {
+  const handleNextNormal = async () => {
     setActionLoading("continue");
     setError(null);
     try {
-      const data = await fetchToday();
+      const data = await startNextNormalGroup();
       resetPractice(data);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to load another group");
@@ -128,8 +181,27 @@ export default function TodayPractice({
     }
   };
 
-  const handleMistakeReview = async () => {
-    setActionLoading("review");
+  const handleCurrentGroupReview = async () => {
+    const sourceGroupId = lastSummarySession?.group_id ?? session?.group_id;
+    if (!sourceGroupId) return;
+    setActionLoading("current-review");
+    setError(null);
+    try {
+      const data = await startCurrentGroupReview(sourceGroupId);
+      if (data.status === "empty" || data.items.length === 0) {
+        setNotice(data.detail ?? "No misses in this group are ready for review.");
+      } else {
+        resetPractice(data);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to start review");
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  const handleRecentReview = async () => {
+    setActionLoading("recent-review");
     setError(null);
     try {
       const data = await startRecentMistakeReview();
@@ -139,7 +211,38 @@ export default function TodayPractice({
         resetPractice(data);
       }
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to start review");
+      setError(err instanceof Error ? err.message : "Failed to start recent review");
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  const handleFocusPractice = async (phonemes: string[]) => {
+    const nextFocus = canonicalFocus(phonemes);
+    if (nextFocus.length === 0) return;
+    setActionLoading("focus");
+    setError(null);
+    try {
+      const data = await startFocusedPractice(nextFocus);
+      resetPractice(data);
+      onFocusChange(data.focus_phonemes ?? nextFocus);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to start focused practice");
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  const handleClearFocus = async () => {
+    setActionLoading("clear-focus");
+    setError(null);
+    try {
+      const data = await clearPracticeFocus();
+      onFocusChange([]);
+      resetPractice(data);
+      setNotice("Focus cleared. Back to normal practice.");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to clear focus");
     } finally {
       setActionLoading(null);
     }
@@ -190,16 +293,21 @@ export default function TodayPractice({
     const correctCount = results.filter((r) => r.isCorrect).length;
     const total = results.length;
     const wrongResults = results.filter((r) => !r.isCorrect);
+    const summarySession = lastSummarySession ?? session;
+    const focusSuggestions = canonicalFocus(
+      wrongResults.flatMap((result) => result.targetPhonemes),
+    ).slice(0, 3);
     return (
       <main className="practice-container">
         <div className="practice-summary">
-          <h2>{groupLabel(session)} complete</h2>
+          <p className="workflow-kicker">{groupReason(summarySession)}</p>
+          <h2>{groupLabel(summarySession)} complete</h2>
           <p className="summary-score">
             {correctCount} / {total} correct
           </p>
           {wrongResults.length > 0 ? (
             <section className="summary-section">
-              <h3>Review these</h3>
+              <h3>Misses from this group</h3>
               <ul className="summary-list">
                 {wrongResults.map((r) => (
                   <li key={r.sessionItemId} className="summary-wrong">
@@ -223,25 +331,53 @@ export default function TodayPractice({
           ) : (
             <p className="summary-perfect">No misses in this group.</p>
           )}
+          {focusSuggestions.length > 0 && (
+            <section className="summary-section focus-choice-panel">
+              <h3>Focus a weak sound next</h3>
+              <p className="section-copy">
+                Start a focused group weighted toward one of the sounds missed here.
+              </p>
+              <div className="phoneme-chip-list">
+                {focusSuggestions.map((phoneme) => (
+                  <button
+                    className="phoneme-chip selectable"
+                    key={phoneme}
+                    onClick={() => void handleFocusPractice([phoneme])}
+                    disabled={actionLoading !== null}
+                    type="button"
+                  >
+                    Focus {phoneme}
+                  </button>
+                ))}
+              </div>
+            </section>
+          )}
           {error && <p className="save-error">{error}</p>}
           {notice && <p className="empty-hint">{notice}</p>}
           <div className="summary-actions">
             <button
               className="primary-action-btn"
-              onClick={handleContinue}
+              onClick={handleNextNormal}
               disabled={actionLoading !== null}
             >
-              {actionLoading === "continue" ? "Loading…" : "Continue"}
+              {actionLoading === "continue" ? "Loading…" : "Start next 10-word group"}
             </button>
             <button
               className="secondary-action-btn"
-              onClick={handleMistakeReview}
+              onClick={handleCurrentGroupReview}
               disabled={actionLoading !== null}
             >
-              {actionLoading === "review" ? "Loading…" : "Review mistakes"}
+              {actionLoading === "current-review" ? "Loading…" : `Review misses from ${groupLabel(summarySession)}`}
+            </button>
+            <button
+              className="secondary-action-btn"
+              onClick={handleRecentReview}
+              disabled={actionLoading !== null}
+            >
+              {actionLoading === "recent-review" ? "Loading…" : "Review recent mistakes"}
             </button>
             <button className="secondary-action-btn" onClick={onOpenProgress}>
-              Stop
+              Return to Progress
             </button>
           </div>
         </div>
@@ -259,14 +395,30 @@ export default function TodayPractice({
         <span className="progress-label">{groupLabel(session)}: {progress}</span>
         <span className="accent-label">{session.primary_accent}</span>
       </div>
-      {focusPhonemes.length > 0 && (
+      <div className="mode-panel">
+        <strong>{groupLabel(session)}</strong>
+        <span>{groupReason(session)}</span>
+      </div>
+      {(session.focus_phonemes?.length || focusPhonemes.length > 0) && (
         <div className="active-focus-banner">
-          <span>Focus</span>
-          {focusPhonemes.map((phoneme) => (
+          <span>Current focus</span>
+          {(session.focus_phonemes ?? focusPhonemes).map((phoneme) => (
             <span className="phoneme-chip" key={phoneme}>{phoneme}</span>
           ))}
+          {session.group_type === "weak_focus" && (
+            <button
+              className="secondary-action-btn compact"
+              onClick={() => void handleClearFocus()}
+              disabled={actionLoading !== null}
+              type="button"
+            >
+              Clear focus
+            </button>
+          )}
         </div>
       )}
+      {notice && <p className="empty-hint">{notice}</p>}
+      {error && <p className="save-error">{error}</p>}
 
       <ChoiceQuestion
         key={currentItem.session_item_id}

--- a/frontend/src/pages/TodayPractice.tsx
+++ b/frontend/src/pages/TodayPractice.tsx
@@ -6,7 +6,7 @@
  * refresh-safe: reloading on the same date resumes the same session.
  */
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { SettingsData, TodayItem, TodayResponse } from "../api";
 import {
   clearPracticeFocus,
@@ -84,6 +84,7 @@ export default function TodayPractice({
   initialSession,
   onInitialSessionConsumed,
 }: Props) {
+  const adoptedInitialSession = useRef(Boolean(initialSession));
   const [session, setSession] = useState<TodayResponse | null>(() => initialSession ?? null);
   const [loading, setLoading] = useState(() => !initialSession);
   const [actionLoading, setActionLoading] = useState<string | null>(null);
@@ -119,7 +120,7 @@ export default function TodayPractice({
 
   // Load today's session on mount.
   useEffect(() => {
-    if (initialSession) return;
+    if (initialSession || adoptedInitialSession.current) return;
 
     let cancelled = false;
     Promise.all([fetchToday(), fetchSettings()])

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -275,6 +275,16 @@ button {
   margin-bottom: 8px;
 }
 
+.workflow-kicker,
+.section-copy {
+  color: #555;
+  font-size: 0.9rem;
+}
+
+.workflow-kicker {
+  margin-bottom: 4px;
+}
+
 .summary-score {
   font-size: 1.5rem;
   font-weight: 700;
@@ -379,7 +389,9 @@ button {
 
 .active-focus-banner,
 .focus-panel,
-.settings-focus-panel {
+.settings-focus-panel,
+.mode-panel,
+.settings-panel {
   align-items: center;
   background: #f8fbff;
   border: 1px solid #d6e4ff;
@@ -396,9 +408,22 @@ button {
 }
 
 .focus-panel,
-.settings-focus-panel {
+.settings-focus-panel,
+.mode-panel,
+.settings-panel {
   align-items: flex-start;
   flex-direction: column;
+}
+
+.mode-panel {
+  margin-bottom: 16px;
+}
+
+.focus-choice-panel {
+  background: #fafafa;
+  border: 1px solid #eee;
+  border-radius: 8px;
+  padding: 12px;
 }
 
 .focus-panel-label {
@@ -509,7 +534,8 @@ button {
 }
 
 .phoneme-item {
-  display: flex;
+  display: grid;
+  grid-template-columns: minmax(44px, auto) 1fr auto;
   align-items: center;
   gap: 8px;
   padding: 8px 0;
@@ -530,7 +556,6 @@ button {
 .phoneme-count {
   color: #aaa;
   font-size: 0.8rem;
-  margin-left: auto;
 }
 
 .focus-action-btn {
@@ -538,9 +563,14 @@ button {
   border: 1px solid #ffcc80;
   color: #b45309;
   font-size: 0.8rem;
-  margin-left: 4px;
   min-height: 32px;
   padding: 5px 8px;
+}
+
+.phoneme-help {
+  color: #666;
+  font-size: 0.8rem;
+  grid-column: 2 / -1;
 }
 
 .phoneme-item.weak .phoneme-symbol {
@@ -630,6 +660,23 @@ button {
 .phoneme-chip.removable {
   background: #fff;
   cursor: pointer;
+}
+
+.phoneme-chip.selectable {
+  background: #fff;
+  cursor: pointer;
+}
+
+.advanced-focus {
+  border-bottom: 1px solid #f0f0f0;
+  padding: 10px 0;
+}
+
+.advanced-focus summary {
+  color: #555;
+  cursor: pointer;
+  font-size: 0.9rem;
+  font-weight: 600;
 }
 
 .save-confirm {

--- a/frontend/tests/e2e/m7-walkthrough.spec.ts
+++ b/frontend/tests/e2e/m7-walkthrough.spec.ts
@@ -85,6 +85,24 @@ const groups: Record<string, MockGroup> = {
       },
     ],
   },
+  currentReview: {
+    session_id: "session-current-review",
+    group_id: "current-review",
+    group_index: 3,
+    group_type: "mistake_review",
+    primary_accent: "US",
+    items: [
+      {
+        session_item_id: "current-review-item-1",
+        word_id: "ship",
+        display_ipa: "/ʃɪp/",
+        word: "ship",
+        meaning_zh: "船",
+        target_phonemes: ["/ʃ/"],
+        choices: ["/sɪp/", "/ʃɪp/"],
+      },
+    ],
+  },
   focused: {
     session_id: "session-focused",
     group_id: "focused-sh",
@@ -113,6 +131,16 @@ interface MockState {
 }
 
 function toTodayResponse(group: MockGroup) {
+  const sourceScope =
+    group.group_id === "current-review"
+      ? "current_group"
+      : group.group_id === "recent-review"
+        ? "recent_global"
+        : group.group_type === "weak_focus"
+          ? "focus_selection"
+          : group.group_index > 1
+            ? "normal_next"
+            : "normal_current";
   return {
     session_id: group.session_id,
     group_id: group.group_id,
@@ -120,6 +148,17 @@ function toTodayResponse(group: MockGroup) {
     group_type: group.group_type,
     date: "2026-06-17",
     primary_accent: group.primary_accent,
+    origin:
+      group.group_type === "weak_focus"
+        ? "focus_start"
+        : sourceScope === "normal_next"
+          ? "normal_next"
+          : "normal_start",
+    source_scope: sourceScope,
+    source_group_id: sourceScope === "current_group" ? "group-1" : undefined,
+    focus_phonemes: group.group_type === "weak_focus" ? ["/ʃ/"] : [],
+    action_label:
+      sourceScope === "normal_next" ? `Start Group ${group.group_index}` : undefined,
     daily_word_count: group.items.length,
     word_count: group.items.length,
     status: "active",
@@ -230,12 +269,16 @@ async function routeMock(route: Route, state: MockState) {
   }
 
   if (path === "/today") {
-    if (state.focusPhonemes.length > 0) {
-      state.activeGroup = "focused";
-    } else if (state.completedGroups.has("group1")) {
+    if (state.completedGroups.has("group1")) {
       state.activeGroup = "group2";
     }
     await route.fulfill({ json: toTodayResponse(groups[state.activeGroup]) });
+    return;
+  }
+
+  if (path === "/practice/next-normal") {
+    state.activeGroup = "group2";
+    await route.fulfill({ json: toTodayResponse(groups.group2) });
     return;
   }
 
@@ -288,6 +331,35 @@ async function routeMock(route: Route, state: MockState) {
     return;
   }
 
+  if (path === "/review/current-group") {
+    state.activeGroup = "currentReview";
+    await route.fulfill({ json: toTodayResponse(groups.currentReview) });
+    return;
+  }
+
+  if (path === "/practice/focus") {
+    const body = request.postDataJSON() as { focus_phonemes?: string[] };
+    state.focusPhonemes = body.focus_phonemes ?? ["/ʃ/"];
+    state.activeGroup = "focused";
+    await route.fulfill({ json: toTodayResponse(groups.focused) });
+    return;
+  }
+
+  if (path === "/practice/clear-focus") {
+    state.focusPhonemes = [];
+    state.activeGroup = "group2";
+    await route.fulfill({
+      json: {
+        ...toTodayResponse(groups.group2),
+        origin: "focus_clear",
+        source_scope: "normal_current",
+        focus_phonemes: [],
+        detail: "Focus selection cleared.",
+      },
+    });
+    return;
+  }
+
   await route.fallback();
 }
 
@@ -326,9 +398,10 @@ test.describe("M7 v2 learner workflow walkthrough", () => {
       await expect(page.getByText("ship")).toBeVisible();
       await expect(page.getByText("picked")).toBeVisible();
       await expect(page.getByText("Target sound: /ʃ/")).toBeVisible();
-      await expect(page.getByRole("button", { name: "Continue" })).toBeVisible();
-      await expect(page.getByRole("button", { name: "Review mistakes" })).toBeVisible();
-      await expect(page.getByRole("button", { name: "Stop" })).toBeVisible();
+      await expect(page.getByRole("button", { name: "Start next 10-word group" })).toBeVisible();
+      await expect(page.getByRole("button", { name: "Review misses from Group 1" })).toBeVisible();
+      await expect(page.getByRole("button", { name: "Review recent mistakes" })).toBeVisible();
+      await expect(page.getByRole("button", { name: "Return to Progress" })).toBeVisible();
     });
   });
 
@@ -337,8 +410,10 @@ test.describe("M7 v2 learner workflow walkthrough", () => {
     await openWalkthrough(page);
     await completeFirstGroupWithOneMiss(page);
 
-    test.fail(true, "Pending #136: next-normal action copy should name the intended group.");
-    await expect(page.getByRole("button", { name: "Start Group 2" })).toBeVisible();
+    await page.getByRole("button", { name: "Start next 10-word group" }).click();
+    await expect(page.getByText("Group 2: 1 / 1")).toBeVisible();
+    await expect(page.getByText("A new normal practice group.")).toBeVisible();
+    await expect(page.getByText("cheese")).toBeVisible();
   });
 
   test("4. current-group review and recent/global review are distinguishable", async ({ page }) => {
@@ -346,9 +421,10 @@ test.describe("M7 v2 learner workflow walkthrough", () => {
     await openWalkthrough(page);
     await completeFirstGroupWithOneMiss(page);
 
-    test.fail(true, "Pending #136: current-group review and recent review need separate actions/copy.");
     await expect(page.getByRole("button", { name: "Review misses from Group 1" })).toBeVisible();
     await expect(page.getByRole("button", { name: "Review recent mistakes" })).toBeVisible();
+    await page.getByRole("button", { name: "Review misses from Group 1" }).click();
+    await expect(page.getByText("Reviewing misses from the group you just finished.")).toBeVisible();
   });
 
   test("5-6. focus can be selected without raw IPA typing and launches focused practice", async ({ page }) => {
@@ -356,18 +432,27 @@ test.describe("M7 v2 learner workflow walkthrough", () => {
     await openWalkthrough(page);
     await page.getByRole("button", { name: "Progress" }).click();
     await expect(page.getByRole("heading", { name: "Progress" })).toBeVisible();
-    await page.getByRole("button", { name: "Focus" }).click();
+    await expect(page.getByText("Start focused practice from a weak sound.")).toBeVisible();
+    await page.getByRole("button", { name: "Focus /ʃ/" }).click();
 
-    test.fail(true, "Pending #136/#138: selected focus should start a named weak-focus group and expose clear-focus in flow.");
-    await expect(page.getByText("Focused group: /ʃ/")).toBeVisible();
+    await expect(page.getByText("Focused group: 1 / 1")).toBeVisible();
+    await expect(page.getByText("Focused practice for /ʃ/.")).toBeVisible();
     await expect(page.getByRole("button", { name: "Clear focus" })).toBeVisible();
+    await page.getByRole("button", { name: "Clear focus" }).click();
+    await expect(page.getByText("Focus cleared. Back to normal practice.")).toBeVisible();
+    const screenshotPath = test.info().outputPath("m7-focus-mobile.png");
+    await page.screenshot({ fullPage: true, path: screenshotPath });
+    await test.info().attach("m7-focus-mobile", {
+      path: screenshotPath,
+      contentType: "image/png",
+    });
   });
 
   test("7. stop/return leaves the learner in a known meaningful state", async ({ page }) => {
     await setupMockApi(page);
     await openWalkthrough(page);
     await completeFirstGroupWithOneMiss(page);
-    await page.getByRole("button", { name: "Stop" }).click();
+    await page.getByRole("button", { name: "Return to Progress" }).click();
 
     await expect(page.getByRole("heading", { name: "Progress" })).toBeVisible();
     await expect(page.getByText("Needs practice")).toBeVisible();
@@ -378,10 +463,10 @@ test.describe("M7 v2 learner workflow walkthrough", () => {
     await setupMockApi(page, { failRecentReview: true });
     await openWalkthrough(page);
     await completeFirstGroupWithOneMiss(page);
-    await page.getByRole("button", { name: "Review mistakes" }).click();
+    await page.getByRole("button", { name: "Review recent mistakes" }).click();
 
     await expect(page.getByRole("heading", { name: "Group 1 complete" })).toBeVisible();
     await expect(page.getByText("REVIEW_FAILED: Review unavailable")).toBeVisible();
-    await expect(page.getByRole("button", { name: "Review mistakes" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Review recent mistakes" })).toBeVisible();
   });
 });

--- a/frontend/tests/e2e/m7-walkthrough.spec.ts
+++ b/frontend/tests/e2e/m7-walkthrough.spec.ts
@@ -269,6 +269,10 @@ async function routeMock(route: Route, state: MockState) {
   }
 
   if (path === "/today") {
+    if (state.activeGroup === "focused") {
+      await route.fulfill({ json: toTodayResponse(groups.group2) });
+      return;
+    }
     if (state.completedGroups.has("group1")) {
       state.activeGroup = "group2";
     }


### PR DESCRIPTION
## Scope completed

### #137 Today practice workflow
- Rebuilt Today around explicit workflow states for normal groups, completion summary, next normal group, current-group review, recent/global review, focused group, empty review, retry/error, and return-to-Progress.
- Replaced ambiguous `Continue` with `Start next 10-word group`.
- Added current-group review and recent mistake review as separate actions/copy.
- Preserved completion summary through empty/error follow-up actions.
- Consumes #136 metadata (`group_type`, `origin`, `source_scope`, `source_group_id`, `focus_phonemes`, `action_label`) to explain what the learner is doing and why.

### #138 Focus workflow
- Progress weak phonemes now explain why focus is suggested and start focused practice without raw IPA typing.
- Settings no longer makes raw IPA entry primary; selectable focus chips are primary and manual IPA entry is moved under advanced/debug.
- Focus selection sends stable/deduped ordering before calling #136 focused-practice API.
- Focus state is visible in Today and Progress, with clear-focus returning to normal practice via #136 API.

Linked issues: #114, #137, #138

## Scenario / walkthrough evidence
- Updated `frontend/tests/e2e/m7-walkthrough.spec.ts` so the previous #137/#138 product-pending expected-fail checks are now ordinary passing assertions.
- Covered mobile viewport scenario steps for: next normal group, current-group review, recent review failure preserving summary, focus selection without raw IPA typing, focused group entry, and clear focus.
- Screenshot artifact generated by the passing walkthrough: `frontend/test-results/m7-walkthrough/m7-walkthrough-M7-v2-learn-e11c7-d-launches-focused-practice-m7-mobile-chromium/m7-focus-mobile.png`.

## Verification
- `cd frontend && pnpm run lint` -> passed
- `cd frontend && pnpm exec tsc --noEmit` -> passed
- `cd frontend && pnpm run build` -> passed
- `cd frontend && pnpm test:e2e:m7` -> 6 passed
- `git diff --check` -> clean
- `tools/agents/agent-audit` -> clean

## Residual risks
- The walkthrough uses route-mocked disposable API fixtures, as intended by #135; #139 should still perform final scenario readiness against the integration branch.
- Settings uses a small fixed common focus list plus Progress weak phonemes; richer phoneme catalog browsing can remain future work if needed.
- No backend behavior changed in this PR.