### PR TITLE
Fix practice review action semantics

### DIFF
--- a/frontend/playwright.m7.config.ts
+++ b/frontend/playwright.m7.config.ts
@@ -1,12 +1,15 @@
 import { defineConfig, devices } from "@playwright/test";
 
+const port = process.env.M7_WALKTHROUGH_PORT ?? "5177";
+const baseURL = `http://127.0.0.1:${port}`;
+
 export default defineConfig({
   testDir: "./tests/e2e",
   outputDir: "./test-results/m7-walkthrough",
   reporter: [["list"], ["html", { open: "never", outputFolder: "playwright-report/m7" }]],
   fullyParallel: false,
   use: {
-    baseURL: "http://127.0.0.1:5177",
+    baseURL,
     screenshot: "only-on-failure",
     trace: "retain-on-failure",
     video: "retain-on-failure",
@@ -21,8 +24,8 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: "pnpm exec vite --host 127.0.0.1 --port 5177 --strictPort",
-    url: "http://127.0.0.1:5177",
+    command: `pnpm exec vite --host 127.0.0.1 --port ${port} --strictPort`,
+    url: baseURL,
     reuseExistingServer: false,
     timeout: 120_000,
   },

--- a/frontend/src/pages/TodayPractice.tsx
+++ b/frontend/src/pages/TodayPractice.tsx
@@ -44,10 +44,10 @@ function canonicalFocus(phonemes: string[]): string[] {
 
 function groupLabel(session: TodayResponse): string {
   if (session.group_type === "weak_focus") return "Focused group";
-  if (session.source_scope === "current_group") return `Group ${session.group_index ?? 1} review`;
+  if (session.source_scope === "current_group") return "Current-group review";
   if (session.source_scope === "recent_global") return "Recent mistake review";
   if (session.group_type === "mistake_review") return "Mistake review";
-  return `Group ${session.group_index ?? 1}`;
+  return "Practice group";
 }
 
 function groupReason(session: TodayResponse): string {
@@ -75,6 +75,13 @@ function buildFocusHint(targetPhonemes: string[]): string {
     return "Focus on the IPA difference, then listen again.";
   }
   return `Focus on ${targetPhonemes.join(" ")} before choosing.`;
+}
+
+function currentReviewActionLabel(session: TodayResponse): string {
+  if (session.group_type === "mistake_review") {
+    return "Review misses from this review";
+  }
+  return "Review misses from this group";
 }
 
 export default function TodayPractice({
@@ -295,6 +302,7 @@ export default function TodayPractice({
     const total = results.length;
     const wrongResults = results.filter((r) => !r.isCorrect);
     const summarySession = lastSummarySession ?? session;
+    const hasCurrentGroupMisses = wrongResults.length > 0;
     const focusSuggestions = canonicalFocus(
       wrongResults.flatMap((result) => result.targetPhonemes),
     ).slice(0, 3);
@@ -363,13 +371,17 @@ export default function TodayPractice({
             >
               {actionLoading === "continue" ? "Loading…" : "Start next 10-word group"}
             </button>
-            <button
-              className="secondary-action-btn"
-              onClick={handleCurrentGroupReview}
-              disabled={actionLoading !== null}
-            >
-              {actionLoading === "current-review" ? "Loading…" : `Review misses from ${groupLabel(summarySession)}`}
-            </button>
+            {hasCurrentGroupMisses && (
+              <button
+                className="secondary-action-btn"
+                onClick={handleCurrentGroupReview}
+                disabled={actionLoading !== null}
+              >
+                {actionLoading === "current-review"
+                  ? "Loading…"
+                  : currentReviewActionLabel(summarySession)}
+              </button>
+            )}
             <button
               className="secondary-action-btn"
               onClick={handleRecentReview}

--- a/frontend/tests/e2e/m7-walkthrough.spec.ts
+++ b/frontend/tests/e2e/m7-walkthrough.spec.ts
@@ -52,7 +52,7 @@ const groups: Record<string, MockGroup> = {
   group2: {
     session_id: "session-group-2",
     group_id: "group-2",
-    group_index: 2,
+    group_index: 6,
     group_type: "normal",
     primary_accent: "US",
     items: [
@@ -70,7 +70,7 @@ const groups: Record<string, MockGroup> = {
   recentReview: {
     session_id: "session-recent-review",
     group_id: "recent-review",
-    group_index: 3,
+    group_index: 7,
     group_type: "mistake_review",
     primary_accent: "US",
     items: [
@@ -88,7 +88,7 @@ const groups: Record<string, MockGroup> = {
   currentReview: {
     session_id: "session-current-review",
     group_id: "current-review",
-    group_index: 3,
+    group_index: 5,
     group_type: "mistake_review",
     primary_accent: "US",
     items: [
@@ -106,7 +106,7 @@ const groups: Record<string, MockGroup> = {
   focused: {
     session_id: "session-focused",
     group_id: "focused-sh",
-    group_index: 4,
+    group_index: 8,
     group_type: "weak_focus",
     primary_accent: "US",
     items: [
@@ -369,7 +369,7 @@ async function routeMock(route: Route, state: MockState) {
 
 async function openWalkthrough(page: Page) {
   await page.goto("/");
-  await expect(page.getByText("Group 1: 1 / 2")).toBeVisible();
+  await expect(page.getByText("Practice group: 1 / 2")).toBeVisible();
 }
 
 async function answerVisibleItem(page: Page, choice: string) {
@@ -384,7 +384,7 @@ async function completeFirstGroupWithOneMiss(page: Page) {
   await expect(page.getByText("thin")).toBeVisible({ timeout: 4_000 });
 
   await answerVisibleItem(page, "/θɪn/");
-  await expect(page.getByRole("heading", { name: "Group 1 complete" })).toBeVisible({
+  await expect(page.getByRole("heading", { name: "Practice group complete" })).toBeVisible({
     timeout: 4_000,
   });
 }
@@ -403,7 +403,7 @@ test.describe("M7 v2 learner workflow walkthrough", () => {
       await expect(page.getByText("picked")).toBeVisible();
       await expect(page.getByText("Target sound: /ʃ/")).toBeVisible();
       await expect(page.getByRole("button", { name: "Start next 10-word group" })).toBeVisible();
-      await expect(page.getByRole("button", { name: "Review misses from Group 1" })).toBeVisible();
+      await expect(page.getByRole("button", { name: "Review misses from this group" })).toBeVisible();
       await expect(page.getByRole("button", { name: "Review recent mistakes" })).toBeVisible();
       await expect(page.getByRole("button", { name: "Return to Progress" })).toBeVisible();
     });
@@ -415,9 +415,10 @@ test.describe("M7 v2 learner workflow walkthrough", () => {
     await completeFirstGroupWithOneMiss(page);
 
     await page.getByRole("button", { name: "Start next 10-word group" }).click();
-    await expect(page.getByText("Group 2: 1 / 1")).toBeVisible();
+    await expect(page.getByText("Practice group: 1 / 1")).toBeVisible();
     await expect(page.getByText("A new normal practice group.")).toBeVisible();
     await expect(page.getByText("cheese")).toBeVisible();
+    await expect(page.getByText(/Group 6/)).toHaveCount(0);
   });
 
   test("4. current-group review and recent/global review are distinguishable", async ({ page }) => {
@@ -425,10 +426,34 @@ test.describe("M7 v2 learner workflow walkthrough", () => {
     await openWalkthrough(page);
     await completeFirstGroupWithOneMiss(page);
 
-    await expect(page.getByRole("button", { name: "Review misses from Group 1" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Review misses from this group" })).toBeVisible();
     await expect(page.getByRole("button", { name: "Review recent mistakes" })).toBeVisible();
-    await page.getByRole("button", { name: "Review misses from Group 1" }).click();
+    await page.getByRole("button", { name: "Review misses from this group" }).click();
     await expect(page.getByText("Reviewing misses from the group you just finished.")).toBeVisible();
+    await expect(page.getByText("Current-group review: 1 / 1")).toBeVisible();
+    await expect(page.getByText(/Group 5/)).toHaveCount(0);
+  });
+
+  test("review completions with no misses hide current-group review action", async ({ page }) => {
+    await setupMockApi(page);
+    await openWalkthrough(page);
+    await completeFirstGroupWithOneMiss(page);
+
+    await page.getByRole("button", { name: "Review misses from this group" }).click();
+    await expect(page.getByText("Current-group review: 1 / 1")).toBeVisible();
+    await answerVisibleItem(page, "/ʃɪp/");
+    await expect(page.getByRole("heading", { name: "Current-group review complete" })).toBeVisible();
+    await expect(page.getByText("No misses in this group.")).toBeVisible();
+    await expect(page.getByRole("button", { name: /Review misses from/ })).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "Review recent mistakes" })).toBeVisible();
+
+    await page.getByRole("button", { name: "Review recent mistakes" }).click();
+    await expect(page.getByText("Recent mistake review: 1 / 1")).toBeVisible();
+    await answerVisibleItem(page, "/ʃɪp/");
+    await expect(page.getByRole("heading", { name: "Recent mistake review complete" })).toBeVisible();
+    await expect(page.getByText("No misses in this group.")).toBeVisible();
+    await expect(page.getByRole("button", { name: /Review misses from/ })).toHaveCount(0);
+    await expect(page.getByText(/Group 7/)).toHaveCount(0);
   });
 
   test("5-6. focus can be selected without raw IPA typing and launches focused practice", async ({ page }) => {
@@ -440,6 +465,7 @@ test.describe("M7 v2 learner workflow walkthrough", () => {
     await page.getByRole("button", { name: "Focus /ʃ/" }).click();
 
     await expect(page.getByText("Focused group: 1 / 1")).toBeVisible();
+    await expect(page.getByText(/Group 8/)).toHaveCount(0);
     await expect(page.getByText("Focused practice for /ʃ/.")).toBeVisible();
     await expect(page.getByRole("button", { name: "Clear focus" })).toBeVisible();
     await page.getByRole("button", { name: "Clear focus" }).click();
@@ -469,7 +495,7 @@ test.describe("M7 v2 learner workflow walkthrough", () => {
     await completeFirstGroupWithOneMiss(page);
     await page.getByRole("button", { name: "Review recent mistakes" }).click();
 
-    await expect(page.getByRole("heading", { name: "Group 1 complete" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Practice group complete" })).toBeVisible();
     await expect(page.getByText("REVIEW_FAILED: Review unavailable")).toBeVisible();
     await expect(page.getByRole("button", { name: "Review recent mistakes" })).toBeVisible();
   });


### PR DESCRIPTION
## Summary

Fixes #158.

- Replace learner-facing normal practice ordinals with neutral `Practice group` copy so review/focus sessions no longer appear as skipped normal groups.
- Keep review/focus groups visibly distinct as `Current-group review`, `Recent mistake review`, and `Focused group`.
- Hide the current-group review action when the completed session has no misses.
- Extend the M7 Playwright walkthrough to cover misleading backend `group_index` values and no-miss review completions.

## Verification

- `cd frontend && pnpm run lint`
- `cd frontend && pnpm exec tsc --noEmit`
- `cd frontend && pnpm run build`
- `cd frontend && pnpm test:e2e:m7` -> 7 passed
- `git diff --check`
- `tools/agents/agent-audit`

## Residual risks

- This PR intentionally fixes learner-facing copy/actions only; it does not change backend `daily_sessions.group_index` semantics.
- The local real-app walkthrough used a rebuilt SQLite DB from `content/core_300_words.json`; the untracked backup DB was not committed.