### PR TITLE
[#108][P1] Wire learner level selection into practice flow

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -63,6 +63,7 @@ class Settings:
     show_accent_compare: bool = False
     practice_mode: str = "ipa_first"
     review_strength: str = "normal"
+    learner_level: str = "entry"
     focus_phonemes: List[str] = field(default_factory=list)
     updated_at: str = ""
 
@@ -82,6 +83,7 @@ class DailySession:
     completed_at: Optional[str] = None
     group_index: int = 1
     group_type: str = "normal"
+    learner_level: str = "entry"
     source_session_item_ids: List[str] = field(default_factory=list)
     source_scope: Optional[str] = None
     source_group_id: Optional[str] = None

--- a/backend/app/routes/settings.py
+++ b/backend/app/routes/settings.py
@@ -15,6 +15,7 @@ router = APIRouter()
 _VALID_ACCENTS = {"US", "UK"}
 _VALID_MODES = {"ipa_first", "reveal_first"}
 _VALID_STRENGTHS = {"normal", "extra_review", "quick"}
+_VALID_LEARNER_LEVELS = {"entry", "mid"}
 
 
 @router.get("/settings")
@@ -31,6 +32,7 @@ def settings_get():
                 "show_accent_compare": False,
                 "practice_mode": "ipa_first",
                 "review_strength": "normal",
+                "learner_level": "entry",
                 "focus_phonemes": [],
             }
         return {
@@ -40,6 +42,7 @@ def settings_get():
             "show_accent_compare": s.show_accent_compare,
             "practice_mode": s.practice_mode,
             "review_strength": s.review_strength,
+            "learner_level": s.learner_level,
             "focus_phonemes": s.focus_phonemes,
         }
 
@@ -102,6 +105,13 @@ async def settings_put(request: Request):
             else:
                 existing.review_strength = v
 
+        if "learner_level" in body:
+            v = body["learner_level"]
+            if v not in _VALID_LEARNER_LEVELS:
+                errors.append(f"learner_level must be one of {_VALID_LEARNER_LEVELS}")
+            else:
+                existing.learner_level = v
+
         if "focus_phonemes" in body:
             v = body["focus_phonemes"]
             if not isinstance(v, list) or any(
@@ -127,5 +137,6 @@ async def settings_put(request: Request):
             "show_accent_compare": existing.show_accent_compare,
             "practice_mode": existing.practice_mode,
             "review_strength": existing.review_strength,
+            "learner_level": existing.learner_level,
             "focus_phonemes": existing.focus_phonemes,
         }

--- a/backend/app/services/db_schema.py
+++ b/backend/app/services/db_schema.py
@@ -56,6 +56,7 @@ TABLES_DDL: List[str] = [
         show_accent_compare  INTEGER NOT NULL,   -- boolean 0/1
         practice_mode        TEXT    NOT NULL,
         review_strength      TEXT    NOT NULL,
+        learner_level        TEXT    NOT NULL DEFAULT 'entry',
         focus_phonemes       TEXT    NOT NULL DEFAULT '[]', -- JSON array
         updated_at           TEXT    NOT NULL
     )
@@ -74,6 +75,7 @@ TABLES_DDL: List[str] = [
         completed_at    TEXT,
         group_index     INTEGER NOT NULL DEFAULT 1,
         group_type      TEXT    NOT NULL DEFAULT 'normal',
+        learner_level   TEXT    NOT NULL DEFAULT 'entry',
         source_session_item_ids TEXT NOT NULL DEFAULT '[]',
         source_scope     TEXT,
         source_group_id  TEXT,
@@ -162,6 +164,10 @@ def ensure_settings_schema(conn: sqlite3.Connection) -> None:
         conn.execute(
             "ALTER TABLE settings ADD COLUMN focus_phonemes TEXT NOT NULL DEFAULT '[]'"
         )
+    if "learner_level" not in columns:
+        conn.execute(
+            "ALTER TABLE settings ADD COLUMN learner_level TEXT NOT NULL DEFAULT 'entry'"
+        )
 
 
 def ensure_daily_sessions_schema(conn: sqlite3.Connection) -> None:
@@ -183,6 +189,10 @@ def ensure_daily_sessions_schema(conn: sqlite3.Connection) -> None:
     if "group_type" not in columns:
         conn.execute(
             "ALTER TABLE daily_sessions ADD COLUMN group_type TEXT NOT NULL DEFAULT 'normal'"
+        )
+    if "learner_level" not in columns:
+        conn.execute(
+            "ALTER TABLE daily_sessions ADD COLUMN learner_level TEXT NOT NULL DEFAULT 'entry'"
         )
     if "source_session_item_ids" not in columns:
         conn.execute(

--- a/backend/app/services/db_store.py
+++ b/backend/app/services/db_store.py
@@ -89,6 +89,7 @@ def _settings_from_row(row: sqlite3.Row) -> Settings:
         show_accent_compare=bool(row["show_accent_compare"]),
         practice_mode=row["practice_mode"],
         review_strength=row["review_strength"],
+        learner_level=row["learner_level"],
         focus_phonemes=_parse_list(row["focus_phonemes"]) or [],
         updated_at=row["updated_at"],
     )
@@ -209,11 +210,11 @@ def upsert_settings(conn: sqlite3.Connection, settings: Settings) -> None:
         INSERT OR REPLACE INTO settings (
             user_id, primary_accent, daily_word_count,
             show_translation, show_accent_compare,
-            practice_mode, review_strength, focus_phonemes, updated_at
+            practice_mode, review_strength, learner_level, focus_phonemes, updated_at
         ) VALUES (
             :user_id, :primary_accent, :daily_word_count,
             :show_translation, :show_accent_compare,
-            :practice_mode, :review_strength, :focus_phonemes, :updated_at
+            :practice_mode, :review_strength, :learner_level, :focus_phonemes, :updated_at
         )
         """,
         {
@@ -224,6 +225,7 @@ def upsert_settings(conn: sqlite3.Connection, settings: Settings) -> None:
             "show_accent_compare": int(settings.show_accent_compare),
             "practice_mode": settings.practice_mode,
             "review_strength": settings.review_strength,
+            "learner_level": settings.learner_level,
             "focus_phonemes": _to_json(settings.focus_phonemes),
             "updated_at": settings.updated_at,
         },
@@ -256,6 +258,7 @@ def _session_from_row(row: sqlite3.Row) -> DailySession:
         completed_at=row["completed_at"],
         group_index=row["group_index"],
         group_type=row["group_type"],
+        learner_level=row["learner_level"],
         source_session_item_ids=_parse_list(row["source_session_item_ids"]) or [],
         source_scope=row["source_scope"],
         source_group_id=row["source_group_id"],
@@ -282,11 +285,11 @@ def create_session(conn: sqlite3.Connection, session: DailySession) -> str:
         """
         INSERT INTO daily_sessions (
             id, user_id, session_date, primary_accent, status, created_at, completed_at,
-            group_index, group_type, source_session_item_ids,
+            group_index, group_type, learner_level, source_session_item_ids,
             source_scope, source_group_id, focus_phonemes
         ) VALUES (
             :id, :user_id, :session_date, :primary_accent, :status, :created_at,
-            :completed_at, :group_index, :group_type, :source_session_item_ids,
+            :completed_at, :group_index, :group_type, :learner_level, :source_session_item_ids,
             :source_scope, :source_group_id, :focus_phonemes
         )
         """,
@@ -300,6 +303,7 @@ def create_session(conn: sqlite3.Connection, session: DailySession) -> str:
             "completed_at": session.completed_at,
             "group_index": session.group_index,
             "group_type": session.group_type,
+            "learner_level": session.learner_level,
             "source_session_item_ids": _to_json(session.source_session_item_ids),
             "source_scope": session.source_scope,
             "source_group_id": session.source_group_id,
@@ -318,6 +322,7 @@ def get_active_session_for_date(
     source_scope: Optional[str] = None,
     source_group_id: Optional[str] = None,
     focus_phonemes: Optional[List[str]] = None,
+    learner_level: Optional[str] = None,
 ) -> Optional[DailySession]:
     """Return the active same-day group for the given type, if one exists."""
     ensure_daily_sessions_schema(conn)
@@ -338,6 +343,9 @@ def get_active_session_for_date(
     if focus_phonemes is not None:
         filters.append("focus_phonemes = ?")
         params.append(_to_json(focus_phonemes))
+    if learner_level is not None:
+        filters.append("learner_level = ?")
+        params.append(learner_level)
     row = conn.execute(
         f"""
         SELECT * FROM daily_sessions

--- a/backend/app/services/scheduler.py
+++ b/backend/app/services/scheduler.py
@@ -24,6 +24,11 @@ _REVIEW_STRENGTH_MULTIPLIERS = {
     "high": 1.7,
 }
 
+_LEARNER_LEVEL_TO_WORD_LEVEL = {
+    "entry": "beginner",
+    "mid": "intermediate",
+}
+
 
 @dataclass(frozen=True)
 class _Candidate:
@@ -41,6 +46,7 @@ def select_daily_words(
     *,
     user_id: str = "default",
     review_strength: str = "normal",
+    learner_level: str = "entry",
     focus_phonemes: Optional[Sequence[str]] = None,
 ) -> List[Word]:
     """Select ``daily_word_count`` usable words for today's practice.
@@ -55,6 +61,7 @@ def select_daily_words(
               so same-day calls return the same order.
         user_id: User whose phoneme stats and recent sessions should be read.
         review_strength: Weighting mode for weak-phoneme review.
+        learner_level: Learner-facing level whose runtime content pool is selected.
         focus_phonemes: Optional phoneme ids/symbols to boost for this session.
 
     Returns:
@@ -66,13 +73,16 @@ def select_daily_words(
     accent = accent.upper()
     ipa_field = "ipa_us" if accent.upper() == "US" else "ipa_uk"
     tag_field = "phoneme_tags_us" if accent.upper() == "US" else "phoneme_tags_uk"
+    word_level = _LEARNER_LEVEL_TO_WORD_LEVEL.get(learner_level, "beginner")
     rows = conn.execute(
         f"""
         SELECT id, {tag_field} AS phoneme_tags
         FROM words
         WHERE {ipa_field} IS NOT NULL AND {ipa_field} != ''
           AND content_status != 'disabled'
-        """
+          AND level = ?
+        """,
+        (word_level,),
     ).fetchall()
 
     recent_word_ids = _recent_word_ids(conn, user_id=user_id, accent=accent)

--- a/backend/app/services/sessions.py
+++ b/backend/app/services/sessions.py
@@ -27,6 +27,11 @@ from app.services.db_store import (
 from app.services.questions import generate_question
 from app.services.scheduler import select_daily_words
 
+_LEARNER_LEVEL_LABELS = {
+    "entry": "Entry",
+    "mid": "Mid",
+}
+
 
 def _today_date_str() -> str:
     return date.today().isoformat()
@@ -80,8 +85,8 @@ def build_today_response(
             accent=accent,
             origin="normal_resume",
             source_scope="normal_current",
-            focus_phonemes=settings.focus_phonemes,
-            action_label=f"Resume Group {existing.group_index}",
+            focus_phonemes=existing.focus_phonemes or settings.focus_phonemes,
+            action_label=f"Resume {learner_level_label(existing.learner_level)} Group {existing.group_index}",
         )
 
     # ---- create new session -------------------------------------------------
@@ -94,13 +99,17 @@ def build_today_response(
         seed=seed,
         user_id=user_id,
         review_strength=settings.review_strength,
+        learner_level=settings.learner_level,
         focus_phonemes=settings.focus_phonemes,
     )
 
     if not words:
         return {
             "error": "CONTENT_NOT_READY",
-            "detail": "No usable words found. Run import_words.py first.",
+            "detail": (
+                f"No usable {learner_level_label(settings.learner_level)} words found. "
+                "Run the level content import first."
+            ),
         }
 
     session, items = _create_group_from_words(
@@ -111,6 +120,8 @@ def build_today_response(
         accent=accent,
         group_index=group_index,
         group_type="normal",
+        learner_level=settings.learner_level,
+        focus_phonemes=settings.focus_phonemes,
     )
 
     return _build_response(
@@ -122,7 +133,7 @@ def build_today_response(
         origin="normal_start",
         source_scope="normal_current",
         focus_phonemes=settings.focus_phonemes,
-        action_label=f"Start Group {session.group_index}",
+        action_label=f"Start {learner_level_label(session.learner_level)} Group {session.group_index}",
     )
 
 
@@ -140,7 +151,10 @@ def build_next_normal_group_response(
         response["origin"] = "normal_next"
     response["source_scope"] = "normal_next"
     if response.get("origin") == "normal_next":
-        response["action_label"] = f"Start Group {response['group_index']}"
+        response["action_label"] = (
+            f"Start {learner_level_label(response.get('learner_level'))} "
+            f"Group {response['group_index']}"
+        )
     return response
 
 
@@ -226,6 +240,7 @@ def build_recent_mistake_review_response(
         accent=accent,
         group_index=group_index,
         group_type="mistake_review",
+        learner_level=settings.learner_level,
         source_session_item_ids=source_item_ids,
         source_scope="recent_global",
     )
@@ -340,6 +355,7 @@ def build_current_group_review_response(
         accent=accent,
         group_index=group_index,
         group_type="mistake_review",
+        learner_level=source_session.learner_level,
         source_session_item_ids=source_item_ids,
         source_scope="current_group",
         source_group_id=source_group_id,
@@ -386,6 +402,7 @@ def build_focused_group_response(
         "weak_focus",
         source_scope="focus_selection",
         focus_phonemes=focus_phonemes,
+        learner_level=settings.learner_level,
     )
     if existing is not None:
         items = get_session_items(conn, existing.id)
@@ -398,7 +415,7 @@ def build_focused_group_response(
             origin="focus_resume",
             source_scope="focus_selection",
             focus_phonemes=focus_phonemes,
-            action_label=f"Resume Focus Group {existing.group_index}",
+            action_label=f"Resume {learner_level_label(existing.learner_level)} Focus Group {existing.group_index}",
         )
 
     group_index = get_next_session_group_index(conn, user_id, session_date, accent)
@@ -410,12 +427,16 @@ def build_focused_group_response(
         seed=seed,
         user_id=user_id,
         review_strength=settings.review_strength,
+        learner_level=settings.learner_level,
         focus_phonemes=focus_phonemes,
     )
     if not words:
         return {
             "error": "CONTENT_NOT_READY",
-            "detail": "No usable words found. Run import_words.py first.",
+            "detail": (
+                f"No usable {learner_level_label(settings.learner_level)} words found. "
+                "Run the level content import first."
+            ),
         }
 
     session, items = _create_group_from_words(
@@ -426,6 +447,7 @@ def build_focused_group_response(
         accent=accent,
         group_index=group_index,
         group_type="weak_focus",
+        learner_level=settings.learner_level,
         source_scope="focus_selection",
         focus_phonemes=focus_phonemes,
     )
@@ -438,7 +460,7 @@ def build_focused_group_response(
         origin="focus_start",
         source_scope="focus_selection",
         focus_phonemes=focus_phonemes,
-        action_label=f"Start Focus Group {session.group_index}",
+        action_label=f"Start {learner_level_label(session.learner_level)} Focus Group {session.group_index}",
     )
 
 
@@ -477,6 +499,7 @@ def _create_group_from_words(
     accent: str,
     group_index: int,
     group_type: str,
+    learner_level: str,
     source_session_item_ids: Optional[List[str]] = None,
     source_scope: Optional[str] = None,
     source_group_id: Optional[str] = None,
@@ -493,6 +516,7 @@ def _create_group_from_words(
         completed_at=None,
         group_index=group_index,
         group_type=group_type,
+        learner_level=learner_level,
         source_session_item_ids=source_session_item_ids or [],
         source_scope=source_scope,
         source_group_id=source_group_id,
@@ -530,6 +554,10 @@ def _build_distractor_pool(conn, accent: str) -> List[str]:
         """
     ).fetchall()
     return [r[0] for r in rows if r[0]]
+
+
+def learner_level_label(learner_level: Optional[str]) -> str:
+    return _LEARNER_LEVEL_LABELS.get(learner_level or "entry", "Entry")
 
 
 def _build_response(
@@ -578,6 +606,8 @@ def _build_response(
         "group_id": session.id,
         "group_index": session.group_index,
         "group_type": session.group_type,
+        "learner_level": session.learner_level,
+        "learner_level_label": learner_level_label(session.learner_level),
         "date": session.session_date,
         "primary_accent": session.primary_accent,
         "daily_word_count": daily_word_count,

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -42,17 +42,19 @@ def _insert_word(
     *,
     status: str = "core_selected",
     ipa: Optional[str] = None,
+    level: str = "beginner",
 ) -> None:
     conn.execute(
         """
         INSERT INTO words (
             id, word, level, ipa_us, ipa_uk, phoneme_tags_us, phoneme_tags_uk,
             content_status
-        ) VALUES (?, ?, 'beginner', ?, ?, ?, ?, ?)
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
             word_id,
             word_id,
+            level,
             ipa or f"/{word_id}/",
             ipa or f"/{word_id}/",
             _json(tags),
@@ -138,6 +140,19 @@ def test_disabled_words_are_never_selected(conn):
     selected = select_daily_words(conn, daily_word_count=2, seed=7)
 
     assert _ids(selected) == ["active"]
+
+
+def test_learner_level_filters_entry_and_mid_pools(conn):
+    _insert_word(conn, "entry_one", ["/e/"], level="beginner")
+    _insert_word(conn, "entry_two", ["/e2/"], level="beginner")
+    _insert_word(conn, "mid_one", ["/m/"], level="intermediate")
+    _insert_word(conn, "mid_two", ["/m2/"], level="intermediate")
+
+    entry = select_daily_words(conn, daily_word_count=10, seed=4, learner_level="entry")
+    mid = select_daily_words(conn, daily_word_count=10, seed=4, learner_level="mid")
+
+    assert set(_ids(entry)) == {"entry_one", "entry_two"}
+    assert set(_ids(mid)) == {"mid_one", "mid_two"}
 
 
 def test_recent_words_are_suppressed_when_alternatives_exist(conn):

--- a/backend/tests/test_settings_api.py
+++ b/backend/tests/test_settings_api.py
@@ -51,18 +51,21 @@ class TestSettingsApi:
         assert data["primary_accent"] == "US"
         assert data["daily_word_count"] == 10
         assert data["show_translation"] is True
+        assert data["learner_level"] == "entry"
         assert data["focus_phonemes"] == []
 
     def test_put_updates_and_persists(self, client, seeded_db):
         resp = client.put("/api/settings", json={
             "daily_word_count": 5,
             "show_translation": False,
+            "learner_level": "mid",
             "focus_phonemes": ["/ʃ/", " /ɪ/ "],
         })
         assert resp.status_code == 200
         data = resp.json()
         assert data["daily_word_count"] == 5
         assert data["show_translation"] is False
+        assert data["learner_level"] == "mid"
         assert data["focus_phonemes"] == ["/ʃ/", "/ɪ/"]
         # Other fields unchanged
         assert data["primary_accent"] == "US"
@@ -74,6 +77,7 @@ class TestSettingsApi:
         assert s is not None
         assert s.daily_word_count == 5
         assert s.show_translation is False
+        assert s.learner_level == "mid"
         assert s.focus_phonemes == ["/ʃ/", "/ɪ/"]
 
     def test_put_invalid_daily_word_count(self, client):
@@ -89,6 +93,11 @@ class TestSettingsApi:
 
     def test_put_invalid_practice_mode(self, client):
         resp = client.put("/api/settings", json={"practice_mode": "random"})
+        assert resp.status_code == 400
+        assert resp.json()["detail"]["error"] == "SETTINGS_INVALID"
+
+    def test_put_invalid_learner_level(self, client):
+        resp = client.put("/api/settings", json={"learner_level": "advanced"})
         assert resp.status_code == 400
         assert resp.json()["detail"]["error"] == "SETTINGS_INVALID"
 
@@ -127,6 +136,7 @@ class TestSettingsApi:
             resp = c.get("/api/settings")
             assert resp.status_code == 200
             assert resp.json()["daily_word_count"] == 10
+            assert resp.json()["learner_level"] == "entry"
             assert resp.json()["focus_phonemes"] == []
         finally:
             db_mod.DEFAULT_DB_PATH = orig

--- a/backend/tests/test_today_persistence.py
+++ b/backend/tests/test_today_persistence.py
@@ -37,6 +37,7 @@ FIXTURES = Path(__file__).resolve().parent / "fixtures"
 CONTENT_SAMPLE = FIXTURES / "content_sample.json"
 PHONEMES_PATH = Path(__file__).resolve().parent.parent.parent / "content" / "phonemes.json"
 CORE_300_PATH = Path(__file__).resolve().parent.parent.parent / "content" / "core_300_words.json"
+CORE_1000_PATH = Path(__file__).resolve().parent.parent.parent / "content" / "core_1000_words.json"
 
 
 # ---------------------------------------------------------------------------
@@ -91,6 +92,36 @@ def core_300_client_fixture(seeded_db_core_300: str) -> TestClient:
     return TestClient(app)
 
 
+@pytest.fixture(name="seeded_db_entry_mid")
+def seeded_db_entry_mid_fixture(tmp_path: Path) -> str:
+    """Create a database with both Entry/Core300 and Mid/Core1000 content."""
+    db_path = str(tmp_path / "entry_mid.sqlite")
+    import_words(
+        source_path=CORE_300_PATH,
+        phonemes_path=PHONEMES_PATH,
+        db_path=db_path,
+        content_level="entry",
+    )
+    import_words(
+        source_path=CORE_1000_PATH,
+        phonemes_path=PHONEMES_PATH,
+        db_path=db_path,
+        content_level="mid",
+    )
+
+    import app.db as db_mod
+
+    orig = db_mod.DEFAULT_DB_PATH
+    db_mod.DEFAULT_DB_PATH = db_path
+    yield db_path
+    db_mod.DEFAULT_DB_PATH = orig
+
+
+@pytest.fixture(name="entry_mid_client")
+def entry_mid_client_fixture(seeded_db_entry_mid: str) -> TestClient:
+    return TestClient(app)
+
+
 # ---------------------------------------------------------------------------
 # Session persistence tests
 # ---------------------------------------------------------------------------
@@ -108,6 +139,8 @@ class TestTodayPersistence:
         assert data["group_id"] == data["session_id"]
         assert data["group_index"] == 1
         assert data["group_type"] == "normal"
+        assert data["learner_level"] == "entry"
+        assert data["learner_level_label"] == "Entry"
         assert data["word_count"] == len(data["items"])
         assert data["source_session_item_ids"] == []
         assert data["date"] == date.today().isoformat()
@@ -268,9 +301,10 @@ class TestTodayPersistence:
         assert data["session_id"] != first["session_id"]
         assert data["group_index"] == 2
         assert data["group_type"] == "normal"
+        assert data["learner_level"] == "entry"
         assert data["origin"] == "normal_next"
         assert data["source_scope"] == "normal_next"
-        assert data["action_label"] == "Start Group 2"
+        assert data["action_label"] == "Start Entry Group 2"
 
     def test_recent_mistake_review_empty_queue_is_stable(self, client):
         resp = client.post("/api/review/recent-mistakes")
@@ -682,6 +716,87 @@ class TestCore300TodayReadiness:
         assert focus_id[0] in {item["word_id"] for item in data["items"]}
 
 
+class TestLevelAwareToday:
+    """Regression coverage for M8 learner-level scheduling semantics."""
+
+    def test_entry_is_default_and_uses_core300_pool(self, entry_mid_client):
+        resp = entry_mid_client.get("/api/today")
+        assert resp.status_code == 200
+        data = resp.json()
+
+        assert data["learner_level"] == "entry"
+        assert data["learner_level_label"] == "Entry"
+        assert data["group_type"] == "normal"
+        assert data["items"]
+        assert all(not item["word_id"].startswith("mid_") for item in data["items"])
+
+    def test_mid_setting_uses_core1000_pool_without_entry_mix(self, entry_mid_client):
+        settings_resp = entry_mid_client.put("/api/settings", json={
+            "learner_level": "mid",
+            "daily_word_count": 6,
+        })
+        assert settings_resp.status_code == 200
+
+        resp = entry_mid_client.get("/api/today")
+        assert resp.status_code == 200
+        data = resp.json()
+
+        assert data["learner_level"] == "mid"
+        assert data["learner_level_label"] == "Mid"
+        assert data["items"]
+        assert all(item["word_id"].startswith("mid_") for item in data["items"])
+
+    def test_level_change_keeps_active_group_and_affects_next_group(
+        self, entry_mid_client, seeded_db_entry_mid
+    ):
+        entry_mid_client.put("/api/settings", json={
+            "learner_level": "entry",
+            "daily_word_count": 2,
+        })
+        first = entry_mid_client.get("/api/today").json()
+        assert first["learner_level"] == "entry"
+        assert all(not item["word_id"].startswith("mid_") for item in first["items"])
+
+        entry_mid_client.put("/api/settings", json={"learner_level": "mid"})
+        resumed = entry_mid_client.get("/api/today").json()
+        assert resumed["session_id"] == first["session_id"]
+        assert resumed["learner_level"] == "entry"
+
+        conn = get_connection(seeded_db_entry_mid)
+        conn.execute(
+            """
+            UPDATE daily_sessions
+            SET status = 'completed', completed_at = '2026-06-17T00:00:00Z'
+            WHERE id = ?
+            """,
+            (first["session_id"],),
+        )
+        conn.commit()
+        conn.close()
+
+        next_group = entry_mid_client.post("/api/practice/next-normal").json()
+        assert next_group["group_index"] == first["group_index"] + 1
+        assert next_group["learner_level"] == "mid"
+        assert next_group["source_scope"] == "normal_next"
+        assert all(item["word_id"].startswith("mid_") for item in next_group["items"])
+
+    def test_focused_practice_uses_active_learner_level_pool(self, entry_mid_client):
+        entry_mid_client.put("/api/settings", json={
+            "learner_level": "mid",
+            "daily_word_count": 5,
+        })
+
+        focused = entry_mid_client.post("/api/practice/focus", json={
+            "focus_phonemes": ["/ʃ/"],
+        }).json()
+
+        assert focused["group_type"] == "weak_focus"
+        assert focused["learner_level"] == "mid"
+        assert focused["focus_phonemes"] == ["/ʃ/"]
+        assert focused["items"]
+        assert all(item["word_id"].startswith("mid_") for item in focused["items"])
+
+
 # ---------------------------------------------------------------------------
 # Session store tests (unit-level)
 # ---------------------------------------------------------------------------
@@ -730,6 +845,7 @@ class TestSessionStore:
         assert got is not None
         assert got.id == "2026-06-06-default"
         assert got.status == "in_progress"
+        assert got.learner_level == "entry"
 
     def test_get_missing_session(self):
         assert (

--- a/docs/05-data-api-contracts.md
+++ b/docs/05-data-api-contracts.md
@@ -84,6 +84,8 @@ settings(
   show_accent_compare INTEGER NOT NULL,
   practice_mode TEXT NOT NULL,
   review_strength TEXT NOT NULL,
+  learner_level TEXT NOT NULL DEFAULT 'entry',
+  focus_phonemes TEXT NOT NULL DEFAULT '[]',
   updated_at TEXT NOT NULL
 )
 
@@ -97,6 +99,7 @@ daily_sessions(
   completed_at TEXT,
   group_index INTEGER NOT NULL DEFAULT 1,
   group_type TEXT NOT NULL DEFAULT 'normal',
+  learner_level TEXT NOT NULL DEFAULT 'entry',
   source_session_item_ids TEXT NOT NULL DEFAULT '[]'
 )
 
@@ -255,6 +258,8 @@ GET /api/today
 - `group_index` 是同一 `user_id`/`date`/`primary_accent` 下的递增序号；
 - `group_type` 当前实现 `normal`、`mistake_review` 和 `weak_focus`，均复用
   同一 session_items/attempts/phoneme_stats 路径；
+- `learner_level` 和 `learner_level_label` 记录创建该 group 时使用的
+  learner-facing level，active group 恢复时不随 settings 切换而改写；
 - `origin` 说明 action reason，例如 `normal_start`、`normal_resume`、
   `normal_next`、`current_group_review_start`、`recent_review_start`、
   `focus_start`、`focus_clear`；
@@ -280,6 +285,8 @@ active normal group，则创建下一个 normal group。不同 group 共用
   "group_id": "2026-06-06-default-g001-normal",
   "group_index": 1,
   "group_type": "normal",
+  "learner_level": "entry",
+  "learner_level_label": "Entry",
   "date": "2026-06-06",
   "primary_accent": "US",
   "origin": "normal_start",
@@ -568,8 +575,8 @@ Mid normal groups select only Mid/Core 1000 runtime content.
 Current-group review reuses the source group's items regardless of later level changes.
 Recent-mistake review may include previously missed words from the user's history,
 but its UI must label it as review rather than as a fresh Entry/Mid group.
-Focused practice uses the active learner_level pool unless the focus action is
-explicitly derived from a source review group.
+Focused practice uses the active learner_level pool; the same focus selection
+resumes only an active focused group with the same learner_level.
 ```
 
 Frontend workflow contract:
@@ -602,6 +609,12 @@ Closure:
   M8 cannot close without a final-user note or trial path describing Entry,
   Mid, how to switch, what changed, verification evidence, exclusions, and
   whether human trial is required.
+
+Route-mocked browser command:
+
+```text
+cd frontend && pnpm test:e2e:m8
+```
 ```
 
 ## 服务端领域规则

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,8 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test:e2e:m7": "playwright test -c playwright.m7.config.ts"
+    "test:e2e:m7": "playwright test -c playwright.m7.config.ts tests/e2e/m7-walkthrough.spec.ts",
+    "test:e2e:m8": "playwright test -c playwright.m7.config.ts tests/e2e/m8-level-selection.spec.ts"
   },
   "dependencies": {
     "react": "^19.2.6",

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -72,6 +72,8 @@ export interface TodayResponse {
   group_id?: string;
   group_index?: number;
   group_type?: string;
+  learner_level?: "entry" | "mid";
+  learner_level_label?: string;
   origin?: string;
   source_scope?: string;
   source_group_id?: string;
@@ -236,6 +238,7 @@ export interface SettingsData {
   show_accent_compare: boolean;
   practice_mode: string;
   review_strength: string;
+  learner_level: "entry" | "mid";
   focus_phonemes: string[];
 }
 

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -24,6 +24,23 @@ interface Props {
 
 const COMMON_FOCUS = ["/ʃ/", "/θ/", "/æ/", "/ɪ/", "/tʃ/", "/ʌ/"];
 
+const LEVEL_OPTIONS: Array<{
+  value: SettingsData["learner_level"];
+  title: string;
+  description: string;
+}> = [
+  {
+    value: "entry",
+    title: "Entry",
+    description: "Starter practice with the current core word set.",
+  },
+  {
+    value: "mid",
+    title: "Mid",
+    description: "Broader word practice for longer words; translations and audio are still under review.",
+  },
+];
+
 function canonicalFocus(phonemes: string[]): string[] {
   return Array.from(new Set(phonemes.map((item) => item.trim()).filter(Boolean))).sort();
 }
@@ -141,6 +158,27 @@ export default function SettingsPage({
             <option value="extra_review">Extra review</option>
           </select>
         </label>
+
+        <section className="settings-panel">
+          <h2>Practice level</h2>
+          <p className="section-copy">
+            Choose the word pool for the next new normal group. Your current group
+            stays unchanged until you finish it.
+          </p>
+          <div className="level-choice-list">
+            {LEVEL_OPTIONS.map((option) => (
+              <button
+                className={`level-choice ${settings.learner_level === option.value ? "selected" : ""}`}
+                key={option.value}
+                onClick={() => void update({ learner_level: option.value })}
+                type="button"
+              >
+                <strong>{option.title}</strong>
+                <span>{option.description}</span>
+              </button>
+            ))}
+          </div>
+        </section>
 
         <section className="settings-panel">
           <h2>Focus practice</h2>

--- a/frontend/src/pages/TodayPractice.tsx
+++ b/frontend/src/pages/TodayPractice.tsx
@@ -50,10 +50,14 @@ function groupLabel(session: TodayResponse): string {
   return "Practice group";
 }
 
+function learnerLevelLabel(session: TodayResponse): string {
+  return session.learner_level_label ?? (session.learner_level === "mid" ? "Mid" : "Entry");
+}
+
 function groupReason(session: TodayResponse): string {
   if (session.group_type === "weak_focus") {
     const focus = session.focus_phonemes?.join(" ") || "selected sounds";
-    return `Focused practice for ${focus}.`;
+    return `${learnerLevelLabel(session)} focused practice for ${focus}.`;
   }
   if (session.source_scope === "current_group") {
     return "Reviewing misses from the group you just finished.";
@@ -62,12 +66,12 @@ function groupReason(session: TodayResponse): string {
     return "Reviewing recent mistakes from earlier practice.";
   }
   if (session.source_scope === "normal_next") {
-    return "A new normal practice group.";
+    return `A new ${learnerLevelLabel(session)} practice group.`;
   }
   if (session.origin === "normal_resume") {
-    return "Resuming your current normal group.";
+    return `Resuming your current ${learnerLevelLabel(session)} group.`;
   }
-  return "Normal practice group.";
+  return `${learnerLevelLabel(session)} practice group.`;
 }
 
 function buildFocusHint(targetPhonemes: string[]): string {
@@ -82,6 +86,11 @@ function currentReviewActionLabel(session: TodayResponse): string {
     return "Review misses from this review";
   }
   return "Review misses from this group";
+}
+
+function nextNormalActionLabel(session: TodayResponse): string {
+  const level = learnerLevelLabel(session);
+  return `Start next ${level} group`;
 }
 
 export default function TodayPractice({
@@ -369,7 +378,7 @@ export default function TodayPractice({
               onClick={handleNextNormal}
               disabled={actionLoading !== null}
             >
-              {actionLoading === "continue" ? "Loading…" : "Start next 10-word group"}
+              {actionLoading === "continue" ? "Loading…" : nextNormalActionLabel(summarySession)}
             </button>
             {hasCurrentGroupMisses && (
               <button
@@ -406,7 +415,10 @@ export default function TodayPractice({
     <main className="practice-container">
       <div className="practice-header">
         <span className="progress-label">{groupLabel(session)}: {progress}</span>
-        <span className="accent-label">{session.primary_accent}</span>
+        <span className="practice-context">
+          <span className="level-label">{learnerLevelLabel(session)}</span>
+          <span className="accent-label">{session.primary_accent}</span>
+        </span>
       </div>
       <div className="mode-panel">
         <strong>{groupLabel(session)}</strong>

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -53,6 +53,23 @@ button {
   font-size: 0.75rem;
 }
 
+.practice-context {
+  align-items: center;
+  display: flex;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.level-label {
+  background: #eef5fc;
+  border: 1px solid #d6e4ff;
+  border-radius: 4px;
+  color: #174ea6;
+  font-size: 0.75rem;
+  font-weight: 700;
+  padding: 1px 7px;
+}
+
 .practice-error {
   text-align: center;
   padding: 32px 0;
@@ -639,6 +656,33 @@ button {
 .setting-row input[type="checkbox"] {
   width: 20px;
   height: 20px;
+}
+
+.level-choice-list {
+  display: grid;
+  gap: 8px;
+  width: 100%;
+}
+
+.level-choice {
+  background: #fff;
+  border: 1px solid #d6e4ff;
+  border-radius: 6px;
+  color: #1a1a1a;
+  display: grid;
+  gap: 3px;
+  padding: 10px;
+  text-align: left;
+}
+
+.level-choice.selected {
+  background: #eef5fc;
+  border-color: #174ea6;
+}
+
+.level-choice span {
+  color: #555;
+  font-size: 0.85rem;
 }
 
 .phoneme-chip-list {

--- a/frontend/tests/e2e/m7-walkthrough.spec.ts
+++ b/frontend/tests/e2e/m7-walkthrough.spec.ts
@@ -146,6 +146,8 @@ function toTodayResponse(group: MockGroup) {
     group_id: group.group_id,
     group_index: group.group_index,
     group_type: group.group_type,
+    learner_level: "entry",
+    learner_level_label: "Entry",
     date: "2026-06-17",
     primary_accent: group.primary_accent,
     origin:
@@ -190,6 +192,7 @@ function settingsResponse(state: MockState) {
     show_accent_compare: false,
     practice_mode: "adaptive",
     review_strength: "normal",
+    learner_level: "entry",
     focus_phonemes: state.focusPhonemes,
   };
 }
@@ -254,7 +257,10 @@ async function routeMock(route: Route, state: MockState) {
 
   if (path === "/settings") {
     if (request.method() === "PUT") {
-      const body = request.postDataJSON() as { focus_phonemes?: string[] };
+      const body = request.postDataJSON() as {
+        focus_phonemes?: string[];
+        learner_level?: "entry" | "mid";
+      };
       if (Array.isArray(body.focus_phonemes)) {
         state.focusPhonemes = body.focus_phonemes;
       }
@@ -402,7 +408,7 @@ test.describe("M7 v2 learner workflow walkthrough", () => {
       await expect(page.getByText("ship")).toBeVisible();
       await expect(page.getByText("picked")).toBeVisible();
       await expect(page.getByText("Target sound: /ʃ/")).toBeVisible();
-      await expect(page.getByRole("button", { name: "Start next 10-word group" })).toBeVisible();
+      await expect(page.getByRole("button", { name: "Start next Entry group" })).toBeVisible();
       await expect(page.getByRole("button", { name: "Review misses from this group" })).toBeVisible();
       await expect(page.getByRole("button", { name: "Review recent mistakes" })).toBeVisible();
       await expect(page.getByRole("button", { name: "Return to Progress" })).toBeVisible();
@@ -414,9 +420,9 @@ test.describe("M7 v2 learner workflow walkthrough", () => {
     await openWalkthrough(page);
     await completeFirstGroupWithOneMiss(page);
 
-    await page.getByRole("button", { name: "Start next 10-word group" }).click();
+    await page.getByRole("button", { name: "Start next Entry group" }).click();
     await expect(page.getByText("Practice group: 1 / 1")).toBeVisible();
-    await expect(page.getByText("A new normal practice group.")).toBeVisible();
+    await expect(page.getByText("A new Entry practice group.")).toBeVisible();
     await expect(page.getByText("cheese")).toBeVisible();
     await expect(page.getByText(/Group 6/)).toHaveCount(0);
   });
@@ -466,7 +472,7 @@ test.describe("M7 v2 learner workflow walkthrough", () => {
 
     await expect(page.getByText("Focused group: 1 / 1")).toBeVisible();
     await expect(page.getByText(/Group 8/)).toHaveCount(0);
-    await expect(page.getByText("Focused practice for /ʃ/.")).toBeVisible();
+    await expect(page.getByText("Entry focused practice for /ʃ/.")).toBeVisible();
     await expect(page.getByRole("button", { name: "Clear focus" })).toBeVisible();
     await page.getByRole("button", { name: "Clear focus" }).click();
     await expect(page.getByText("Focus cleared. Back to normal practice.")).toBeVisible();

--- a/frontend/tests/e2e/m8-level-selection.spec.ts
+++ b/frontend/tests/e2e/m8-level-selection.spec.ts
@@ -1,0 +1,168 @@
+import { expect, type Page, type Route, test } from "@playwright/test";
+
+type LearnerLevel = "entry" | "mid";
+
+interface MockState {
+  learnerLevel: LearnerLevel;
+}
+
+const items = {
+  entry: {
+    session_item_id: "entry-item-1",
+    word_id: "ship",
+    display_ipa: "/ʃɪp/",
+    word: "ship",
+    meaning_zh: "船",
+    target_phonemes: ["/ʃ/"],
+    choices: ["/sɪp/", "/ʃɪp/"],
+  },
+  mid: {
+    session_item_id: "mid-item-1",
+    word_id: "mid_remember",
+    display_ipa: "/rɪˈmembɚ/",
+    word: "remember",
+    meaning_zh: "记得",
+    target_phonemes: ["/r/", "/ɚ/"],
+    choices: ["/rɪˈmembɚ/", "/rɪˈmembə/"],
+  },
+};
+
+function levelLabel(level: LearnerLevel) {
+  return level === "mid" ? "Mid" : "Entry";
+}
+
+function todayResponse(level: LearnerLevel) {
+  const item = items[level];
+  return {
+    session_id: `${level}-session-1`,
+    group_id: `${level}-group-1`,
+    group_index: 1,
+    group_type: "normal",
+    learner_level: level,
+    learner_level_label: levelLabel(level),
+    date: "2026-06-18",
+    primary_accent: "US",
+    origin: "normal_start",
+    source_scope: "normal_current",
+    focus_phonemes: [],
+    daily_word_count: 1,
+    word_count: 1,
+    status: "active",
+    source_session_item_ids: [],
+    items: [
+      {
+        ...item,
+        audio_url: `/audio/us/${item.word}.mp3`,
+        question: {
+          type: "ipa_choice",
+          prompt: "Pick the matching IPA",
+          choices: item.choices,
+        },
+      },
+    ],
+  };
+}
+
+function settingsResponse(state: MockState) {
+  return {
+    primary_accent: "US",
+    daily_word_count: 1,
+    show_translation: true,
+    show_accent_compare: false,
+    practice_mode: "ipa_first",
+    review_strength: "normal",
+    learner_level: state.learnerLevel,
+    focus_phonemes: [],
+  };
+}
+
+async function setupMockApi(page: Page): Promise<MockState> {
+  const state: MockState = { learnerLevel: "entry" };
+  await page.route("**/api/**", async (route) => {
+    await routeMock(route, state);
+  });
+  return state;
+}
+
+async function routeMock(route: Route, state: MockState) {
+  const request = route.request();
+  const path = new URL(request.url()).pathname.replace(/^\/api/, "");
+
+  if (path === "/health") {
+    await route.fulfill({
+      json: { status: "ok", content_version: "m8-level-selection", db_ready: true },
+    });
+    return;
+  }
+
+  if (path === "/settings") {
+    if (request.method() === "PUT") {
+      const body = request.postDataJSON() as { learner_level?: LearnerLevel };
+      if (body.learner_level === "entry" || body.learner_level === "mid") {
+        state.learnerLevel = body.learner_level;
+      }
+    }
+    await route.fulfill({ json: settingsResponse(state) });
+    return;
+  }
+
+  if (path === "/today") {
+    await route.fulfill({ json: todayResponse(state.learnerLevel) });
+    return;
+  }
+
+  if (path === "/progress") {
+    await route.fulfill({
+      json: {
+        today_completed: false,
+        today_status: "active",
+        streak_days: 0,
+        total_attempts: 0,
+        total_sessions: 0,
+        weak_phonemes: [],
+        strong_phonemes: [],
+      },
+    });
+    return;
+  }
+
+  await route.fallback();
+}
+
+test.describe("M8 learner level selection walkthrough", () => {
+  test("Entry is default and Mid switching is visible in Settings and Today", async ({ page }) => {
+    await setupMockApi(page);
+
+    await test.step("Entry default practice context", async () => {
+      await page.goto("/");
+      await expect(page.getByText("Practice group: 1 / 1")).toBeVisible();
+      await expect(page.getByText("Entry practice group.")).toBeVisible();
+      await expect(page.getByText("ship")).toBeVisible();
+      await expect(page.getByText("Mid")).toHaveCount(0);
+    });
+
+    await test.step("Settings exposes learner-facing level choices", async () => {
+      await page.getByRole("button", { name: "Settings" }).click();
+      await expect(page.getByRole("heading", { name: "Settings" })).toBeVisible();
+      await expect(page.getByRole("heading", { name: "Practice level" })).toBeVisible();
+      await expect(page.getByRole("button", { name: /Entry/ })).toBeVisible();
+      await page.getByRole("button", { name: /Mid/ }).click();
+      await expect(page.getByText("Saved")).toBeVisible();
+      await expect(page.getByText(/core_1000_words|core_300_words/i)).toHaveCount(0);
+    });
+
+    await test.step("Mid practice uses the Mid pool and visible context", async () => {
+      await page.getByRole("button", { name: "Today", exact: true }).click();
+      await expect(page.getByText("Practice group: 1 / 1")).toBeVisible();
+      await expect(page.getByText("Mid practice group.")).toBeVisible();
+      await expect(page.getByText("remember")).toBeVisible();
+      await expect(page.getByText("ship")).toHaveCount(0);
+      const screenshotPath = test.info().outputPath("m8-mid-level-mobile.png");
+      await page.screenshot({ fullPage: true, path: screenshotPath });
+      await test.info().attach("m8-mid-level-mobile", {
+        path: screenshotPath,
+        contentType: "image/png",
+      });
+    });
+  });
+});


### PR DESCRIPTION
## User-facing behavior

- Settings now has a learner-facing **Practice level** choice.
- **Entry** remains the default and uses the current Core300/beginner pool.
- **Mid** uses the Core1000/intermediate pool for future new normal/focused practice groups.
- The current practice screen shows the active level next to accent, and group copy says Entry/Mid in product terms rather than internal filenames.
- Changing level does not rewrite an already active group; it affects the next generated normal/focus group.

## Scope completed

- Added `learner_level` to settings and daily session persistence with compatibility migrations.
- Wired `learner_level` through `/api/settings`, `/api/today`, normal next-group generation, and focused practice generation.
- Filtered scheduler selection by learner level: Entry -> `beginner`, Mid -> `intermediate`.
- Added Settings UI level selector, Today level badges/copy, frontend API types, and API contract docs.
- Added M8 Playwright walkthrough for Entry default -> Settings Mid switch -> Mid Today practice.
- Kept #128 readiness/Epic closure out of scope.

## Trial path

1. Start backend and frontend normally.
2. Open the app on Today: it should show Entry practice by default.
3. Go to Settings -> Practice level and choose Mid.
4. Return to Today or start the next new group after finishing the current one: new practice should show Mid and draw from the Mid/Core1000 pool.
5. Existing active groups should keep their original level until completed.

## Verification

- `uv run --project backend pytest backend/tests/test_scheduler.py backend/tests/test_settings_api.py backend/tests/test_today_persistence.py` -> 59 passed, 1 existing warning.
- `uv run --project backend pytest` -> 187 passed, 1 existing warning.
- `cd frontend && pnpm run lint` -> passed.
- `cd frontend && pnpm exec tsc --noEmit` -> passed.
- `cd frontend && pnpm run build` -> passed.
- `cd frontend && M7_WALKTHROUGH_PORT=5189 pnpm test:e2e:m8` -> 1 passed.
- `cd frontend && M7_WALKTHROUGH_PORT=5191 pnpm test:e2e:m7` -> 7 passed.
- `cd frontend && M7_WALKTHROUGH_PORT=5192 pnpm test:e2e:m8` -> 1 passed.
- `git diff --check` -> passed.
- `tools/agents/agent-audit` -> clean.

## Walkthrough evidence

- Added `frontend/tests/e2e/m8-level-selection.spec.ts`.
- The walkthrough route-mocks disposable API responses and captures `m8-mid-level-mobile.png` on the Mid path.
- The local M8 run passed using an alternate port because `5177` can be occupied in local dogfood sessions.

## Residual risks

- Mid learner exposure still carries accepted content risks from #125/#126: 845 placeholder Chinese meanings, 53 UK IPA/tag warning-only gaps, and missing Mid audio.
- This PR wires level selection; it does not resolve Mid content QA, audio generation, or #128 readiness closure.
- Existing active groups keep their stored level by design, so users may not see Mid until they finish or start a future group.

Linked issues: #108, #127