### PR TITLE
Define M8 learner level contract

### DIFF
--- a/docs/05-data-api-contracts.md
+++ b/docs/05-data-api-contracts.md
@@ -463,11 +463,119 @@ MVP 默认：
   "show_translation": true,
   "show_accent_compare": false,
   "practice_mode": "ipa_first",
-  "review_strength": "normal"
+  "review_strength": "normal",
+  "learner_level": "entry"
 }
 ```
 
 `primary_accent = UK` 可以先不在 UI 开放，但字段应存在。
+
+### M8 learner levels
+
+M8 introduces a learner-facing level setting for future practice groups:
+
+```text
+learner_level = entry | mid
+```
+
+This is separate from `words.level`, which remains word-level difficulty metadata
+from the content source. Runtime scheduling must use `settings.learner_level`
+plus content-set readiness, not infer the user's selected level from
+`words.level`.
+
+User-facing labels:
+
+```text
+entry = Entry
+mid = Mid
+```
+
+Level meanings:
+
+```text
+Entry:
+  uses the existing Core 300 runtime set
+  is the default for existing and new users
+  must not overwrite, delete, or reshuffle the current Core 300 source file
+
+Mid:
+  uses a newly curated Core 1000 runtime set
+  should increase two-syllable and multi-syllable word ratio versus Core 300
+  must not become selectable as a working practice path until Core 1000 is imported and validated
+```
+
+Settings API contract:
+
+```json
+{
+  "primary_accent": "US",
+  "daily_word_count": 10,
+  "show_translation": true,
+  "show_accent_compare": false,
+  "practice_mode": "ipa_first",
+  "review_strength": "normal",
+  "focus_phonemes": [],
+  "learner_level": "entry"
+}
+```
+
+`PUT /api/settings` accepts partial updates. `learner_level` validation:
+
+```text
+entry | mid      accepted values
+other values     400 SETTINGS_INVALID
+```
+
+If the UI exposes `mid` before the Mid content set is ready, the action must fail
+with a clear disabled/hold state or a structured backend error. Final M8
+acceptance requires Mid to be selectable and usable, so the preferred completed
+state is not fallback-to-Entry but verified Core 1000 readiness.
+
+Practice generation contract:
+
+```text
+Changing learner_level affects future generated normal practice groups.
+An already active normal group remains resumable until completed.
+Entry normal groups select only Entry/Core 300 runtime content.
+Mid normal groups select only Mid/Core 1000 runtime content.
+Current-group review reuses the source group's items regardless of later level changes.
+Recent-mistake review may include previously missed words from the user's history,
+but its UI must label it as review rather than as a fresh Entry/Mid group.
+Focused practice uses the active learner_level pool unless the focus action is
+explicitly derived from a source review group.
+```
+
+Frontend workflow contract:
+
+```text
+Settings shows a Practice level control with Entry and Mid options.
+Today Practice displays the active level for normal practice groups.
+Normal practice wording must not imply Mid is only a larger daily quota; it is a
+different content pool.
+Review/focus groups remain visually distinct from normal Entry/Mid practice.
+If Mid is unavailable in a developer or partial-import state, the UI explains
+the hold instead of silently starting Entry practice.
+```
+
+Walkthrough gate:
+
+```text
+Entry smoke:
+  default settings show learner_level=entry
+  a normal group starts from Core 300 content
+  completing a group keeps M7 next/review/focus actions coherent
+
+Mid smoke:
+  switching to Mid is visible in Settings and Today Practice
+  the next normal group uses Core 1000 content
+  sample Mid words include visibly more two-syllable or multi-syllable items
+  switching levels does not corrupt Entry progress or current-group review
+
+Closure:
+  M8 cannot close without a final-user note or trial path describing Entry,
+  Mid, how to switch, what changed, verification evidence, exclusions, and
+  whether human trial is required.
+```
 
 ## 服务端领域规则
 

--- a/docs/06-epic-roadmap.md
+++ b/docs/06-epic-roadmap.md
@@ -280,6 +280,20 @@ Mid level uses a newly generated and reviewed Core 1000 candidate set
 Core 1000 improves two-syllable and multi-syllable coverage compared with Core 300
 level selection affects future practice generation and is visible to the learner
 validation reports separate Entry and Mid coverage/readiness
+M8 closure includes final-user usage/trial notes for Entry vs Mid behavior
+and browser walkthrough evidence for level switching and practice generation
+```
+
+Dependency plan:
+
+```text
+#122 defines the Entry/Mid API, domain, UX, and walkthrough contract.
+#123 proves Core 1000 source feasibility and syllable metadata strategy.
+#124 generates Core 1000 candidates plus rebalance reports.
+#125 curates the Mid runtime content set and requires human sample acceptance.
+#126 adds level-aware validation/import reports.
+#127 wires settings, scheduler, and frontend level selection.
+#128 performs final M8 QA, user-facing usage note, and Epic readiness review.
 ```
 
 ## M9：VPS Deployment and Backup


### PR DESCRIPTION
## Summary
- define the M8 Entry/Mid learner-level contract in the data/API contract doc
- clarify that `settings.learner_level` is separate from existing `words.level` content metadata
- add M8 dependency plan and final-user/walkthrough closure requirements to the roadmap

## Execution Contract
- Issue: #122
- Owner role: Architect
- Risk class: low-risk documentation/contract change
- User-visible behavior/UX impact: defines future Entry/Mid level behavior; no runtime behavior changes in this PR
- Human verification needed: no manual trial for this contract PR; later M8 content curation and final closure require human-facing notes/trial path
- Auto-main-merge allowed: no; target is the M8 Epic integration branch only
- Merge rule: may be accepted into `epic/m8-level-content-core1000` after validation because this is a low-risk child contract PR

## Verification
- `git diff --check`
- `tools/agents/agent-audit`

## Residual risks
- This PR locks the contract but does not implement runtime settings, scheduler filtering, Core 1000 generation, or frontend level selection.
- Mid content sample acceptance remains a future human/product gate under #125/#128.

Closes #122 when accepted into the M8 Epic branch.
