### PR TITLE
[#108] Add M8 workflow hub and level-aware progress stats

### DIFF
--- a/backend/app/routes/practice.py
+++ b/backend/app/routes/practice.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter, HTTPException, Request
 
 from app.db import get_db
 from app.services.sessions import (
+    build_abandon_current_and_next_response,
     build_clear_focus_response,
     build_current_group_review_response,
     build_focused_group_response,
@@ -17,10 +18,10 @@ router = APIRouter()
 
 @router.get("/today")
 def today():
-    """Return today's practice session, creating it if needed.
+    """Return today's practice hub state without creating a new group.
 
-    Refresh-safe: repeated calls on the same date return the same session
-    and items. Session and item rows are persisted in SQLite.
+    Refresh-safe: repeated calls on the same date return the active normal group
+    if one exists, otherwise a no-active hub response.
     """
     with get_db() as conn:
         return build_today_response(conn)
@@ -28,9 +29,16 @@ def today():
 
 @router.post("/practice/next-normal")
 def next_normal_group():
-    """Resume the active normal group or create the next normal group."""
+    """Resume active normal group or explicitly create the first/next normal group."""
     with get_db() as conn:
         return build_next_normal_group_response(conn)
+
+
+@router.post("/practice/abandon-current-and-next")
+def abandon_current_and_next_group():
+    """Abandon active normal group and create the next selected-level group."""
+    with get_db() as conn:
+        return build_abandon_current_and_next_response(conn)
 
 
 @router.post("/review/recent-mistakes")

--- a/backend/app/services/db_store.py
+++ b/backend/app/services/db_store.py
@@ -418,6 +418,23 @@ def mark_session_completed(
     )
 
 
+def mark_session_abandoned(
+    conn: sqlite3.Connection,
+    session_id: str,
+    completed_at: str,
+) -> None:
+    """Mark a practice group abandoned without counting it as completed."""
+    ensure_daily_sessions_schema(conn)
+    conn.execute(
+        """
+        UPDATE daily_sessions
+        SET status = 'abandoned', completed_at = ?
+        WHERE id = ? AND status = 'in_progress'
+        """,
+        (completed_at, session_id),
+    )
+
+
 def create_session_item(conn: sqlite3.Connection, item: SessionItem) -> str:
     """Insert a session item row. Returns the item id."""
     conn.execute(

--- a/backend/app/services/progress.py
+++ b/backend/app/services/progress.py
@@ -11,6 +11,7 @@ GET /api/progress reads ``phoneme_stats``, ``attempts``, and
 from __future__ import annotations
 
 import sqlite3
+import json
 from datetime import date, timedelta
 from typing import List, Optional, Tuple
 
@@ -185,6 +186,7 @@ def update_phoneme_stats(
 # ============================================================================
 
 _MIN_ATTEMPTS_FOR_PHONEME_LIST = 2
+_LEVEL_LABELS = {"entry": "Entry", "mid": "Mid"}
 
 
 def build_progress_response(
@@ -216,12 +218,22 @@ def build_progress_response(
     ).fetchone()
     total_sessions = sess_row["cnt"] if sess_row else 0
 
+    normal_row = conn.execute(
+        """
+        SELECT COUNT(*) AS cnt
+        FROM daily_sessions
+        WHERE user_id = ? AND group_type = 'normal'
+        """,
+        (user_id,),
+    ).fetchone()
+    total_normal_groups = normal_row["cnt"] if normal_row else 0
+
     # ---- today ---------------------------------------------------------------
     today_str = date.today().isoformat()
     today_rows = conn.execute(
         """
         SELECT status FROM daily_sessions
-        WHERE user_id = ? AND session_date = ?
+        WHERE user_id = ? AND session_date = ? AND group_type = 'normal'
         """,
         (user_id, today_str),
     ).fetchall()
@@ -241,6 +253,7 @@ def build_progress_response(
     weak_phonemes, strong_phonemes = _compute_phoneme_lists(
         conn, user_id, primary_accent
     )
+    level_stats = _compute_level_stats(conn, user_id, primary_accent, today_str)
 
     return {
         "today_completed": today_completed,
@@ -248,8 +261,11 @@ def build_progress_response(
         "streak_days": streak_days,
         "total_attempts": total_attempts,
         "total_sessions": total_sessions,
+        "total_normal_groups": total_normal_groups,
         "weak_phonemes": weak_phonemes,
         "strong_phonemes": strong_phonemes,
+        "stat_scope": "global",
+        "level_stats": level_stats,
     }
 
 
@@ -267,7 +283,7 @@ def _compute_streak(conn: sqlite3.Connection, user_id: str) -> int:
     rows = conn.execute(
         """
         SELECT session_date FROM daily_sessions
-        WHERE user_id = ? AND status = 'completed'
+        WHERE user_id = ? AND status = 'completed' AND group_type = 'normal'
         ORDER BY session_date DESC
         """,
         (user_id,),
@@ -290,6 +306,127 @@ def _compute_streak(conn: sqlite3.Connection, user_id: str) -> int:
             break
 
     return streak
+
+
+def _compute_level_stats(
+    conn: sqlite3.Connection,
+    user_id: str,
+    primary_accent: str,
+    today_str: str,
+) -> dict:
+    result = {
+        level: {
+            "learner_level": level,
+            "label": _LEVEL_LABELS[level],
+            "attempts": 0,
+            "correct_attempts": 0,
+            "accuracy": None,
+            "normal_groups": 0,
+            "completed_normal_groups": 0,
+            "completed_normal_groups_today": 0,
+            "weak_phonemes": [],
+            "strong_phonemes": [],
+        }
+        for level in ("entry", "mid")
+    }
+
+    group_rows = conn.execute(
+        """
+        SELECT learner_level, status, session_date, COUNT(*) AS cnt
+        FROM daily_sessions
+        WHERE user_id = ? AND group_type = 'normal'
+        GROUP BY learner_level, status, session_date
+        """,
+        (user_id,),
+    ).fetchall()
+    for row in group_rows:
+        level = row["learner_level"] if row["learner_level"] in result else "entry"
+        result[level]["normal_groups"] += int(row["cnt"])
+        if row["status"] == "completed":
+            result[level]["completed_normal_groups"] += int(row["cnt"])
+            if row["session_date"] == today_str:
+                result[level]["completed_normal_groups_today"] += int(row["cnt"])
+
+    attempt_rows = conn.execute(
+        """
+        SELECT
+          ds.learner_level,
+          a.is_correct,
+          si.target_phonemes
+        FROM attempts a
+        JOIN session_items si ON si.id = a.session_item_id
+        JOIN daily_sessions ds ON ds.id = si.session_id
+        WHERE a.user_id = ?
+          AND a.primary_accent = ?
+          AND ds.group_type = 'normal'
+        """,
+        (user_id, primary_accent),
+    ).fetchall()
+
+    phoneme_by_level: dict[str, dict[str, dict[str, int]]] = {
+        "entry": {},
+        "mid": {},
+    }
+    for row in attempt_rows:
+        level = row["learner_level"] if row["learner_level"] in result else "entry"
+        is_correct = bool(row["is_correct"])
+        result[level]["attempts"] += 1
+        if is_correct:
+            result[level]["correct_attempts"] += 1
+        for phoneme in _parse_target_phonemes(row["target_phonemes"]):
+            stat = phoneme_by_level[level].setdefault(phoneme, {"attempts": 0, "correct": 0})
+            stat["attempts"] += 1
+            if is_correct:
+                stat["correct"] += 1
+
+    for level, stats in phoneme_by_level.items():
+        attempts = result[level]["attempts"]
+        if attempts:
+            result[level]["accuracy"] = round(result[level]["correct_attempts"] / attempts, 2)
+        weak, strong = _phoneme_lists_from_counts(stats)
+        result[level]["weak_phonemes"] = weak
+        result[level]["strong_phonemes"] = strong
+
+    return result
+
+
+def _parse_target_phonemes(raw: Optional[str]) -> List[str]:
+    if not raw:
+        return []
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return []
+    if not isinstance(parsed, list):
+        return []
+    return [str(item) for item in parsed if item]
+
+
+def _phoneme_lists_from_counts(stats: dict[str, dict[str, int]]) -> Tuple[List[dict], List[dict]]:
+    entries: List[dict] = []
+    for phoneme, counts in stats.items():
+        attempts = counts["attempts"]
+        if attempts < _MIN_ATTEMPTS_FOR_PHONEME_LIST:
+            continue
+        correct = counts["correct"]
+        accuracy = correct / attempts if attempts else 0.0
+        entries.append({
+            "phoneme": phoneme,
+            "accuracy": round(accuracy, 2),
+            "attempt_count": attempts,
+            "correct_count": correct,
+            "mastery_status": _compute_mastery(attempts, correct),
+        })
+
+    weak = sorted(
+        [e for e in entries if e["accuracy"] < 0.70],
+        key=lambda e: (e["accuracy"], -e["attempt_count"]),
+    )
+    strong = sorted(
+        [e for e in entries if e["accuracy"] >= 0.85],
+        key=lambda e: (-e["accuracy"], -e["attempt_count"]),
+    )
+    return weak, strong
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/services/sessions.py
+++ b/backend/app/services/sessions.py
@@ -22,6 +22,7 @@ from app.services.db_store import (
     get_session_items,
     get_settings,
     get_word_by_id,
+    mark_session_abandoned,
     upsert_settings,
 )
 from app.services.questions import generate_question
@@ -72,6 +73,7 @@ def build_today_response(
         }
 
     daily_word_count = settings.daily_word_count
+    selected_level = settings.learner_level
 
     # ---- check for existing session -----------------------------------------
     existing = get_active_session_for_date(conn, user_id, session_date, accent, "normal")
@@ -86,15 +88,78 @@ def build_today_response(
             origin="normal_resume",
             source_scope="normal_current",
             focus_phonemes=existing.focus_phonemes or settings.focus_phonemes,
+            selected_learner_level=selected_level,
             action_label=f"Resume {learner_level_label(existing.learner_level)} Group {existing.group_index}",
         )
 
-    # ---- create new session -------------------------------------------------
+    return _normal_empty_response(
+        conn,
+        user_id=user_id,
+        session_date=session_date,
+        accent=accent,
+        daily_word_count=daily_word_count,
+        selected_level=selected_level,
+        focus_phonemes=settings.focus_phonemes,
+    )
+
+
+def build_next_normal_group_response(
+    conn,
+    *,
+    user_id: str = "default",
+    accent: str = "US",
+) -> dict:
+    """Resume the active normal group or explicitly create the next normal group."""
+    session_date = _today_date_str()
+    settings = get_settings(conn, user_id)
+    if settings is None:
+        return {
+            "error": "CONTENT_NOT_READY",
+            "detail": "Settings not initialised. Run import_words.py first.",
+        }
+
+    existing = get_active_session_for_date(conn, user_id, session_date, accent, "normal")
+    if existing is not None:
+        items = get_session_items(conn, existing.id)
+        return _build_response(
+            session=existing,
+            items=items,
+            daily_word_count=settings.daily_word_count,
+            conn=conn,
+            accent=accent,
+            origin="normal_resume",
+            source_scope="normal_current",
+            focus_phonemes=existing.focus_phonemes or settings.focus_phonemes,
+            selected_learner_level=settings.learner_level,
+            action_label=f"Resume {learner_level_label(existing.learner_level)} Group {existing.group_index}",
+        )
+
+    return _create_normal_group_response(
+        conn,
+        user_id=user_id,
+        session_date=session_date,
+        accent=accent,
+        settings=settings,
+        origin="normal_next",
+        source_scope="normal_next",
+    )
+
+
+def _create_normal_group_response(
+    conn,
+    *,
+    user_id: str,
+    session_date: str,
+    accent: str,
+    settings,
+    origin: str,
+    source_scope: str,
+) -> dict:
     group_index = get_next_session_group_index(conn, user_id, session_date, accent)
     seed = _seed_from_group(session_date, group_index, "normal")
     words = select_daily_words(
         conn,
-        daily_word_count,
+        settings.daily_word_count,
         accent,
         seed=seed,
         user_id=user_id,
@@ -127,33 +192,57 @@ def build_today_response(
     return _build_response(
         session=session,
         items=items,
-        daily_word_count=daily_word_count,
+        daily_word_count=settings.daily_word_count,
         conn=conn,
         accent=accent,
-        origin="normal_start",
-        source_scope="normal_current",
+        origin=origin,
+        source_scope=source_scope,
         focus_phonemes=settings.focus_phonemes,
+        selected_learner_level=settings.learner_level,
         action_label=f"Start {learner_level_label(session.learner_level)} Group {session.group_index}",
     )
 
 
-def build_next_normal_group_response(
+def build_abandon_current_and_next_response(
     conn,
     *,
     user_id: str = "default",
     accent: str = "US",
 ) -> dict:
-    """Resume the active normal group or create the next normal same-day group."""
-    response = build_today_response(conn, user_id=user_id, accent=accent)
-    if "error" in response:
-        return response
-    if response.get("origin") == "normal_start":
-        response["origin"] = "normal_next"
-    response["source_scope"] = "normal_next"
-    if response.get("origin") == "normal_next":
+    """Abandon the active normal group and create the next selected-level group."""
+    session_date = _today_date_str()
+    existing = get_active_session_for_date(conn, user_id, session_date, accent, "normal")
+    if existing is None:
+        return build_next_normal_group_response(conn, user_id=user_id, accent=accent)
+
+    settings = get_settings(conn, user_id)
+    if settings is None:
+        return {
+            "error": "CONTENT_NOT_READY",
+            "detail": "Settings not initialised. Run import_words.py first.",
+        }
+
+    mark_session_abandoned(conn, existing.id, _now_iso())
+    response = _create_normal_group_response(
+        conn,
+        user_id=user_id,
+        session_date=session_date,
+        accent=accent,
+        settings=settings,
+        origin="normal_abandon_next",
+        source_scope="normal_next",
+    )
+    if "error" not in response:
+        response["abandoned_group_id"] = existing.id
+        response["detail"] = (
+            f"Ended {learner_level_label(existing.learner_level)} Group "
+            f"{existing.group_index} and started "
+            f"{learner_level_label(response.get('learner_level'))} Group "
+            f"{response.get('group_index')}."
+        )
         response["action_label"] = (
             f"Start {learner_level_label(response.get('learner_level'))} "
-            f"Group {response['group_index']}"
+            f"Group {response.get('group_index')}"
         )
     return response
 
@@ -415,6 +504,7 @@ def build_focused_group_response(
             origin="focus_resume",
             source_scope="focus_selection",
             focus_phonemes=focus_phonemes,
+            selected_learner_level=settings.learner_level,
             action_label=f"Resume {learner_level_label(existing.learner_level)} Focus Group {existing.group_index}",
         )
 
@@ -460,6 +550,7 @@ def build_focused_group_response(
         origin="focus_start",
         source_scope="focus_selection",
         focus_phonemes=focus_phonemes,
+        selected_learner_level=settings.learner_level,
         action_label=f"Start {learner_level_label(session.learner_level)} Focus Group {session.group_index}",
     )
 
@@ -484,7 +575,9 @@ def build_clear_focus_response(
     response = build_today_response(conn, user_id=user_id, accent=accent)
     if "error" not in response:
         response["origin"] = "focus_clear"
-        response["source_scope"] = "normal_current"
+        response["source_scope"] = (
+            "normal_current" if response.get("group_id") else "normal_none"
+        )
         response["focus_phonemes"] = []
         response["detail"] = "Focus selection cleared."
     return response
@@ -556,6 +649,64 @@ def _build_distractor_pool(conn, accent: str) -> List[str]:
     return [r[0] for r in rows if r[0]]
 
 
+def _completed_normal_groups_today(conn, user_id: str, session_date: str) -> dict:
+    rows = conn.execute(
+        """
+        SELECT learner_level, COUNT(*) AS cnt
+        FROM daily_sessions
+        WHERE user_id = ?
+          AND session_date = ?
+          AND group_type = 'normal'
+          AND status = 'completed'
+        GROUP BY learner_level
+        """,
+        (user_id, session_date),
+    ).fetchall()
+    by_level = {"entry": 0, "mid": 0}
+    for row in rows:
+        level = row["learner_level"] if row["learner_level"] in by_level else "entry"
+        by_level[level] = int(row["cnt"])
+    return {
+        "entry": by_level["entry"],
+        "mid": by_level["mid"],
+        "total": by_level["entry"] + by_level["mid"],
+    }
+
+
+def _normal_empty_response(
+    conn,
+    *,
+    user_id: str,
+    session_date: str,
+    accent: str,
+    daily_word_count: int,
+    selected_level: str,
+    focus_phonemes: Optional[List[str]],
+) -> dict:
+    return {
+        "group_type": "normal",
+        "learner_level": selected_level,
+        "learner_level_label": learner_level_label(selected_level),
+        "selected_learner_level": selected_level,
+        "selected_learner_level_label": learner_level_label(selected_level),
+        "pending_level_change": False,
+        "completed_normal_groups_today": _completed_normal_groups_today(
+            conn, user_id, session_date
+        ),
+        "date": session_date,
+        "primary_accent": accent,
+        "daily_word_count": daily_word_count,
+        "word_count": 0,
+        "status": "idle",
+        "origin": "normal_empty",
+        "source_scope": "normal_none",
+        "source_session_item_ids": [],
+        "focus_phonemes": focus_phonemes or [],
+        "action_label": f"Start {learner_level_label(selected_level)} group",
+        "items": [],
+    }
+
+
 def learner_level_label(learner_level: Optional[str]) -> str:
     return _LEARNER_LEVEL_LABELS.get(learner_level or "entry", "Entry")
 
@@ -571,6 +722,7 @@ def _build_response(
     source_scope: Optional[str] = None,
     source_group_id: Optional[str] = None,
     focus_phonemes: Optional[List[str]] = None,
+    selected_learner_level: Optional[str] = None,
     action_label: Optional[str] = None,
 ) -> dict:
     """Assemble the /api/today JSON response from session + items."""
@@ -608,6 +760,17 @@ def _build_response(
         "group_type": session.group_type,
         "learner_level": session.learner_level,
         "learner_level_label": learner_level_label(session.learner_level),
+        "selected_learner_level": selected_learner_level or session.learner_level,
+        "selected_learner_level_label": learner_level_label(
+            selected_learner_level or session.learner_level
+        ),
+        "pending_level_change": (
+            session.group_type == "normal"
+            and (selected_learner_level or session.learner_level) != session.learner_level
+        ),
+        "completed_normal_groups_today": _completed_normal_groups_today(
+            conn, session.user_id, session.session_date
+        ),
         "date": session.session_date,
         "primary_accent": session.primary_accent,
         "daily_word_count": daily_word_count,

--- a/backend/tests/test_attempts.py
+++ b/backend/tests/test_attempts.py
@@ -51,8 +51,8 @@ def client_fixture(seeded_db: str) -> TestClient:
 
 
 def _get_first_item(client: TestClient) -> dict:
-    """Get today's session and return the first item."""
-    today = client.get("/api/today").json()
+    """Start today's normal session and return the first item."""
+    today = client.post("/api/practice/next-normal").json()
     assert "error" not in today, today
     items = today["items"]
     assert len(items) > 0

--- a/backend/tests/test_audio_validation.py
+++ b/backend/tests/test_audio_validation.py
@@ -191,7 +191,7 @@ class TestTodayAudioUrl:
         db_mod.DEFAULT_DB_PATH = self._orig_db
 
     def test_today_includes_audio_url(self):
-        resp = self.client.get("/api/today")
+        resp = self.client.post("/api/practice/next-normal")
         assert resp.status_code == 200
         data = resp.json()
         assert "error" not in data
@@ -201,7 +201,7 @@ class TestTodayAudioUrl:
         assert ship_item.get("audio_url") == "/audio/us/ship.mp3"
 
     def test_today_null_audio_url_when_missing(self):
-        resp = self.client.get("/api/today")
+        resp = self.client.post("/api/practice/next-normal")
         data = resp.json()
         # cat has audio_us=null in fixture
         cat_item = next((i for i in data["items"] if i["word"] == "cat"), None)

--- a/backend/tests/test_progress_api.py
+++ b/backend/tests/test_progress_api.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import sys
 from datetime import date, timedelta
 from pathlib import Path
@@ -62,6 +63,10 @@ class TestProgressApi:
         data = resp.json()
         assert data["total_attempts"] == 0
         assert data["total_sessions"] == 0
+        assert data["total_normal_groups"] == 0
+        assert data["stat_scope"] == "global"
+        assert data["level_stats"]["entry"]["label"] == "Entry"
+        assert data["level_stats"]["mid"]["label"] == "Mid"
         assert data["today_completed"] is False
         assert data["streak_days"] == 0
         assert data["weak_phonemes"] == []
@@ -70,7 +75,7 @@ class TestProgressApi:
     def test_today_status_reflects_session(self, client, seeded_db):
         """After creating today's session, progress reflects it."""
         # Create today's session
-        client.get("/api/today")
+        client.post("/api/practice/next-normal")
         resp = client.get("/api/progress")
         data = resp.json()
         assert data["today_status"] == "in_progress"
@@ -79,7 +84,7 @@ class TestProgressApi:
     def test_total_attempts_counted(self, client, seeded_db):
         """After submitting attempts, total_attempts increases."""
         # Get a session item
-        today = client.get("/api/today").json()
+        today = client.post("/api/practice/next-normal").json()
         item = today["items"][0]
 
         # Submit one attempt
@@ -95,7 +100,7 @@ class TestProgressApi:
 
     def test_phoneme_lists_after_attempts(self, client, seeded_db):
         """After several attempts across phonemes, weak/strong lists appear."""
-        today = client.get("/api/today").json()
+        today = client.post("/api/practice/next-normal").json()
 
         # Submit 3 wrong answers for first item
         for _ in range(3):
@@ -141,10 +146,101 @@ class TestProgressApi:
         data = resp.json()
         for key in (
             "today_completed", "today_status", "streak_days",
-            "total_attempts", "total_sessions",
-            "weak_phonemes", "strong_phonemes",
+            "total_attempts", "total_sessions", "total_normal_groups",
+            "weak_phonemes", "strong_phonemes", "stat_scope", "level_stats",
         ):
             assert key in data, f"missing key: {key}"
+
+    def test_level_stats_scope_normal_practice_by_entry_and_mid(self, seeded_db):
+        conn = get_connection(seeded_db)
+        today = date.today().isoformat()
+        sessions = [
+            ("entry-normal", "normal", "entry", "completed"),
+            ("mid-normal", "normal", "mid", "completed"),
+            ("mid-focus", "weak_focus", "mid", "completed"),
+        ]
+        for session_id, group_type, level, status in sessions:
+            conn.execute(
+                """
+                INSERT INTO daily_sessions (
+                    id, user_id, session_date, primary_accent,
+                    status, created_at, completed_at, group_index,
+                    group_type, learner_level
+                ) VALUES (?, 'default', ?, 'US', ?, ?, ?, 1, ?, ?)
+                """,
+                (
+                    session_id,
+                    today,
+                    status,
+                    f"{today}T10:00:00Z",
+                    f"{today}T10:05:00Z",
+                    group_type,
+                    level,
+                ),
+            )
+            conn.execute(
+                """
+                INSERT INTO session_items (
+                    id, session_id, word_id, order_index, target_phonemes,
+                    question_type, status
+                ) VALUES (?, ?, ?, 0, ?, 'choose_ipa', 'complete')
+                """,
+                (
+                    f"{session_id}-item",
+                    session_id,
+                    "cat",
+                    json.dumps(["/æ/"] if level == "entry" else ["/ʃ/"]),
+                ),
+            )
+
+        for index in range(3):
+            conn.execute(
+                """
+                INSERT INTO attempts (
+                    id, user_id, session_item_id, word_id, primary_accent,
+                    question_type, selected_answer, correct_answer, is_correct, created_at
+                ) VALUES (?, 'default', 'entry-normal-item', 'cat', 'US',
+                    'choose_ipa', '/wrong/', '/kæt/', 0, ?)
+                """,
+                (f"entry-attempt-{index}", f"{today}T10:0{index}:00Z"),
+            )
+        for index in range(3):
+            conn.execute(
+                """
+                INSERT INTO attempts (
+                    id, user_id, session_item_id, word_id, primary_accent,
+                    question_type, selected_answer, correct_answer, is_correct, created_at
+                ) VALUES (?, 'default', 'mid-normal-item', 'cat', 'US',
+                    'choose_ipa', '/ʃɪp/', '/ʃɪp/', 1, ?)
+                """,
+                (f"mid-attempt-{index}", f"{today}T11:0{index}:00Z"),
+            )
+        conn.execute(
+            """
+            INSERT INTO attempts (
+                id, user_id, session_item_id, word_id, primary_accent,
+                question_type, selected_answer, correct_answer, is_correct, created_at
+            ) VALUES ('focus-attempt', 'default', 'mid-focus-item', 'cat', 'US',
+                'choose_ipa', '/ʃɪp/', '/ʃɪp/', 1, ?)
+            """,
+            (f"{today}T12:00:00Z",),
+        )
+        conn.commit()
+        conn.close()
+
+        conn = get_connection(seeded_db)
+        resp = build_progress_response(conn)
+        conn.close()
+
+        assert resp["total_attempts"] == 7
+        assert resp["total_sessions"] == 3
+        assert resp["total_normal_groups"] == 2
+        assert resp["level_stats"]["entry"]["completed_normal_groups_today"] == 1
+        assert resp["level_stats"]["mid"]["completed_normal_groups_today"] == 1
+        assert resp["level_stats"]["entry"]["attempts"] == 3
+        assert resp["level_stats"]["mid"]["attempts"] == 3
+        assert resp["level_stats"]["entry"]["weak_phonemes"][0]["phoneme"] == "/æ/"
+        assert resp["level_stats"]["mid"]["strong_phonemes"][0]["phoneme"] == "/ʃ/"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_today_persistence.py
+++ b/backend/tests/test_today_persistence.py
@@ -130,32 +130,35 @@ def entry_mid_client_fixture(seeded_db_entry_mid: str) -> TestClient:
 class TestTodayPersistence:
     """Tests that /api/today is database-backed and refresh-safe."""
 
-    def test_first_today_creates_session(self, client, seeded_db):
+    def test_first_today_returns_no_active_hub_without_creating_session(
+        self, client, seeded_db
+    ):
         resp = client.get("/api/today")
         assert resp.status_code == 200
         data = resp.json()
         assert "error" not in data, data
-        assert data["status"] == "in_progress"
-        assert data["group_id"] == data["session_id"]
-        assert data["group_index"] == 1
+        assert data["status"] == "idle"
+        assert data["origin"] == "normal_empty"
+        assert data["source_scope"] == "normal_none"
         assert data["group_type"] == "normal"
         assert data["learner_level"] == "entry"
         assert data["learner_level_label"] == "Entry"
-        assert data["word_count"] == len(data["items"])
+        assert data["selected_learner_level"] == "entry"
+        assert data["pending_level_change"] is False
+        assert data["word_count"] == 0
         assert data["source_session_item_ids"] == []
         assert data["date"] == date.today().isoformat()
         assert data["primary_accent"] == "US"
         assert data["daily_word_count"] == 10
-        assert len(data["items"]) == 3  # fixture has 3 words
-        # Session row exists in DB
+        assert data["items"] == []
+        assert data["action_label"] == "Start Entry group"
         conn = get_connection(seeded_db)
         s = get_session_for_date(conn, "default", date.today().isoformat(), "US")
         conn.close()
-        assert s is not None
-        assert s.status == "in_progress"
+        assert s is None
 
     def test_second_today_returns_same_session(self, client, seeded_db):
-        first = client.get("/api/today").json()
+        first = client.post("/api/practice/next-normal").json()
         second = client.get("/api/today").json()
         assert second["session_id"] == first["session_id"]
         assert len(second["items"]) == len(first["items"])
@@ -164,6 +167,7 @@ class TestTodayPersistence:
             assert a["word_id"] == b["word_id"]
 
     def test_second_today_creates_no_duplicate(self, client, seeded_db):
+        client.post("/api/practice/next-normal")
         client.get("/api/today")
         client.get("/api/today")
         conn = get_connection(seeded_db)
@@ -176,7 +180,7 @@ class TestTodayPersistence:
         assert items["cnt"] == 1
 
     def test_completed_group_allows_next_same_day_group(self, client, seeded_db):
-        first = client.get("/api/today").json()
+        first = client.post("/api/practice/next-normal").json()
         conn = get_connection(seeded_db)
         conn.execute(
             """
@@ -189,7 +193,11 @@ class TestTodayPersistence:
         conn.commit()
         conn.close()
 
-        second = client.get("/api/today").json()
+        empty = client.get("/api/today").json()
+        assert empty["status"] == "idle"
+        assert empty["origin"] == "normal_empty"
+
+        second = client.post("/api/practice/next-normal").json()
 
         assert second["session_id"] != first["session_id"]
         assert second["group_index"] == 2
@@ -214,7 +222,7 @@ class TestTodayPersistence:
         ]
 
     def test_items_have_required_fields(self, client, seeded_db):
-        resp = client.get("/api/today")
+        resp = client.post("/api/practice/next-normal")
         data = resp.json()
         for item in data["items"]:
             assert "session_item_id" in item
@@ -227,7 +235,7 @@ class TestTodayPersistence:
             assert len(item["question"]["choices"]) >= 2  # correct + distractors
 
     def test_items_use_us_accent(self, client, seeded_db):
-        resp = client.get("/api/today")
+        resp = client.post("/api/practice/next-normal")
         data = resp.json()
         for item in data["items"]:
             conn = get_connection(seeded_db)
@@ -244,7 +252,7 @@ class TestTodayPersistence:
         conn.commit()
         conn.close()
 
-        resp = client.get("/api/today")
+        resp = client.post("/api/practice/next-normal")
         data = resp.json()
         word_ids = [item["word_id"] for item in data["items"]]
         assert "cat" not in word_ids
@@ -256,7 +264,7 @@ class TestTodayPersistence:
         conn.commit()
         conn.close()
 
-        resp = client.get("/api/today")
+        resp = client.post("/api/practice/next-normal")
         data = resp.json()
         assert len(data["items"]) <= 1
 
@@ -268,7 +276,7 @@ class TestTodayPersistence:
         conn.commit()
         conn.close()
 
-        first = client.get("/api/today").json()
+        first = client.post("/api/practice/next-normal").json()
         item = first["items"][0]
         attempt = client.post("/api/attempt", json={
             "session_item_id": item["session_item_id"],
@@ -278,6 +286,9 @@ class TestTodayPersistence:
         assert attempt["next_action"] == "group_complete"
 
         second = client.get("/api/today").json()
+        assert second["status"] == "idle"
+
+        second = client.post("/api/practice/next-normal").json()
         assert second["session_id"] != first["session_id"]
         assert second["group_index"] == 2
 
@@ -287,7 +298,7 @@ class TestTodayPersistence:
         conn.commit()
         conn.close()
 
-        first = client.get("/api/today").json()
+        first = client.post("/api/practice/next-normal").json()
         item = first["items"][0]
         client.post("/api/attempt", json={
             "session_item_id": item["session_item_id"],
@@ -317,7 +328,7 @@ class TestTodayPersistence:
         assert data["source_scope"] == "recent_global"
 
     def test_recent_mistake_review_group_reuses_attempt_path(self, client, seeded_db):
-        today = client.get("/api/today").json()
+        today = client.post("/api/practice/next-normal").json()
         missed = today["items"][0]
         miss_resp = client.post("/api/attempt", json={
             "session_item_id": missed["session_item_id"],
@@ -367,7 +378,7 @@ class TestTodayPersistence:
         assert stats["attempt_count"] == 2
 
     def test_current_group_review_uses_only_source_group_misses(self, client, seeded_db):
-        today = client.get("/api/today").json()
+        today = client.post("/api/practice/next-normal").json()
         missed = today["items"][0]
         client.post("/api/attempt", json={
             "session_item_id": missed["session_item_id"],
@@ -387,7 +398,7 @@ class TestTodayPersistence:
         assert review["items"][0]["word_id"] == missed["word_id"]
 
     def test_current_group_review_empty_queue_is_non_error(self, client, seeded_db):
-        today = client.get("/api/today").json()
+        today = client.post("/api/practice/next-normal").json()
         resp = client.post("/api/review/current-group", json={
             "group_id": today["group_id"],
         })
@@ -415,7 +426,7 @@ class TestTodayPersistence:
     def test_current_and_recent_review_scopes_do_not_reuse_each_other(
         self, client, seeded_db
     ):
-        today = client.get("/api/today").json()
+        today = client.post("/api/practice/next-normal").json()
         missed = today["items"][0]
         client.post("/api/attempt", json={
             "session_item_id": missed["session_item_id"],
@@ -458,7 +469,7 @@ class TestTodayPersistence:
 
         assert cleared["group_type"] == "normal"
         assert cleared["origin"] == "focus_clear"
-        assert cleared["source_scope"] == "normal_current"
+        assert cleared["source_scope"] == "normal_none"
         assert cleared["focus_phonemes"] == []
 
     def test_focus_action_resumes_active_weak_focus_group(self, client, seeded_db):
@@ -517,7 +528,7 @@ class TestTodayPersistence:
         conn.commit()
         conn.close()
 
-        resp = client.get("/api/today")
+        resp = client.post("/api/practice/next-normal")
         data = resp.json()
 
         assert [item["word_id"] for item in data["items"]] == ["cat"]
@@ -535,7 +546,7 @@ class TestTodayPersistence:
         conn.commit()
         conn.close()
 
-        first = client.get("/api/today").json()
+        first = client.post("/api/practice/next-normal").json()
         assert [item["word_id"] for item in first["items"]] == ["cat"]
 
         conn = get_connection(seeded_db)
@@ -575,7 +586,7 @@ class TestTodayPersistence:
         conn.commit()
         conn.close()
 
-        resp = client.get("/api/today")
+        resp = client.post("/api/practice/next-normal")
         data = resp.json()
 
         assert [item["word_id"] for item in data["items"]] == ["cat"]
@@ -637,7 +648,7 @@ class TestCore300TodayReadiness:
     """Regression coverage for the full Core 300 runtime content path."""
 
     def test_core_300_today_keeps_daily_count_to_settings(self, core_300_client):
-        resp = core_300_client.get("/api/today")
+        resp = core_300_client.post("/api/practice/next-normal")
         assert resp.status_code == 200
         data = resp.json()
         assert "error" not in data, data
@@ -649,7 +660,7 @@ class TestCore300TodayReadiness:
         import app.db as db_mod
 
         conn = get_connection(db_mod.DEFAULT_DB_PATH)
-        first_resp = core_300_client.get("/api/today")
+        first_resp = core_300_client.post("/api/practice/next-normal")
         assert first_resp.status_code == 200
         first_data = first_resp.json()
         session_id = first_data["session_id"]
@@ -679,7 +690,7 @@ class TestCore300TodayReadiness:
         conn.commit()
         conn.close()
 
-        resp = core_300_client.get("/api/today")
+        resp = core_300_client.post("/api/practice/next-normal")
         assert resp.status_code == 200
         data = resp.json()
         assert "error" not in data, data
@@ -709,7 +720,7 @@ class TestCore300TodayReadiness:
         conn.commit()
         conn.close()
 
-        resp = core_300_client.get("/api/today")
+        resp = core_300_client.post("/api/practice/next-normal")
         assert resp.status_code == 200
         data = resp.json()
         assert "error" not in data, data
@@ -720,7 +731,7 @@ class TestLevelAwareToday:
     """Regression coverage for M8 learner-level scheduling semantics."""
 
     def test_entry_is_default_and_uses_core300_pool(self, entry_mid_client):
-        resp = entry_mid_client.get("/api/today")
+        resp = entry_mid_client.post("/api/practice/next-normal")
         assert resp.status_code == 200
         data = resp.json()
 
@@ -737,7 +748,7 @@ class TestLevelAwareToday:
         })
         assert settings_resp.status_code == 200
 
-        resp = entry_mid_client.get("/api/today")
+        resp = entry_mid_client.post("/api/practice/next-normal")
         assert resp.status_code == 200
         data = resp.json()
 
@@ -753,7 +764,7 @@ class TestLevelAwareToday:
             "learner_level": "entry",
             "daily_word_count": 2,
         })
-        first = entry_mid_client.get("/api/today").json()
+        first = entry_mid_client.post("/api/practice/next-normal").json()
         assert first["learner_level"] == "entry"
         assert all(not item["word_id"].startswith("mid_") for item in first["items"])
 
@@ -761,6 +772,13 @@ class TestLevelAwareToday:
         resumed = entry_mid_client.get("/api/today").json()
         assert resumed["session_id"] == first["session_id"]
         assert resumed["learner_level"] == "entry"
+        assert resumed["selected_learner_level"] == "mid"
+        assert resumed["pending_level_change"] is True
+        assert resumed["completed_normal_groups_today"] == {
+            "entry": 0,
+            "mid": 0,
+            "total": 0,
+        }
 
         conn = get_connection(seeded_db_entry_mid)
         conn.execute(
@@ -778,6 +796,7 @@ class TestLevelAwareToday:
         assert next_group["group_index"] == first["group_index"] + 1
         assert next_group["learner_level"] == "mid"
         assert next_group["source_scope"] == "normal_next"
+        assert next_group["pending_level_change"] is False
         assert all(item["word_id"].startswith("mid_") for item in next_group["items"])
 
     def test_focused_practice_uses_active_learner_level_pool(self, entry_mid_client):
@@ -795,6 +814,36 @@ class TestLevelAwareToday:
         assert focused["focus_phonemes"] == ["/ʃ/"]
         assert focused["items"]
         assert all(item["word_id"].startswith("mid_") for item in focused["items"])
+
+    def test_abandon_current_group_starts_selected_level_group(
+        self, entry_mid_client, seeded_db_entry_mid
+    ):
+        entry_mid_client.put("/api/settings", json={
+            "learner_level": "entry",
+            "daily_word_count": 2,
+        })
+        first = entry_mid_client.post("/api/practice/next-normal").json()
+        entry_mid_client.put("/api/settings", json={"learner_level": "mid"})
+
+        resp = entry_mid_client.post("/api/practice/abandon-current-and-next")
+        assert resp.status_code == 200
+        data = resp.json()
+
+        assert data["abandoned_group_id"] == first["session_id"]
+        assert data["origin"] == "normal_abandon_next"
+        assert data["learner_level"] == "mid"
+        assert data["selected_learner_level"] == "mid"
+        assert data["pending_level_change"] is False
+        assert all(item["word_id"].startswith("mid_") for item in data["items"])
+
+        conn = get_connection(seeded_db_entry_mid)
+        old_status = conn.execute(
+            "SELECT status FROM daily_sessions WHERE id = ?",
+            (first["session_id"],),
+        ).fetchone()
+        conn.close()
+
+        assert old_status["status"] == "abandoned"
 
 
 # ---------------------------------------------------------------------------

--- a/docs/05-data-api-contracts.md
+++ b/docs/05-data-api-contracts.md
@@ -212,7 +212,7 @@ why the learner is seeing a group.
 
 | Current UI state | Domain state | User action | Command/query | Next domain state | Next UI state | User-facing copy | Failure/empty state |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| Entry/home | No active group or unknown | Start practice | `GET /api/today` or future explicit start query | Active normal group | Active normal group | `Group 1`, `10 words` | Show setup/import error with retry |
+| Entry/home | No active group | Start practice | `POST /api/practice/next-normal` | Active normal group | Active normal group | `Start Entry group` / `Start Mid group` | Show setup/import error with retry |
 | Entry/home | Active normal group exists | Resume practice | `GET /api/today` | Same active normal group | Active normal group | `Resume Group N` | Keep entry/home actions visible |
 | Active normal group | Pending items remain | Submit answer | `POST /api/attempt` | Attempt recorded; next item pending | Active normal group | Feedback on current answer | Keep item visible with retry |
 | Active normal group | Last item answered | Submit answer | `POST /api/attempt` | Group completed | Group completed | Score, current misses, target sounds, next choices | Keep summary if follow-up load fails |
@@ -250,21 +250,30 @@ against the M7 v2 integration branch, not only route-mocked fixtures.
 GET /api/today
 ```
 
-创建或恢复当天的普通练习组。M7 起，Tiny IPA 将“每日练习”收窄为
-“当天可重复创建的 10 词 practice group”：
+查询 Today hub 状态，不创建新的普通练习组。M7 起，Tiny IPA 将“每日练习”
+收窄为“当天可重复创建的 practice group”，group creation 必须来自显式
+user command：
 
-- `session_id` 仍是 attempt 提交使用的持久 session id；
-- `group_id` 是 `session_id` 的语义别名，供 UI 用 group 语言表达；
-- `group_index` 是同一 `user_id`/`date`/`primary_accent` 下的递增序号；
+- active group response 中，`session_id` 仍是 attempt 提交使用的持久 session id；
+- active group response 中，`group_id` 是 `session_id` 的语义别名，供 UI 用
+  group 语言表达；
+- active group response 中，`group_index` 是同一
+  `user_id`/`date`/`primary_accent` 下的递增序号；
 - `group_type` 当前实现 `normal`、`mistake_review` 和 `weak_focus`，均复用
   同一 session_items/attempts/phoneme_stats 路径；
 - `learner_level` 和 `learner_level_label` 记录创建该 group 时使用的
   learner-facing level，active group 恢复时不随 settings 切换而改写；
-- `origin` 说明 action reason，例如 `normal_start`、`normal_resume`、
-  `normal_next`、`current_group_review_start`、`recent_review_start`、
-  `focus_start`、`focus_clear`；
-- `source_scope` 说明数据来源范围，例如 `normal_current`、`normal_next`、
-  `current_group`、`recent_global`、`focus_selection`；
+- `selected_learner_level` 和 `selected_learner_level_label` 记录 Settings
+  当前选择，用于 Today hub 说明“已选择的未来练习 level”；
+- `pending_level_change` 在 active normal group 的 level 与 Settings level
+  不一致时为 true；
+- `completed_normal_groups_today` 按 Entry/Mid/total 统计当天已完成的 normal
+  practice group，不包含 review/focus group；
+- `origin` 说明 action reason，例如 `normal_empty`、`normal_resume`、
+  `normal_next`、`normal_abandon_next`、`current_group_review_start`、
+  `recent_review_start`、`focus_start`、`focus_clear`；
+- `source_scope` 说明数据来源范围，例如 `normal_none`、`normal_current`、
+  `normal_next`、`current_group`、`recent_global`、`focus_selection`；
 - `source_group_id` 仅 current-group review 使用，指向被复习的 source group；
 - `focus_phonemes` 在 focus 影响选词或清除 focus 时返回；
 - `action_label` 是后端状态驱动的短文案提示，前端可按产品语气改写；
@@ -273,11 +282,36 @@ GET /api/today
 - `source_session_item_ids` 仅 review group 使用，用于追踪错题来源。
 
 重复调用 `GET /api/today` 时，如果存在当天同 accent 的 `normal`
-`in_progress` group，则恢复它；如果当天已有 completed normal group 且没有
-active normal group，则创建下一个 normal group。不同 group 共用
+`in_progress` group，则恢复它；如果没有 active normal group，则返回
+`status = "idle"`、`origin = "normal_empty"`、`source_scope = "normal_none"`、
+`items = []` 的 hub response，不写入 `daily_sessions`。不同 group 共用
 `session_items`、`attempts` 和 `phoneme_stats`，不引入第二套判题或统计来源。
 
-返回领域摘要，不返回原始调度内部状态：
+No-active hub response 示例：
+
+```json
+{
+  "group_type": "normal",
+  "learner_level": "entry",
+  "learner_level_label": "Entry",
+  "selected_learner_level": "entry",
+  "selected_learner_level_label": "Entry",
+  "pending_level_change": false,
+  "completed_normal_groups_today": {"entry": 0, "mid": 0, "total": 0},
+  "date": "2026-06-06",
+  "primary_accent": "US",
+  "origin": "normal_empty",
+  "source_scope": "normal_none",
+  "action_label": "Start Entry group",
+  "daily_word_count": 10,
+  "word_count": 0,
+  "status": "idle",
+  "source_session_item_ids": [],
+  "items": []
+}
+```
+
+Active group response 返回领域摘要，不返回原始调度内部状态：
 
 ```json
 {
@@ -287,11 +321,15 @@ active normal group，则创建下一个 normal group。不同 group 共用
   "group_type": "normal",
   "learner_level": "entry",
   "learner_level_label": "Entry",
+  "selected_learner_level": "entry",
+  "selected_learner_level_label": "Entry",
+  "pending_level_change": false,
+  "completed_normal_groups_today": {"entry": 0, "mid": 0, "total": 0},
   "date": "2026-06-06",
   "primary_accent": "US",
-  "origin": "normal_start",
+  "origin": "normal_next",
   "source_scope": "normal_current",
-  "action_label": "Start Group 1",
+  "action_label": "Start Entry Group 1",
   "daily_word_count": 10,
   "word_count": 10,
   "status": "in_progress",
@@ -323,11 +361,24 @@ active normal group，则创建下一个 normal group。不同 group 共用
 POST /api/practice/next-normal
 ```
 
-显式从完成摘要进入下一个 normal group。若当天已经有 active normal group，
-返回该 group 并标记 `origin = "normal_resume"`；否则创建递增
-`group_index` 的 normal group 并标记 `origin = "normal_next"`、
-`source_scope = "normal_next"`。该 endpoint 用于避免 UI 把“继续”误解为重复
-当前 group。
+显式从 Today hub 或完成摘要进入第一个/下一个 normal group。若当天已经有
+active normal group，返回该 group 并标记 `origin = "normal_resume"`；
+否则按 Settings 当前 `learner_level` 创建递增 `group_index` 的 normal group，
+并标记 `origin = "normal_next"`、`source_scope = "normal_next"`。该 endpoint
+用于避免 UI 把打开 Today 或“继续”误解为自动分配/重复当前 group。
+
+### Abandon current and start selected level
+
+```http
+POST /api/practice/abandon-current-and-next
+```
+
+显式结束当天 active normal group，并创建 Settings 当前 `learner_level` 对应的
+new normal group。旧 group 标记为 `status = "abandoned"`，保留已有 attempts，
+但不计入 completed normal group。该 endpoint 用于 Today hub 的 intentional
+restart / level-switch path，例如 `End this Entry group and start Mid`。
+
+如果没有 active normal group，该 endpoint 退化为 next normal group creation。
 
 ### Current-group review
 
@@ -445,6 +496,35 @@ GET /api/progress
   "today_completed": true,
   "streak_days": 5,
   "total_attempts": 120,
+  "total_sessions": 12,
+  "total_normal_groups": 9,
+  "stat_scope": "global",
+  "level_stats": {
+    "entry": {
+      "learner_level": "entry",
+      "label": "Entry",
+      "attempts": 60,
+      "correct_attempts": 44,
+      "accuracy": 0.73,
+      "normal_groups": 5,
+      "completed_normal_groups": 4,
+      "completed_normal_groups_today": 1,
+      "weak_phonemes": [],
+      "strong_phonemes": []
+    },
+    "mid": {
+      "learner_level": "mid",
+      "label": "Mid",
+      "attempts": 40,
+      "correct_attempts": 30,
+      "accuracy": 0.75,
+      "normal_groups": 4,
+      "completed_normal_groups": 3,
+      "completed_normal_groups_today": 0,
+      "weak_phonemes": [],
+      "strong_phonemes": []
+    }
+  },
   "weak_phonemes": [
     {"phoneme": "/ɪ/", "accuracy": 0.62, "attempt_count": 13}
   ],

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -68,12 +68,20 @@ export interface TodayItem {
 }
 
 export interface TodayResponse {
-  session_id: string;
+  session_id?: string;
   group_id?: string;
   group_index?: number;
   group_type?: string;
   learner_level?: "entry" | "mid";
   learner_level_label?: string;
+  selected_learner_level?: "entry" | "mid";
+  selected_learner_level_label?: string;
+  pending_level_change?: boolean;
+  completed_normal_groups_today?: {
+    entry: number;
+    mid: number;
+    total: number;
+  };
   origin?: string;
   source_scope?: string;
   source_group_id?: string;
@@ -101,6 +109,16 @@ export async function fetchToday(): Promise<TodayResponse> {
 
 export async function startNextNormalGroup(): Promise<TodayResponse> {
   const res = await fetch(`${API_BASE}/practice/next-normal`, {
+    method: "POST",
+  });
+  if (!res.ok) {
+    throw new Error(await normalizeApiError(res));
+  }
+  return res.json();
+}
+
+export async function abandonCurrentAndStartNext(): Promise<TodayResponse> {
+  const res = await fetch(`${API_BASE}/practice/abandon-current-and-next`, {
     method: "POST",
   });
   if (!res.ok) {
@@ -187,14 +205,30 @@ export interface PhonemeStat {
   mastery_status: string;
 }
 
+export interface LevelProgressStats {
+  learner_level: "entry" | "mid";
+  label: string;
+  attempts: number;
+  correct_attempts: number;
+  accuracy: number | null;
+  normal_groups: number;
+  completed_normal_groups: number;
+  completed_normal_groups_today: number;
+  weak_phonemes: PhonemeStat[];
+  strong_phonemes: PhonemeStat[];
+}
+
 export interface ProgressResponse {
   today_completed: boolean;
   today_status: string;
   streak_days: number;
   total_attempts: number;
   total_sessions: number;
+  total_normal_groups: number;
   weak_phonemes: PhonemeStat[];
   strong_phonemes: PhonemeStat[];
+  stat_scope?: "global";
+  level_stats?: Record<"entry" | "mid", LevelProgressStats>;
 }
 
 export async function fetchProgress(): Promise<ProgressResponse> {

--- a/frontend/src/pages/ProgressPage.tsx
+++ b/frontend/src/pages/ProgressPage.tsx
@@ -5,7 +5,12 @@
  */
 
 import { useEffect, useState } from "react";
-import type { ProgressResponse, SettingsData, TodayResponse } from "../api";
+import type {
+  LevelProgressStats,
+  ProgressResponse,
+  SettingsData,
+  TodayResponse,
+} from "../api";
 import {
   clearPracticeFocus,
   fetchProgress,
@@ -18,6 +23,66 @@ interface Props {
   focusPhonemes: string[];
   onFocusChange: (focusPhonemes: string[]) => void;
   onStartPractice: (session: TodayResponse) => void;
+}
+
+function formatAccuracy(value: number | null): string {
+  if (value === null) return "No attempts";
+  return `${Math.round(value * 100)}% accuracy`;
+}
+
+function LevelStatsSection({
+  stats,
+  onFocus,
+  activeFocus,
+  savingFocus,
+}: {
+  stats: LevelProgressStats;
+  onFocus: (phoneme: string) => void;
+  activeFocus: string[];
+  savingFocus: string | null;
+}) {
+  return (
+    <section className="level-progress-panel">
+      <div className="level-progress-header">
+        <h2>{stats.label} stats</h2>
+        <span className="level-scope-label">{stats.label}</span>
+      </div>
+      <div className="level-stat-grid">
+        <span>{stats.completed_normal_groups_today} completed today</span>
+        <span>{stats.normal_groups} normal groups</span>
+        <span>{stats.attempts} attempts</span>
+        <span>{formatAccuracy(stats.accuracy)}</span>
+      </div>
+      {stats.weak_phonemes.length > 0 ? (
+        <>
+          <h3>Needs practice in {stats.label}</h3>
+          <ul className="phoneme-list">
+            {stats.weak_phonemes.map((p) => (
+              <li key={`${stats.learner_level}-${p.phoneme}`} className="phoneme-item weak">
+                <span className="phoneme-symbol">{p.phoneme}</span>
+                <span className="phoneme-acc">
+                  {Math.round(p.accuracy * 100)}% accuracy
+                </span>
+                <span className="phoneme-count">{p.attempt_count} attempts</span>
+                <button
+                  className="focus-action-btn"
+                  onClick={() => onFocus(p.phoneme)}
+                  disabled={savingFocus !== null}
+                >
+                  {activeFocus.includes(p.phoneme) ? "Resume focus" : `Focus ${p.phoneme}`}
+                </button>
+                <span className="phoneme-help">
+                  Focused practice starts at the selected level in Settings.
+                </span>
+              </li>
+            ))}
+          </ul>
+        </>
+      ) : (
+        <p className="section-copy">No weak phoneme signal yet for {stats.label}.</p>
+      )}
+    </section>
+  );
 }
 
 export default function ProgressPage({
@@ -121,19 +186,37 @@ export default function ProgressPage({
         </div>
         <div className="stat-card">
           <span className="stat-number">{data.total_attempts}</span>
-          <span className="stat-label">attempts</span>
+          <span className="stat-label">global attempts</span>
         </div>
         <div className="stat-card">
-          <span className="stat-number">{data.total_sessions}</span>
-          <span className="stat-label">sessions</span>
+          <span className="stat-number">{data.total_normal_groups}</span>
+          <span className="stat-label">normal groups</span>
         </div>
       </div>
 
+      {data.level_stats && (
+        <div className="level-progress-list">
+          <LevelStatsSection
+            stats={data.level_stats.entry}
+            onFocus={focusOne}
+            activeFocus={activeFocus}
+            savingFocus={savingFocus}
+          />
+          <LevelStatsSection
+            stats={data.level_stats.mid}
+            onFocus={focusOne}
+            activeFocus={activeFocus}
+            savingFocus={savingFocus}
+          />
+        </div>
+      )}
+
       {data.weak_phonemes.length > 0 && (
         <section className="phoneme-section">
-          <h2>Needs practice</h2>
+          <h2>Global needs practice</h2>
           <p className="section-copy">
-            Start focused practice from a weak sound. No IPA typing needed.
+            All-level weak sounds from your complete history. Use the Entry/Mid
+            sections above when level context matters.
           </p>
           <ul className="phoneme-list">
             {data.weak_phonemes.map((p) => (
@@ -163,7 +246,7 @@ export default function ProgressPage({
 
       {data.strong_phonemes.length > 0 && (
         <section className="phoneme-section">
-          <h2>Strong</h2>
+          <h2>Global strong sounds</h2>
           <ul className="phoneme-list">
             {data.strong_phonemes.map((p) => (
               <li key={p.phoneme} className="phoneme-item strong">

--- a/frontend/src/pages/TodayPractice.tsx
+++ b/frontend/src/pages/TodayPractice.tsx
@@ -9,6 +9,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { SettingsData, TodayItem, TodayResponse } from "../api";
 import {
+  abandonCurrentAndStartNext,
   clearPracticeFocus,
   fetchSettings,
   fetchToday,
@@ -54,6 +55,11 @@ function learnerLevelLabel(session: TodayResponse): string {
   return session.learner_level_label ?? (session.learner_level === "mid" ? "Mid" : "Entry");
 }
 
+function selectedLevelLabel(session: TodayResponse): string {
+  return session.selected_learner_level_label
+    ?? (session.selected_learner_level === "mid" ? "Mid" : "Entry");
+}
+
 function groupReason(session: TodayResponse): string {
   if (session.group_type === "weak_focus") {
     const focus = session.focus_phonemes?.join(" ") || "selected sounds";
@@ -89,8 +95,18 @@ function currentReviewActionLabel(session: TodayResponse): string {
 }
 
 function nextNormalActionLabel(session: TodayResponse): string {
-  const level = learnerLevelLabel(session);
+  const level = selectedLevelLabel(session);
   return `Start next ${level} group`;
+}
+
+function resumeActionLabel(session: TodayResponse): string {
+  const level = learnerLevelLabel(session);
+  return `Resume ${level} group`;
+}
+
+function completedGroupsCopy(session: TodayResponse): string {
+  const counts = session.completed_normal_groups_today ?? { entry: 0, mid: 0, total: 0 };
+  return `${counts.total} normal groups completed today: Entry ${counts.entry}, Mid ${counts.mid}.`;
 }
 
 export default function TodayPractice({
@@ -111,9 +127,14 @@ export default function TodayPractice({
   const [finished, setFinished] = useState(() =>
     Boolean(initialSession && initialSession.items.length === 0),
   );
+  const [showHub, setShowHub] = useState(() => !initialSession);
   const [lastSummarySession, setLastSummarySession] = useState<TodayResponse | null>(null);
 
-  const resetPractice = useCallback((data: TodayResponse, settings?: SettingsData) => {
+  const resetPractice = useCallback((
+    data: TodayResponse,
+    settings?: SettingsData,
+    options: { showHub?: boolean } = {},
+  ) => {
     if (data.error) {
       setError(data.detail ?? data.error);
       return;
@@ -122,6 +143,7 @@ export default function TodayPractice({
     setCurrentIndex(0);
     setResults([]);
     setFinished(data.items.length === 0);
+    setShowHub(options.showHub ?? false);
     setLastSummarySession(null);
     setNotice(null);
     if (data.focus_phonemes) onFocusChange(data.focus_phonemes);
@@ -143,7 +165,7 @@ export default function TodayPractice({
       .then(([today, settings]) => {
         if (cancelled) return;
         setError(null);
-        resetPractice(today, settings);
+        resetPractice(today, settings, { showHub: true });
       })
       .catch((err) => {
         if (!cancelled) {
@@ -193,6 +215,28 @@ export default function TodayPractice({
       resetPractice(data);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to load another group");
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  const handleAbandonAndNext = async () => {
+    if (!session) return;
+    const isPending = Boolean(session.pending_level_change);
+    const ok = window.confirm(
+      isPending
+        ? `End this ${learnerLevelLabel(session)} group and start ${selectedLevelLabel(session)}?`
+        : `End this ${learnerLevelLabel(session)} group and start a fresh ${selectedLevelLabel(session)} group?`,
+    );
+    if (!ok) return;
+    setActionLoading("abandon-next");
+    setError(null);
+    try {
+      const data = await abandonCurrentAndStartNext();
+      resetPractice(data);
+      setNotice(data.detail ?? null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to switch groups");
     } finally {
       setActionLoading(null);
     }
@@ -256,7 +300,7 @@ export default function TodayPractice({
     try {
       const data = await clearPracticeFocus();
       onFocusChange([]);
-      resetPractice(data);
+      resetPractice(data, undefined, { showHub: true });
       setNotice("Focus cleared. Back to normal practice.");
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to clear focus");
@@ -301,6 +345,96 @@ export default function TodayPractice({
             is running.
           </p>
         </div>
+      </main>
+    );
+  }
+
+  if (showHub && session.group_type === "normal") {
+    const hasActiveGroup = Boolean(
+      session.group_id && session.items.length > 0 && session.status !== "idle",
+    );
+    const pendingLevelChange = hasActiveGroup && Boolean(session.pending_level_change);
+    return (
+      <main className="practice-container">
+        <section className="today-hub">
+          <p className="workflow-kicker">Today practice hub</p>
+          <h1>{selectedLevelLabel(session)} selected</h1>
+          <p className="section-copy">
+            {completedGroupsCopy(session)}
+          </p>
+
+          <div className={`hub-status-card ${pendingLevelChange ? "pending" : ""}`}>
+            {hasActiveGroup ? (
+              <>
+                <span className="focus-panel-label">Active group</span>
+                <strong>{learnerLevelLabel(session)} group in progress</strong>
+                <span>
+                  {session.word_count ?? session.items.length} words assigned · {session.primary_accent}
+                </span>
+                {pendingLevelChange && (
+                  <p className="pending-copy">
+                    You selected {selectedLevelLabel(session)}. This {learnerLevelLabel(session)} group is still in progress.
+                  </p>
+                )}
+              </>
+            ) : (
+              <>
+                <span className="focus-panel-label">No active group</span>
+                <strong>Ready to start {selectedLevelLabel(session)}</strong>
+                <span>
+                  {session.daily_word_count} words per normal group · {session.primary_accent}
+                </span>
+              </>
+            )}
+          </div>
+
+          {notice && <p className="empty-hint">{notice}</p>}
+          {error && <p className="save-error">{error}</p>}
+
+          <div className="summary-actions">
+            <button
+              className="primary-action-btn"
+              onClick={() => {
+                if (hasActiveGroup) {
+                  setShowHub(false);
+                  setNotice(null);
+                } else {
+                  void handleNextNormal();
+                }
+              }}
+              disabled={actionLoading !== null}
+            >
+              {actionLoading === "continue"
+                ? "Loading…"
+                : hasActiveGroup
+                  ? resumeActionLabel(session)
+                  : session.action_label ?? `Start ${selectedLevelLabel(session)} group`}
+            </button>
+            {hasActiveGroup && (
+              <button
+                className="secondary-action-btn"
+                onClick={() => void handleAbandonAndNext()}
+                disabled={actionLoading !== null}
+              >
+                {actionLoading === "abandon-next"
+                  ? "Loading…"
+                  : pendingLevelChange
+                    ? `End this ${learnerLevelLabel(session)} group and start ${selectedLevelLabel(session)}`
+                    : `End this group and start fresh ${selectedLevelLabel(session)}`}
+              </button>
+            )}
+            <button
+              className="secondary-action-btn"
+              onClick={handleRecentReview}
+              disabled={actionLoading !== null}
+            >
+              {actionLoading === "recent-review" ? "Loading…" : "Review recent mistakes"}
+            </button>
+            <button className="secondary-action-btn" onClick={onOpenProgress}>
+              View Progress
+            </button>
+          </div>
+        </section>
       </main>
     );
   }

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -420,6 +420,36 @@ button {
   padding: 10px;
 }
 
+.today-hub {
+  display: grid;
+  gap: 14px;
+}
+
+.today-hub h1 {
+  font-size: 1.5rem;
+  line-height: 1.2;
+}
+
+.hub-status-card,
+.level-progress-panel {
+  background: #f8fbff;
+  border: 1px solid #d6e4ff;
+  border-radius: 8px;
+  display: grid;
+  gap: 7px;
+  padding: 12px;
+}
+
+.hub-status-card.pending {
+  background: #fff7ed;
+  border-color: #ffcc80;
+}
+
+.pending-copy {
+  color: #92400e;
+  font-size: 0.9rem;
+}
+
 .active-focus-banner {
   font-size: 0.85rem;
 }
@@ -603,6 +633,46 @@ button {
   color: #999;
   font-size: 0.9rem;
   margin-top: 24px;
+}
+
+.level-progress-list {
+  display: grid;
+  gap: 12px;
+  margin-bottom: 20px;
+}
+
+.level-progress-header {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.level-progress-header h2 {
+  font-size: 1rem;
+}
+
+.level-scope-label {
+  background: #eef5fc;
+  border: 1px solid #d6e4ff;
+  border-radius: 4px;
+  color: #174ea6;
+  font-size: 0.75rem;
+  font-weight: 700;
+  padding: 2px 7px;
+}
+
+.level-stat-grid {
+  color: #555;
+  display: grid;
+  font-size: 0.85rem;
+  gap: 4px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.level-progress-panel h3 {
+  font-size: 0.9rem;
+  margin-top: 4px;
 }
 
 /* ---------------------------------------------------------------------------

--- a/frontend/tests/e2e/m7-walkthrough.spec.ts
+++ b/frontend/tests/e2e/m7-walkthrough.spec.ts
@@ -148,6 +148,14 @@ function toTodayResponse(group: MockGroup) {
     group_type: group.group_type,
     learner_level: "entry",
     learner_level_label: "Entry",
+    selected_learner_level: "entry",
+    selected_learner_level_label: "Entry",
+    pending_level_change: false,
+    completed_normal_groups_today: {
+      entry: stateCompletedCount(group.group_id),
+      mid: 0,
+      total: stateCompletedCount(group.group_id),
+    },
     date: "2026-06-17",
     primary_accent: group.primary_accent,
     origin:
@@ -184,6 +192,37 @@ function toTodayResponse(group: MockGroup) {
   };
 }
 
+function noActiveTodayResponse() {
+  return {
+    group_type: "normal",
+    learner_level: "entry",
+    learner_level_label: "Entry",
+    selected_learner_level: "entry",
+    selected_learner_level_label: "Entry",
+    pending_level_change: false,
+    completed_normal_groups_today: {
+      entry: 0,
+      mid: 0,
+      total: 0,
+    },
+    date: "2026-06-17",
+    primary_accent: "US",
+    origin: "normal_empty",
+    source_scope: "normal_none",
+    focus_phonemes: [],
+    action_label: "Start Entry group",
+    daily_word_count: groups.group1.items.length,
+    word_count: 0,
+    status: "idle",
+    source_session_item_ids: [],
+    items: [],
+  };
+}
+
+function stateCompletedCount(groupId: string) {
+  return groupId === "group-2" ? 1 : 0;
+}
+
 function settingsResponse(state: MockState) {
   return {
     primary_accent: "US",
@@ -204,6 +243,42 @@ function progressResponse() {
     streak_days: 2,
     total_attempts: 8,
     total_sessions: 2,
+    total_normal_groups: 2,
+    stat_scope: "global",
+    level_stats: {
+      entry: {
+        learner_level: "entry",
+        label: "Entry",
+        attempts: 8,
+        correct_attempts: 4,
+        accuracy: 0.5,
+        normal_groups: 2,
+        completed_normal_groups: 1,
+        completed_normal_groups_today: 1,
+        weak_phonemes: [
+          {
+            phoneme: "/ʃ/",
+            accuracy: 0.25,
+            attempt_count: 4,
+            correct_count: 1,
+            mastery_status: "weak",
+          },
+        ],
+        strong_phonemes: [],
+      },
+      mid: {
+        learner_level: "mid",
+        label: "Mid",
+        attempts: 0,
+        correct_attempts: 0,
+        accuracy: null,
+        normal_groups: 0,
+        completed_normal_groups: 0,
+        completed_normal_groups_today: 0,
+        weak_phonemes: [],
+        strong_phonemes: [],
+      },
+    },
     weak_phonemes: [
       {
         phoneme: "/ʃ/",
@@ -281,14 +356,16 @@ async function routeMock(route: Route, state: MockState) {
     }
     if (state.completedGroups.has("group1")) {
       state.activeGroup = "group2";
+      await route.fulfill({ json: toTodayResponse(groups[state.activeGroup]) });
+      return;
     }
-    await route.fulfill({ json: toTodayResponse(groups[state.activeGroup]) });
+    await route.fulfill({ json: noActiveTodayResponse() });
     return;
   }
 
   if (path === "/practice/next-normal") {
-    state.activeGroup = "group2";
-    await route.fulfill({ json: toTodayResponse(groups.group2) });
+    state.activeGroup = state.completedGroups.has("group1") ? "group2" : "group1";
+    await route.fulfill({ json: toTodayResponse(groups[state.activeGroup]) });
     return;
   }
 
@@ -375,6 +452,9 @@ async function routeMock(route: Route, state: MockState) {
 
 async function openWalkthrough(page: Page) {
   await page.goto("/");
+  await expect(page.getByText("Today practice hub")).toBeVisible();
+  await expect(page.getByText("No active group")).toBeVisible();
+  await page.getByRole("button", { name: "Start Entry group" }).click();
   await expect(page.getByText("Practice group: 1 / 2")).toBeVisible();
 }
 
@@ -387,7 +467,9 @@ async function completeFirstGroupWithOneMiss(page: Page) {
   await expect(page.getByText("Not quite")).toBeVisible();
   await expect(page.getByText("Target sound")).toBeVisible();
   await page.getByText("Focus on /ʃ/ before choosing.").waitFor();
-  await expect(page.getByText("thin")).toBeVisible({ timeout: 4_000 });
+  await expect(page.getByRole("button", { name: "Select /θɪn/" })).toBeVisible({
+    timeout: 6_000,
+  });
 
   await answerVisibleItem(page, "/θɪn/");
   await expect(page.getByRole("heading", { name: "Practice group complete" })).toBeVisible({
@@ -467,8 +549,9 @@ test.describe("M7 v2 learner workflow walkthrough", () => {
     await openWalkthrough(page);
     await page.getByRole("button", { name: "Progress" }).click();
     await expect(page.getByRole("heading", { name: "Progress" })).toBeVisible();
-    await expect(page.getByText("Start focused practice from a weak sound.")).toBeVisible();
-    await page.getByRole("button", { name: "Focus /ʃ/" }).click();
+    await expect(page.getByRole("heading", { name: "Needs practice in Entry" })).toBeVisible();
+    await expect(page.getByText("Focused practice starts at the selected level in Settings.")).toBeVisible();
+    await page.getByRole("button", { name: "Focus /ʃ/" }).first().click();
 
     await expect(page.getByText("Focused group: 1 / 1")).toBeVisible();
     await expect(page.getByText(/Group 8/)).toHaveCount(0);
@@ -491,7 +574,8 @@ test.describe("M7 v2 learner workflow walkthrough", () => {
     await page.getByRole("button", { name: "Return to Progress" }).click();
 
     await expect(page.getByRole("heading", { name: "Progress" })).toBeVisible();
-    await expect(page.getByText("Needs practice")).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Needs practice in Entry" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Global needs practice" })).toBeVisible();
     await expect(page.getByRole("button", { name: "Today", exact: true })).toBeVisible();
   });
 

--- a/frontend/tests/e2e/m8-level-selection.spec.ts
+++ b/frontend/tests/e2e/m8-level-selection.spec.ts
@@ -3,7 +3,9 @@ import { expect, type Page, type Route, test } from "@playwright/test";
 type LearnerLevel = "entry" | "mid";
 
 interface MockState {
-  learnerLevel: LearnerLevel;
+  selectedLevel: LearnerLevel;
+  activeLevel: LearnerLevel | null;
+  completed: Record<LearnerLevel, number>;
 }
 
 const items = {
@@ -31,15 +33,50 @@ function levelLabel(level: LearnerLevel) {
   return level === "mid" ? "Mid" : "Entry";
 }
 
-function todayResponse(level: LearnerLevel) {
-  const item = items[level];
+function todayResponse(state: MockState) {
+  if (state.activeLevel === null) {
+    return {
+      group_type: "normal",
+      learner_level: state.selectedLevel,
+      learner_level_label: levelLabel(state.selectedLevel),
+      selected_learner_level: state.selectedLevel,
+      selected_learner_level_label: levelLabel(state.selectedLevel),
+      pending_level_change: false,
+      completed_normal_groups_today: {
+        entry: state.completed.entry,
+        mid: state.completed.mid,
+        total: state.completed.entry + state.completed.mid,
+      },
+      date: "2026-06-18",
+      primary_accent: "US",
+      origin: "normal_empty",
+      source_scope: "normal_none",
+      focus_phonemes: [],
+      action_label: `Start ${levelLabel(state.selectedLevel)} group`,
+      daily_word_count: 1,
+      word_count: 0,
+      status: "idle",
+      source_session_item_ids: [],
+      items: [],
+    };
+  }
+  const item = items[state.activeLevel];
+  const pending = state.selectedLevel !== state.activeLevel;
   return {
-    session_id: `${level}-session-1`,
-    group_id: `${level}-group-1`,
+    session_id: `${state.activeLevel}-session-1`,
+    group_id: `${state.activeLevel}-group-1`,
     group_index: 1,
     group_type: "normal",
-    learner_level: level,
-    learner_level_label: levelLabel(level),
+    learner_level: state.activeLevel,
+    learner_level_label: levelLabel(state.activeLevel),
+    selected_learner_level: state.selectedLevel,
+    selected_learner_level_label: levelLabel(state.selectedLevel),
+    pending_level_change: pending,
+    completed_normal_groups_today: {
+      entry: state.completed.entry,
+      mid: state.completed.mid,
+      total: state.completed.entry + state.completed.mid,
+    },
     date: "2026-06-18",
     primary_accent: "US",
     origin: "normal_start",
@@ -71,13 +108,17 @@ function settingsResponse(state: MockState) {
     show_accent_compare: false,
     practice_mode: "ipa_first",
     review_strength: "normal",
-    learner_level: state.learnerLevel,
+    learner_level: state.selectedLevel,
     focus_phonemes: [],
   };
 }
 
 async function setupMockApi(page: Page): Promise<MockState> {
-  const state: MockState = { learnerLevel: "entry" };
+  const state: MockState = {
+    selectedLevel: "entry",
+    activeLevel: null,
+    completed: { entry: 0, mid: 0 },
+  };
   await page.route("**/api/**", async (route) => {
     await routeMock(route, state);
   });
@@ -99,7 +140,7 @@ async function routeMock(route: Route, state: MockState) {
     if (request.method() === "PUT") {
       const body = request.postDataJSON() as { learner_level?: LearnerLevel };
       if (body.learner_level === "entry" || body.learner_level === "mid") {
-        state.learnerLevel = body.learner_level;
+        state.selectedLevel = body.learner_level;
       }
     }
     await route.fulfill({ json: settingsResponse(state) });
@@ -107,7 +148,33 @@ async function routeMock(route: Route, state: MockState) {
   }
 
   if (path === "/today") {
-    await route.fulfill({ json: todayResponse(state.learnerLevel) });
+    await route.fulfill({ json: todayResponse(state) });
+    return;
+  }
+
+  if (path === "/practice/next-normal") {
+    state.activeLevel = state.selectedLevel;
+    await route.fulfill({
+      json: {
+        ...todayResponse(state),
+        origin: "normal_next",
+        source_scope: "normal_next",
+      },
+    });
+    return;
+  }
+
+  if (path === "/practice/abandon-current-and-next") {
+    state.activeLevel = state.selectedLevel;
+    await route.fulfill({
+      json: {
+        ...todayResponse(state),
+        origin: "normal_abandon_next",
+        source_scope: "normal_next",
+        abandoned_group_id: "entry-session-1",
+        detail: "Ended Entry Group 1 and started Mid Group 1.",
+      },
+    });
     return;
   }
 
@@ -117,8 +184,52 @@ async function routeMock(route: Route, state: MockState) {
         today_completed: false,
         today_status: "active",
         streak_days: 0,
-        total_attempts: 0,
-        total_sessions: 0,
+        total_attempts: 6,
+        total_sessions: 2,
+        total_normal_groups: 2,
+        stat_scope: "global",
+        level_stats: {
+          entry: {
+            learner_level: "entry",
+            label: "Entry",
+            attempts: 3,
+            correct_attempts: 1,
+            accuracy: 0.33,
+            normal_groups: 1,
+            completed_normal_groups: state.completed.entry,
+            completed_normal_groups_today: state.completed.entry,
+            weak_phonemes: [
+              {
+                phoneme: "/ʃ/",
+                accuracy: 0.33,
+                attempt_count: 3,
+                correct_count: 1,
+                mastery_status: "weak",
+              },
+            ],
+            strong_phonemes: [],
+          },
+          mid: {
+            learner_level: "mid",
+            label: "Mid",
+            attempts: 3,
+            correct_attempts: 3,
+            accuracy: 1,
+            normal_groups: 1,
+            completed_normal_groups: state.completed.mid,
+            completed_normal_groups_today: state.completed.mid,
+            weak_phonemes: [],
+            strong_phonemes: [
+              {
+                phoneme: "/r/",
+                accuracy: 1,
+                attempt_count: 3,
+                correct_count: 3,
+                mastery_status: "learning",
+              },
+            ],
+          },
+        },
         weak_phonemes: [],
         strong_phonemes: [],
       },
@@ -130,15 +241,18 @@ async function routeMock(route: Route, state: MockState) {
 }
 
 test.describe("M8 learner level selection walkthrough", () => {
-  test("Entry is default and Mid switching is visible in Settings and Today", async ({ page }) => {
+  test("Entry-to-Mid lifecycle is explicit from Today hub through Progress stats", async ({ page }) => {
     await setupMockApi(page);
 
-    await test.step("Entry default practice context", async () => {
+    await test.step("Entry default hub context", async () => {
       await page.goto("/");
+      await expect(page.getByText("Today practice hub")).toBeVisible();
+      await expect(page.getByRole("heading", { name: "Entry selected" })).toBeVisible();
+      await expect(page.getByText("0 normal groups completed today: Entry 0, Mid 0.")).toBeVisible();
+      await expect(page.getByText("No active group")).toBeVisible();
+      await page.getByRole("button", { name: "Start Entry group" }).click();
       await expect(page.getByText("Practice group: 1 / 1")).toBeVisible();
-      await expect(page.getByText("Entry practice group.")).toBeVisible();
       await expect(page.getByText("ship")).toBeVisible();
-      await expect(page.getByText("Mid")).toHaveCount(0);
     });
 
     await test.step("Settings exposes learner-facing level choices", async () => {
@@ -151,12 +265,26 @@ test.describe("M8 learner level selection walkthrough", () => {
       await expect(page.getByText(/core_1000_words|core_300_words/i)).toHaveCount(0);
     });
 
-    await test.step("Mid practice uses the Mid pool and visible context", async () => {
+    await test.step("Today explains pending level change and intentional switch", async () => {
       await page.getByRole("button", { name: "Today", exact: true }).click();
+      await expect(page.getByText("Today practice hub")).toBeVisible();
+      await expect(page.getByRole("heading", { name: "Mid selected" })).toBeVisible();
+      await expect(page.getByText("You selected Mid. This Entry group is still in progress.")).toBeVisible();
+      await expect(page.getByRole("button", { name: "Resume Entry group" })).toBeVisible();
+      page.once("dialog", (dialog) => dialog.accept());
+      await page.getByRole("button", { name: "End this Entry group and start Mid" }).click();
       await expect(page.getByText("Practice group: 1 / 1")).toBeVisible();
       await expect(page.getByText("Mid practice group.")).toBeVisible();
       await expect(page.getByText("remember")).toBeVisible();
       await expect(page.getByText("ship")).toHaveCount(0);
+    });
+
+    await test.step("Progress distinguishes Entry and Mid statistics", async () => {
+      await page.getByRole("button", { name: "Progress" }).click();
+      await expect(page.getByRole("heading", { name: "Progress" })).toBeVisible();
+      await expect(page.getByRole("heading", { name: "Entry stats" })).toBeVisible();
+      await expect(page.getByRole("heading", { name: "Mid stats" })).toBeVisible();
+      await expect(page.getByText("Global needs practice")).toHaveCount(0);
       const screenshotPath = test.info().outputPath("m8-mid-level-mobile.png");
       await page.screenshot({ fullPage: true, path: screenshotPath });
       await test.info().attach("m8-mid-level-mobile", {


### PR DESCRIPTION
## Scope completed

Covers #166 and #167 for the M8 v2 workflow/stats batch.

- #166: Reworked Today into a practice hub with selected level, active group state, pending level change copy, completed normal groups today, explicit resume/start actions, and explicit abandon-and-start behavior for same-level restart or Entry -> Mid switching.
- #166: Changed `GET /api/today` to query-only hub behavior. With no active normal group it now returns `status: idle`, `origin: normal_empty`, `source_scope: normal_none`, and does not create a `daily_sessions` row. Normal group creation now happens through the explicit `POST /api/practice/next-normal` command, while abandon-and-start creates the selected-level group directly.
- #167: Added Entry/Mid scoped progress stats while keeping global stats explicitly labeled. Normal group/completion counts exclude review/focus sessions.
- Updated API contract docs and M7/M8 route-mocked walkthrough coverage for the new explicit first-start, resume, pending level switch, abandon/start, and Entry/Mid progress paths.

## Verification

- `uv run --project backend pytest backend/tests/test_today_persistence.py backend/tests/test_progress_api.py` -> 49 passed, 1 existing Starlette warning
- `uv run --project backend pytest` -> 189 passed, 1 existing Starlette warning
- `cd frontend && pnpm exec tsc --noEmit` -> passed
- `cd frontend && pnpm run lint` -> passed
- `cd frontend && pnpm run build` -> passed
- `cd frontend && pnpm test:e2e:m7` -> 7 passed
- `cd frontend && pnpm test:e2e:m8` -> 1 passed
- `git diff --check` -> passed
- `tools/agents/agent-audit` -> clean

## Walkthrough evidence

- M8 route-mocked mobile walkthrough now covers first visit no-active hub -> `Start Entry group` -> Settings Mid selection -> Today pending Entry/Mid state -> `Resume Entry group` visibility -> explicit `End this Entry group and start Mid` -> Mid practice -> Entry/Mid Progress stats.
- M7 route-mocked mobile walkthrough still passes after the no-active hub change.

## Residual risks

- #168 remains the real imported Entry+Mid browser walkthrough acceptance gate; this PR updates route-mocked/product-contract coverage only.
- Mid content readiness risks remain unchanged: placeholder Chinese meanings, UK IPA/tag warnings, and missing Mid audio are still content/readiness gates outside #166/#167.
- No final `main` integration, #108 closure, or #128 readiness closure is included.