### PR TITLE
[#146] Harden helper migration readiness blockers

### DIFF
--- a/tools/agents/README.md
+++ b/tools/agents/README.md
@@ -9,7 +9,55 @@ Requirements:
 ```bash
 gh
 jq
+bash
 ```
+
+Supported shell target for migrated helpers:
+
+- macOS Bash 3.2
+- modern Bash 5.x
+
+Run `tools/agents/test-shell-compat` before moving helper changes toward a
+portable runtime. Unsupported shells should fail before mutation; these helpers
+are not written for POSIX `sh`, `zsh`, or fish.
+
+## New Repository Setup
+
+For Tiny IPA, helpers discover `farmerhunter/tiny-ipa` from the local Git
+remote and preserve the current dogfood behavior. For another repository, set
+the target explicitly or run from a checkout whose `origin` remote points at the
+target GitHub repo:
+
+```bash
+export GH_REPO=owner/name
+```
+
+`AGENT_REPO` is accepted as a secondary repo override, but `GH_REPO` matches the
+GitHub CLI convention and should be preferred. If neither override is set, the
+helpers try to parse `git remote get-url origin`. The built-in Tiny IPA fallback
+exists only for this project-local dogfood checkout; new projects should not
+depend on it.
+
+Repo-local role routing is configured with:
+
+```bash
+export AGENT_ROLE_ROUTING_CONFIG=/path/to/role-routing.conf
+tools/agents/agent-role-config
+```
+
+The config is shell-readable and must define `AGENT_ROLES`,
+`AGENT_ROLE_LABEL_<role>`, and `AGENT_PRIMARY_NEXT_LABELS`. Unknown roles,
+unknown primary labels, duplicate labels, and malformed `needs:*` labels fail
+closed.
+
+Use a project-local cache path when Project v2 helpers are enabled:
+
+```bash
+export AGENT_CACHE_DIR=.agent-cache
+```
+
+Normal inbox, context, comment, label, pickup, handoff, audit, and dry-run
+planning helpers do not require GitHub Project v2 access.
 
 ## Fast Inbox
 
@@ -37,14 +85,30 @@ Role routing is configured by `tools/agents/role-routing.conf`, with a built-in
 fallback in `_lib.sh` so helpers still work if the config file is absent. The
 config is shell-readable and defines roles, each role's inbox label, and the
 primary next-action labels. Use `tools/agents/agent-role-config` to print the
-active config compactly. Future projects can adapt the role set by changing
-that one config file instead of editing every helper script.
+active repo and config compactly. Future projects can adapt the role set by
+changing that one config file instead of editing every helper script.
 
 `agent-permission-smoke` is the first check for delegated or resumed agent
 turns. It verifies non-mutating GitHub API reads, remote Git reads, and local
-Git metadata writes. If it fails, do not begin branch/PR work from that turn;
+Git metadata writes, using the same retry wrapper as other GitHub helper paths.
+Add `--project` only when the turn needs Project v2 helper access. If it fails,
+do not begin branch/PR work from that turn;
 report the permission downgrade and wait for a user turn with full GitHub
 network access and local Git metadata write permission.
+
+Recommended scopes:
+
+- Read-only inbox/context/audit: repo issue and PR read access.
+- `agent-comment --apply`: permission to create issue/PR conversation comments.
+- `agent-label`: permission to add/remove issue labels.
+- Git branch/PR workflow outside these helpers: normal Git remote read/write
+  permission for the task branch.
+- `agent-project-status`: Project v2 access plus explicit Project env vars.
+
+`gh-retry` retries transient GitHub/TLS failures. `GH_RETRY_ATTEMPTS` and
+`GH_RETRY_SLEEP` tune retry count and delay. Auth failures, missing Project
+access, and permission downgrade should still be treated as blockers rather
+than hidden by repeated retries.
 
 `agent-inbox` reads primary next-action labels only. It deliberately avoids Project v2
 queries because labels are faster and more reliable for agent pickup. It uses
@@ -116,7 +180,12 @@ risks. It deliberately does not parse arbitrary terminal logs or infer success.
 `agent-dispatch-note` is explicit-input only. It prints a bounded dispatch note
 for direct-thread acceleration only. It resolves roles/labels through role routing,
 fetches durable context (subject title/state/link) from GitHub REST, and emits a
-copy/paste thread note that must not be used as the source of truth.
+copy/paste thread note that must not be used as the source of truth. The helper
+does not call thread APIs. Use `--evidence-mode live-thread --evidence <tool
+result>` only after a real runtime thread tool, such as `send_message_to_thread`,
+accepts the dispatch. Use `--evidence-mode github-comment` or
+`--evidence-mode portable-prompt` for runtimes without live thread tools. The
+default `generated-note` mode means a note was generated, not dispatched.
 
 `agent-audit` is a read-only consistency check. It looks for common workflow
 drift without touching GitHub Project v2:
@@ -166,6 +235,7 @@ unnecessary delete/add calls when the issue is already in the requested route.
 tools/agents/agent-project-status 15 "In progress"
 tools/agents/agent-project-status 15 "In Review"
 tools/agents/agent-project-status 15 Done
+tools/agents/agent-project-status --check-config
 ```
 
 Project v2 item IDs are cached in `.agent-cache/project-items.tsv`. Refresh
@@ -177,3 +247,56 @@ tools/agents/agent-project-status --refresh
 
 Do not use Project status as the only routing signal. Update labels and comments
 first, then sync Project status for the visual board.
+
+Project v2 config is optional and deliberately separate from the ordinary helper
+path. Outside Tiny IPA, set all of these before using `agent-project-status`:
+
+```bash
+export GH_PROJECT_OWNER=owner-or-org
+export GH_PROJECT_NUMBER=1
+export GH_PROJECT_ID=PVT_...
+export GH_PROJECT_STATUS_FIELD_ID=PVTSSF_...
+```
+
+If these are missing, `agent-project-status --check-config` fails with
+actionable guidance. This keeps new repositories from inheriting Tiny IPA
+Project IDs accidentally.
+
+## Portable Fixtures
+
+The helper tests now have two categories:
+
+- Portable fixtures: repo-neutral fake `gh-retry` tests that run offline with
+  `GH_REPO=example-org/example-repo`. Use these as migration evidence.
+- Tiny IPA dogfood regression fixtures: tests that preserve project-local
+  examples, historical Epic branches, and issue narratives from #58/#83.
+
+Run:
+
+```bash
+tools/agents/test-portable-fixtures
+tools/agents/test-shell-compat
+```
+
+The portable fixture suite covers repo-neutral role config, read-only inbox,
+dry-run pickup, narrow comment apply through a fake REST endpoint, and Project
+config fail-closed behavior.
+
+## Troubleshooting
+
+- GitHub TLS or HTTP/2 instability: rerun through the helper path so `gh-retry`
+  applies. If retries still fail, report the network/TLS blocker exactly.
+- Auth failure: run `gh auth status` and `tools/agents/agent-permission-smoke`;
+  do not start branch/PR work if smoke fails.
+- Missing Project access: continue label/comment routing when Project is not
+  required; run `tools/agents/agent-permission-smoke --project` only for Project
+  helper work.
+- Missing thread tools: use `agent-dispatch-note --evidence-mode
+  portable-prompt` or a durable GitHub comment fallback, and do not claim a live
+  dispatch happened.
+- Shell incompatibility: run `tools/agents/test-shell-compat`; unsupported
+  shells should be treated as an execution-layer blocker.
+- Permission downgrade: distinguish Codex sandbox execution permission from
+  workflow approval. Authorized issue branch/PR/comment/label routing remains a
+  normal workflow action, but sandbox/network failures must be reported or
+  retried with execution-layer permission.

--- a/tools/agents/_lib.sh
+++ b/tools/agents/_lib.sh
@@ -5,6 +5,81 @@ repo_api_path() {
   printf 'repos/%s' "$repo"
 }
 
+agent_parse_github_repo_from_remote() {
+  local remote="$1"
+
+  case "$remote" in
+    git@github.com:*.git)
+      printf '%s\n' "${remote#git@github.com:}" | sed 's/\.git$//'
+      ;;
+    git@github.com:*)
+      printf '%s\n' "${remote#git@github.com:}"
+      ;;
+    https://github.com/*.git)
+      printf '%s\n' "${remote#https://github.com/}" | sed 's/\.git$//'
+      ;;
+    https://github.com/*)
+      printf '%s\n' "${remote#https://github.com/}"
+      ;;
+    ssh://git@github.com/*.git)
+      printf '%s\n' "${remote#ssh://git@github.com/}" | sed 's/\.git$//'
+      ;;
+    ssh://git@github.com/*)
+      printf '%s\n' "${remote#ssh://git@github.com/}"
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+agent_repo() {
+  local remote repo
+
+  if [[ -n "${GH_REPO:-}" ]]; then
+    printf '%s\n' "$GH_REPO"
+    return
+  fi
+
+  if [[ -n "${AGENT_REPO:-}" ]]; then
+    printf '%s\n' "$AGENT_REPO"
+    return
+  fi
+
+  if remote="$(git remote get-url origin 2>/dev/null)" &&
+    repo="$(agent_parse_github_repo_from_remote "$remote")" &&
+    [[ "$repo" =~ ^[^/[:space:]]+/[^/[:space:]]+$ ]]; then
+    printf '%s\n' "$repo"
+    return
+  fi
+
+  printf '%s\n' 'Warning: using built-in Tiny IPA repo fallback; set GH_REPO or run from a GitHub checkout to avoid this fallback.' >&2
+  printf '%s\n' 'farmerhunter/tiny-ipa'
+}
+
+agent_repo_source() {
+  local remote repo
+
+  if [[ -n "${GH_REPO:-}" ]]; then
+    printf '%s\n' 'GH_REPO'
+    return
+  fi
+
+  if [[ -n "${AGENT_REPO:-}" ]]; then
+    printf '%s\n' 'AGENT_REPO'
+    return
+  fi
+
+  if remote="$(git remote get-url origin 2>/dev/null)" &&
+    repo="$(agent_parse_github_repo_from_remote "$remote")" &&
+    [[ "$repo" =~ ^[^/[:space:]]+/[^/[:space:]]+$ ]]; then
+    printf '%s\n' 'git remote origin'
+    return
+  fi
+
+  printf '%s\n' 'built-in Tiny IPA fallback'
+}
+
 agent_role_config_path() {
   if [[ -n "${AGENT_ROLE_ROUTING_CONFIG:-}" ]]; then
     printf '%s\n' "$AGENT_ROLE_ROUTING_CONFIG"
@@ -252,6 +327,7 @@ agent_print_role_routing_config() {
   local role label first=1
 
   agent_load_role_config || return 2
+  printf 'Repository: %s (%s)\n' "$(agent_repo)" "$(agent_repo_source)"
   printf 'Config: %s\n' "$AGENT_ROLE_CONFIG_SOURCE"
   printf 'Roles:'
   for role in "${AGENT_ROLES[@]}"; do

--- a/tools/agents/agent-audit
+++ b/tools/agents/agent-audit
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-repo="${GH_REPO:-farmerhunter/tiny-ipa}"
 limit="${AGENT_AUDIT_LIMIT:-100}"
 comments_limit="${AGENT_COMMENTS_LIMIT:-100}"
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 gh_retry="$root/tools/agents/gh-retry"
 source "$root/tools/agents/_lib.sh"
+repo="$(agent_repo)"
 
 usage() {
   cat <<'USAGE'

--- a/tools/agents/agent-batch-accept
+++ b/tools/agents/agent-batch-accept
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-repo="${GH_REPO:-farmerhunter/tiny-ipa}"
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 gh_retry="$root/tools/agents/gh-retry"
 source "$root/tools/agents/_lib.sh"
+repo="$(agent_repo)"
 
 usage() {
   cat <<'USAGE'

--- a/tools/agents/agent-comment
+++ b/tools/agents/agent-comment
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-repo="${GH_REPO:-farmerhunter/tiny-ipa}"
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 gh_retry="$root/tools/agents/gh-retry"
 source "$root/tools/agents/_lib.sh"
+repo="$(agent_repo)"
 
 usage() {
   cat <<'USAGE'

--- a/tools/agents/agent-dispatch-note
+++ b/tools/agents/agent-dispatch-note
@@ -1,20 +1,26 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-repo="${GH_REPO:-farmerhunter/tiny-ipa}"
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 gh_retry="$root/tools/agents/gh-retry"
 source "$root/tools/agents/_lib.sh"
+repo="$(agent_repo)"
 
 usage() {
   cat <<'USAGE'
 Usage:
-  tools/agents/agent-dispatch-note --issue <issue> --to <role|label> [--from <role|label>] [--reason <text>]
-  tools/agents/agent-dispatch-note --pr <pr> --to <role|label> [--from <role|label>] [--reason <text>]
-  tools/agents/agent-dispatch-note --batch --epic <issue> --to <role|label> [--child <issue>...] [--from <role|label>] [--reason <text>]
+  tools/agents/agent-dispatch-note --issue <issue> --to <role|label> [--from <role|label>] [--reason <text>] [--evidence-mode <mode>] [--evidence <text>]
+  tools/agents/agent-dispatch-note --pr <pr> --to <role|label> [--from <role|label>] [--reason <text>] [--evidence-mode <mode>] [--evidence <text>]
+  tools/agents/agent-dispatch-note --batch --epic <issue> --to <role|label> [--child <issue>...] [--from <role|label>] [--reason <text>] [--evidence-mode <mode>] [--evidence <text>]
 
 Generates a bounded dispatch prompt for direct-thread acceleration. This helper only
 prints the durable-boundary note and does not call thread APIs.
+
+Evidence modes:
+  generated-note    default; this helper generated a copy/paste note only
+  live-thread       a runtime thread tool accepted a dispatch; --evidence required
+  github-comment    durable GitHub comment used as portable dispatch fallback
+  portable-prompt   prompt text handed off manually outside a thread tool
 USAGE
 }
 
@@ -29,6 +35,8 @@ epic=""
 to_target=""
 from_target=""
 reason="handoff to next role"
+evidence_mode="generated-note"
+evidence=""
 children=()
 
 while [[ $# -gt 0 ]]; do
@@ -111,6 +119,22 @@ while [[ $# -gt 0 ]]; do
       reason="$2"
       shift 2
       ;;
+    --evidence-mode)
+      if [[ -z "${2:-}" ]]; then
+        printf '%s\n' '--evidence-mode requires a mode' >&2
+        exit 2
+      fi
+      evidence_mode="$2"
+      shift 2
+      ;;
+    --evidence)
+      if [[ -z "${2:-}" ]]; then
+        printf '%s\n' '--evidence requires text' >&2
+        exit 2
+      fi
+      evidence="$2"
+      shift 2
+      ;;
     *)
       usage >&2
       exit 2
@@ -125,6 +149,21 @@ fi
 
 if [[ -z "$to_target" ]]; then
   printf '%s\n' '--to is required' >&2
+  exit 2
+fi
+
+case "$evidence_mode" in
+  generated-note|live-thread|github-comment|portable-prompt)
+    ;;
+  *)
+    printf 'Unknown evidence mode: %s\n' "$evidence_mode" >&2
+    printf '%s\n' 'Use generated-note, live-thread, github-comment, or portable-prompt.' >&2
+    exit 2
+    ;;
+esac
+
+if [[ "$evidence_mode" == "live-thread" && -z "$evidence" ]]; then
+  printf '%s\n' 'live-thread evidence mode requires --evidence naming the accepted tool/result' >&2
   exit 2
 fi
 
@@ -150,6 +189,7 @@ format_dispatch_payload() {
 
 Do not use this as the durable source of truth.
 Use durable GitHub issue/PR/Project state for state transitions.
+This helper does not call thread APIs by itself.
 
 Bounded dispatch:
 - Subject: $subject_type #$subject_ref
@@ -159,6 +199,8 @@ Bounded dispatch:
 - To: $to_display
 - Reason: $reason
 - Expected result: $summary
+- Evidence mode: $evidence_mode
+- Evidence: ${evidence:-not a live dispatch; generated note/fallback only}
 
 Copy/paste thread note:
 \`\`\`

--- a/tools/agents/agent-handoff
+++ b/tools/agents/agent-handoff
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-repo="${GH_REPO:-farmerhunter/tiny-ipa}"
 comments_limit="${AGENT_COMMENTS_LIMIT:-100}"
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 gh_retry="$root/tools/agents/gh-retry"
 source "$root/tools/agents/_lib.sh"
+repo="$(agent_repo)"
 
 usage() {
   cat <<'USAGE'

--- a/tools/agents/agent-inbox
+++ b/tools/agents/agent-inbox
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-repo="${GH_REPO:-farmerhunter/tiny-ipa}"
 limit="${AGENT_INBOX_LIMIT:-30}"
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 gh_retry="$root/tools/agents/gh-retry"
 source "$root/tools/agents/_lib.sh"
+repo="$(agent_repo)"
 
 usage() {
   cat <<'USAGE'

--- a/tools/agents/agent-issue-context
+++ b/tools/agents/agent-issue-context
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-repo="${GH_REPO:-farmerhunter/tiny-ipa}"
 comments_limit="${AGENT_COMMENTS_LIMIT:-100}"
 pr_limit="${AGENT_PR_LIMIT:-50}"
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 gh_retry="$root/tools/agents/gh-retry"
 source "$root/tools/agents/_lib.sh"
+repo="$(agent_repo)"
 
 usage() {
   cat <<'USAGE'

--- a/tools/agents/agent-label
+++ b/tools/agents/agent-label
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-repo="${GH_REPO:-farmerhunter/tiny-ipa}"
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 gh_retry="$root/tools/agents/gh-retry"
 source "$root/tools/agents/_lib.sh"
+repo="$(agent_repo)"
 
 usage() {
   cat <<'USAGE'

--- a/tools/agents/agent-permission-smoke
+++ b/tools/agents/agent-permission-smoke
@@ -1,13 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-repo="${GH_REPO:-farmerhunter/tiny-ipa}"
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+gh_retry="$root/tools/agents/gh-retry"
+source "$root/tools/agents/_lib.sh"
+repo="$(agent_repo)"
+check_project=0
 
 usage() {
   cat <<'USAGE'
 Usage:
-  tools/agents/agent-permission-smoke
+  tools/agents/agent-permission-smoke [--project]
 
 Checks whether the current agent turn can perform the basic non-mutating
 permissions needed before issue pickup:
@@ -15,6 +18,7 @@ permissions needed before issue pickup:
 - read the GitHub API through gh
 - read the remote Git repository
 - write temporary Git metadata in this local checkout
+- optionally validate Project v2 helper config with --project
 
 It does not mutate GitHub, create branches, push, or change Project state.
 USAGE
@@ -24,10 +28,18 @@ if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
   usage
   exit 0
 fi
-if [[ $# -gt 0 ]]; then
-  usage >&2
-  exit 2
-fi
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --project)
+      check_project=1
+      shift
+      ;;
+    *)
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
 
 failures=0
 
@@ -44,8 +56,12 @@ check() {
   fi
 }
 
-check "GitHub API read via gh" gh api "repos/$repo" --jq .full_name
-check "remote Git read" git ls-remote --heads origin HEAD
+check "GitHub API read via gh for $repo" "$gh_retry" gh api "repos/$repo" --jq .full_name
+check "remote Git read" "$gh_retry" git ls-remote --heads origin HEAD
+
+if [[ "$check_project" -eq 1 ]]; then
+  check "Project v2 helper config" "$root/tools/agents/agent-project-status" --check-config
+fi
 
 git_dir="$(git -C "$root" rev-parse --git-dir)"
 case "$git_dir" in

--- a/tools/agents/agent-pickup
+++ b/tools/agents/agent-pickup
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-repo="${GH_REPO:-farmerhunter/tiny-ipa}"
 comments_limit="${AGENT_COMMENTS_LIMIT:-100}"
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 gh_retry="$root/tools/agents/gh-retry"
 source "$root/tools/agents/_lib.sh"
+repo="$(agent_repo)"
 
 usage() {
   cat <<'USAGE'

--- a/tools/agents/agent-pr-context
+++ b/tools/agents/agent-pr-context
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-repo="${GH_REPO:-farmerhunter/tiny-ipa}"
 comments_limit="${AGENT_COMMENTS_LIMIT:-100}"
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 gh_retry="$root/tools/agents/gh-retry"
 source "$root/tools/agents/_lib.sh"
+repo="$(agent_repo)"
 
 usage() {
   cat <<'USAGE'

--- a/tools/agents/agent-project-status
+++ b/tools/agents/agent-project-status
@@ -1,26 +1,53 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-repo="${GH_REPO:-farmerhunter/tiny-ipa}"
-owner="${GH_PROJECT_OWNER:-farmerhunter}"
-project_number="${GH_PROJECT_NUMBER:-2}"
-project_id="${GH_PROJECT_ID:-PVT_kwHOAaWXD84BZ3xw}"
-status_field_id="${GH_PROJECT_STATUS_FIELD_ID:-PVTSSF_lAHOAaWXD84BZ3xwzhUzcCU}"
-cache_dir="${AGENT_CACHE_DIR:-.agent-cache}"
-cache_file="$cache_dir/project-items.tsv"
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 gh_retry="$root/tools/agents/gh-retry"
+source "$root/tools/agents/_lib.sh"
+repo="$(agent_repo)"
+owner="${GH_PROJECT_OWNER:-}"
+project_number="${GH_PROJECT_NUMBER:-}"
+project_id="${GH_PROJECT_ID:-}"
+status_field_id="${GH_PROJECT_STATUS_FIELD_ID:-}"
+cache_dir="${AGENT_CACHE_DIR:-.agent-cache}"
+cache_file="$cache_dir/project-items.tsv"
+
+if [[ "$repo" == "farmerhunter/tiny-ipa" ]]; then
+  owner="${owner:-farmerhunter}"
+  project_number="${project_number:-2}"
+  project_id="${project_id:-PVT_kwHOAaWXD84BZ3xw}"
+  status_field_id="${status_field_id:-PVTSSF_lAHOAaWXD84BZ3xwzhUzcCU}"
+fi
 
 usage() {
   cat <<'USAGE'
 Usage:
   tools/agents/agent-project-status <issue-number> <Backlog|Ready|In progress|In Review|Done>
   tools/agents/agent-project-status --refresh
+  tools/agents/agent-project-status --check-config
 
 Updates GitHub Project v2 status for a known issue.
 This is intentionally separate from inbox lookup because Project v2 is slower
 and more brittle than issue labels.
 USAGE
+}
+
+project_config_missing() {
+  [[ -z "$owner" || -z "$project_number" || -z "$project_id" || -z "$status_field_id" ]]
+}
+
+require_project_config() {
+  if project_config_missing; then
+    cat >&2 <<'MESSAGE'
+Project v2 helper config is incomplete.
+
+Set GH_PROJECT_OWNER, GH_PROJECT_NUMBER, GH_PROJECT_ID, and
+GH_PROJECT_STATUS_FIELD_ID before using Project v2 helpers outside Tiny IPA.
+Ordinary inbox/context/comment/label/audit helper paths do not require
+Project v2 access.
+MESSAGE
+    return 2
+  fi
 }
 
 option_id_for_status() {
@@ -35,6 +62,7 @@ option_id_for_status() {
 }
 
 refresh_cache() {
+  require_project_config || return 2
   mkdir -p "$cache_dir"
   "$gh_retry" gh project item-list "$project_number" \
     --owner "$owner" \
@@ -46,6 +74,13 @@ refresh_cache() {
 
 if [[ "${1:-}" == "-h" || "${1:-}" == "--help" || $# -eq 0 ]]; then
   usage
+  exit 0
+fi
+
+if [[ "${1:-}" == "--check-config" ]]; then
+  require_project_config
+  printf 'Project v2 config ok for %s (owner=%s project=%s cache=%s)\n' \
+    "$repo" "$owner" "$project_number" "$cache_file"
   exit 0
 fi
 

--- a/tools/agents/agent-ready-queue
+++ b/tools/agents/agent-ready-queue
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-repo="${GH_REPO:-farmerhunter/tiny-ipa}"
 limit="${AGENT_READY_LIMIT:-30}"
 comments_limit="${AGENT_COMMENTS_LIMIT:-100}"
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 gh_retry="$root/tools/agents/gh-retry"
 source "$root/tools/agents/_lib.sh"
+repo="$(agent_repo)"
 
 usage() {
   cat <<'USAGE'

--- a/tools/agents/agent-release-queue
+++ b/tools/agents/agent-release-queue
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-repo="${GH_REPO:-farmerhunter/tiny-ipa}"
 comments_limit="${AGENT_COMMENTS_LIMIT:-100}"
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 gh_retry="$root/tools/agents/gh-retry"
 source "$root/tools/agents/_lib.sh"
+repo="$(agent_repo)"
 
 usage() {
   cat <<'USAGE'

--- a/tools/agents/test-dispatch-note
+++ b/tools/agents/test-dispatch-note
@@ -43,6 +43,8 @@ grep -Fq "Bounded dispatch:" <<< "$issue_output"
 grep -Fq "Subject: issue #101" <<< "$issue_output"
 grep -Fq "From: needs:architect" <<< "$issue_output"
 grep -Fq "To: needs:reviewer" <<< "$issue_output"
+grep -Fq "Evidence mode: generated-note" <<< "$issue_output"
+grep -Fq "Evidence: not a live dispatch; generated note/fallback only" <<< "$issue_output"
 grep -Fq -- "- Context:" <<< "$issue_output"
 grep -Fq "Title: Issue note" <<< "$issue_output"
 grep -Fq "Expected result: release next-step to needs:reviewer" <<< "$issue_output"
@@ -60,6 +62,23 @@ grep -Fq "Epic: #203 Batch epic" <<< "$batch_output"
 grep -Fq "Child: #11 Child one" <<< "$batch_output"
 grep -Fq "Child: #22 Child two" <<< "$batch_output"
 grep -Fq "Child set: #11 #22" <<< "$batch_output"
+
+live_output="$("$fixture_root/tools/agents/agent-dispatch-note" --issue 101 --to reviewer --evidence-mode live-thread --evidence "send_message_to_thread accepted thread 123")"
+grep -Fq "Evidence mode: live-thread" <<< "$live_output"
+grep -Fq "Evidence: send_message_to_thread accepted thread 123" <<< "$live_output"
+
+github_fallback="$("$fixture_root/tools/agents/agent-dispatch-note" --issue 101 --to reviewer --evidence-mode github-comment --evidence "https://example.test/issues/101#comment")"
+grep -Fq "Evidence mode: github-comment" <<< "$github_fallback"
+
+if "$fixture_root/tools/agents/agent-dispatch-note" --issue 101 --to reviewer --evidence-mode live-thread >/dev/null 2>&1; then
+  printf 'live-thread mode without evidence unexpectedly succeeded\n' >&2
+  exit 1
+fi
+
+if "$fixture_root/tools/agents/agent-dispatch-note" --issue 101 --to reviewer --evidence-mode copied-text >/dev/null 2>&1; then
+  printf 'unknown evidence mode unexpectedly succeeded\n' >&2
+  exit 1
+fi
 
 if "$fixture_root/tools/agents/agent-dispatch-note" --batch --epic 203 --to reviewer >/dev/null 2>&1; then
   printf 'batch without child unexpectedly succeeded\n' >&2

--- a/tools/agents/test-portable-fixtures
+++ b/tools/agents/test-portable-fixtures
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+fixture_root="$tmp_dir/fixture-root"
+mkdir -p "$fixture_root/tools/agents"
+ln -s "$root/tools/agents/_lib.sh" "$fixture_root/tools/agents/_lib.sh"
+ln -s "$root/tools/agents/agent-comment" "$fixture_root/tools/agents/agent-comment"
+ln -s "$root/tools/agents/agent-inbox" "$fixture_root/tools/agents/agent-inbox"
+ln -s "$root/tools/agents/agent-pickup" "$fixture_root/tools/agents/agent-pickup"
+ln -s "$root/tools/agents/agent-project-status" "$fixture_root/tools/agents/agent-project-status"
+ln -s "$root/tools/agents/agent-role-config" "$fixture_root/tools/agents/agent-role-config"
+
+cat > "$tmp_dir/portable-role-routing.conf" <<'CONFIG'
+AGENT_ROLES=(planner builder reviewer user)
+AGENT_ROLE_LABEL_planner="needs:planner"
+AGENT_ROLE_LABEL_builder="needs:builder"
+AGENT_ROLE_LABEL_reviewer="needs:reviewer"
+AGENT_ROLE_LABEL_user="needs:user"
+AGENT_PRIMARY_NEXT_LABELS=(needs:planner needs:builder needs:reviewer needs:user blocked)
+CONFIG
+
+cat > "$fixture_root/tools/agents/gh-retry" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s\n' "$*" >> "$FAKE_GH_LOG"
+
+issue_json() {
+  jq -n '{
+    number: 42,
+    title: "Portable builder task",
+    state: "open",
+    html_url: "https://example.test/issues/42",
+    body: "## Execution Contract\n\nOwner role: builder\nReview role: reviewer\nAcceptance role: planner\nBranch strategy: issue branch\nBase branch: `feature/base`\nTarget PR base: `feature/base`\nDepends on: none\nCompletion handoff: to:reviewer\n",
+    labels: [{name: "type:task"}, {name: "needs:builder"}]
+  }'
+}
+
+case "$*" in
+  *"POST"*"repos/example-org/example-repo/issues/42/comments"*)
+    jq -n '{html_url:"https://example.test/issues/42#comment"}'
+    ;;
+  *"repos/example-org/example-repo/issues/42/comments"*)
+    printf '[]\n'
+    ;;
+  *"repos/example-org/example-repo/issues/42"*)
+    issue_json
+    ;;
+  *"repos/example-org/example-repo/issues"*"state=open"*)
+    cat <<'JSON'
+[
+  {
+    "number": 42,
+    "title": "Portable builder task",
+    "html_url": "https://example.test/issues/42",
+    "updated_at": "2026-06-17T00:00:00Z",
+    "labels": [{"name": "type:task"}, {"name": "needs:builder"}]
+  },
+  {
+    "number": 43,
+    "title": "Portable review task",
+    "html_url": "https://example.test/issues/43",
+    "updated_at": "2026-06-17T00:00:00Z",
+    "labels": [{"name": "type:task"}, {"name": "needs:reviewer"}]
+  }
+]
+JSON
+    ;;
+  *)
+    printf 'unexpected fake gh call: %s\n' "$*" >&2
+    exit 21
+    ;;
+esac
+SH
+chmod +x "$fixture_root/tools/agents/gh-retry"
+
+body_file="$tmp_dir/body.md"
+printf 'portable comment body\n' > "$body_file"
+
+export GH_REPO="example-org/example-repo"
+export AGENT_ROLE_ROUTING_CONFIG="$tmp_dir/portable-role-routing.conf"
+export FAKE_GH_LOG="$tmp_dir/fake-gh.log"
+
+role_output="$("$fixture_root/tools/agents/agent-role-config")"
+grep -Fq "Repository: example-org/example-repo (GH_REPO)" <<< "$role_output"
+grep -Fq "builder=needs:builder" <<< "$role_output"
+
+inbox_output="$("$fixture_root/tools/agents/agent-inbox" all)"
+grep -Fq "== needs:builder ==" <<< "$inbox_output"
+grep -Fq "#42 Portable builder task" <<< "$inbox_output"
+grep -Fq "== needs:reviewer ==" <<< "$inbox_output"
+grep -Fq "#43 Portable review task" <<< "$inbox_output"
+
+pickup_output="$("$fixture_root/tools/agents/agent-pickup" 42 --role builder)"
+grep -Fq "Role: builder (needs:builder)" <<< "$pickup_output"
+grep -Fq "Mode: dry-run" <<< "$pickup_output"
+grep -Fq "Gate: startable" <<< "$pickup_output"
+grep -Fq "remove needs:builder" <<< "$pickup_output"
+
+comment_output="$("$fixture_root/tools/agents/agent-comment" issue 42 --body-file "$body_file" --apply)"
+grep -Fq "Posted comment: https://example.test/issues/42#comment" <<< "$comment_output"
+
+if grep -Fq "farmerhunter/tiny-ipa" "$FAKE_GH_LOG"; then
+  printf 'portable fixture unexpectedly called Tiny IPA repo\n' >&2
+  exit 1
+fi
+
+if AGENT_REPO="example-org/example-repo" "$fixture_root/tools/agents/agent-project-status" --check-config >/dev/null 2>&1; then
+  printf 'Project config check unexpectedly passed without Project env\n' >&2
+  exit 1
+fi
+
+project_output="$(
+  AGENT_REPO="example-org/example-repo" \
+  GH_PROJECT_OWNER="example-org" \
+  GH_PROJECT_NUMBER="7" \
+  GH_PROJECT_ID="PVT_example" \
+  GH_PROJECT_STATUS_FIELD_ID="PVTSSF_example" \
+    "$fixture_root/tools/agents/agent-project-status" --check-config
+)"
+grep -Fq "Project v2 config ok for example-org/example-repo" <<< "$project_output"
+
+printf 'portable helper fixture checks passed\n'

--- a/tools/agents/test-shell-compat
+++ b/tools/agents/test-shell-compat
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+scripts=()
+while IFS= read -r path; do
+  scripts+=("$path")
+done < <(find "$root/tools/agents" -maxdepth 1 -type f -perm -u+x | sort)
+
+candidates=()
+if command -v bash >/dev/null 2>&1; then
+  candidates+=("$(command -v bash)")
+fi
+if [[ -x /bin/bash ]]; then
+  seen=0
+  for candidate in "${candidates[@]}"; do
+    if [[ "$candidate" == "/bin/bash" ]]; then
+      seen=1
+    fi
+  done
+  if [[ "$seen" -eq 0 ]]; then
+    candidates+=("/bin/bash")
+  fi
+fi
+
+if (( ${#candidates[@]} == 0 )); then
+  printf '%s\n' 'No bash runtime found for helper compatibility checks' >&2
+  exit 1
+fi
+
+cat > "$tmp_dir/custom.conf" <<'CONFIG'
+AGENT_ROLES=(planner builder reviewer user)
+AGENT_ROLE_LABEL_planner="needs:planner"
+AGENT_ROLE_LABEL_builder="needs:builder"
+AGENT_ROLE_LABEL_reviewer="needs:reviewer"
+AGENT_ROLE_LABEL_user="needs:user"
+AGENT_PRIMARY_NEXT_LABELS=(needs:planner needs:builder needs:reviewer needs:user blocked)
+CONFIG
+
+for bash_bin in "${candidates[@]}"; do
+  version="$("$bash_bin" --version | sed -n '1p')"
+  printf 'shell: %s\n' "$version"
+
+  for script in "${scripts[@]}"; do
+    "$bash_bin" -n "$script"
+  done
+
+  AGENT_ROLE_ROUTING_CONFIG="$tmp_dir/custom.conf" ROOT="$root" "$bash_bin" -c '
+    set -euo pipefail
+    source "$ROOT/tools/agents/_lib.sh"
+    [[ "$(agent_role_label_for_role builder)" == "needs:builder" ]]
+    agent_require_primary_next_label blocked
+    agent_join_lines < /dev/null >/tmp/agent-shell-compat-empty.out
+    [[ ! -s /tmp/agent-shell-compat-empty.out ]]
+    rm -f /tmp/agent-shell-compat-empty.out
+  '
+
+  AGENT_REPO="example-org/example-repo" ROOT="$root" "$bash_bin" -c '
+    set -euo pipefail
+    source "$ROOT/tools/agents/_lib.sh"
+    [[ "$(agent_repo)" == "example-org/example-repo" ]]
+  '
+done
+
+printf 'shell compatibility checks passed\n'


### PR DESCRIPTION
## Scope completed

Covers #149, #150, #151, #153, #154, and #156 for the #146 P0 migration-readiness blocker batch.

- #149: added repo discovery/override boundary through `agent_repo`, exposed repo source in `agent-role-config`, documented new-repo setup, and added a repo-neutral portable fixture that exercises helpers with `GH_REPO=example-org/example-repo`.
- #150: routed permission smoke through `gh-retry`, added optional `--project` config check, made Project v2 config explicit outside Tiny IPA, and documented auth/retry/Project optionality and troubleshooting.
- #151: extended `agent-dispatch-note` with dispatch evidence modes so generated notes, live-thread evidence, GitHub-comment fallback, and portable-prompt fallback are distinguishable; added regression coverage.
- #153: added `test-shell-compat` covering Bash syntax plus key `set -u`/array/config checks under available Bash runtimes.
- #154: added `test-portable-fixtures` as a repo-neutral offline fixture suite and documented the portable-vs-dogfood fixture split.
- #156: expanded `tools/agents/README.md` with new-repository onboarding, role config, cache, auth, Project v2, dispatch fallback, shell compatibility, and troubleshooting guidance.

No Agent Foundry migration, vault/runtime changes, Project v2 mutation, final `main` integration, or broad apply semantics were added.

## Verification

- `tools/agents/test-portable-fixtures` passed.
- `tools/agents/test-shell-compat` passed on GNU Bash 5.3.9 and macOS Bash 3.2.57.
- `tools/agents/test-dispatch-note` passed.
- `tools/agents/test-role-routing-config` passed.
- `tools/agents/test-agent-comment` passed.
- `tools/agents/test-agent-audit` passed.
- `tools/agents/test-batch-accept` passed.
- `tools/agents/test-contract-role-fields` passed.
- `tools/agents/test-dogfood-report` passed.
- `tools/agents/test-handoff` passed.
- `tools/agents/test-pickup` passed.
- `tools/agents/test-ready-queue` passed.
- `tools/agents/test-release-queue` passed.
- `bash -n` on touched helper scripts/tests passed.
- `git diff --check` passed.
- `tools/agents/agent-role-config` live smoke showed repo discovery from `git remote origin`.
- `tools/agents/agent-project-status --check-config` passed for Tiny IPA defaults.
- `tools/agents/agent-permission-smoke` passed.
- `tools/agents/agent-permission-smoke --project` passed.
- `tools/agents/agent-audit` passed with no workflow drift findings.

## Residual risks

- Project v2 option IDs remain Tiny IPA defaults only when the resolved repo is `farmerhunter/tiny-ipa`; other repos must provide explicit Project env vars.
- `gh-retry` still uses coarse retry behavior; it documents and retries transient failures but does not classify every GitHub error type.
- #155 inventory/classification remains Architect-owned and is intentionally not implemented here.
- #152 staged migration plan remains blocked until the P0 blocker batch is reviewed/accepted.