### PR TITLE
Add M10 UX walkthrough evidence harness

### DIFF
--- a/docs/10-ux-research-and-optimization.md
+++ b/docs/10-ux-research-and-optimization.md
@@ -208,6 +208,42 @@ failure states covered
 
 If the flow cannot be automated yet, record the manual path and the reason automation is deferred.
 
+## Repeatable M10 Walkthrough Harness
+
+Issue #176 adds a repeatable browser harness for M10 UX observations:
+
+```bash
+cd frontend
+pnpm test:e2e:m10
+```
+
+The harness runs desktop Chromium and Pixel 5 Chromium projects with disposable route-mocked API data. It does not connect to the local backend and does not mutate `backend/tiny_ipa.sqlite`.
+
+Evidence output:
+
+```text
+frontend/test-results/m10-walkthrough/
+frontend/playwright-report/m10/
+```
+
+Scenario matrix:
+
+| Flow | Viewport | Seed state | Entry URL | Expected visible copy | Expected actions | Hidden or blocked actions | Evidence |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Today start | desktop and mobile | no active group; Entry selected; no completed groups | `/` | `Today practice hub`, `Entry selected`, `No active group` | `Start Entry group`, `Review recent mistakes`, `View Progress` | no practice question before start | `m10-today-start` screenshot attachment |
+| Wrong answer feedback | desktop and mobile | Entry group with `ship` then `thin`; first answer deliberately wrong | `/` then `Start Entry group` | `Not quite`, `You picked`, `Correct IPA`, `Target sound` | IPA choices remain visible until auto-advance | current-group review is unavailable before summary | `m10-wrong-answer-feedback` screenshot attachment |
+| Completion recovery | desktop and mobile | Entry group completed with one miss | same session | `Practice group complete`, `Misses from this group` | `Review misses from this group`, `Review recent mistakes`, `Start next Entry group`, `Return to Progress` | no current-review action when no miss exists in later review summary | `m10-completion-recovery-actions` screenshot attachment |
+| Current-group review | desktop and mobile | source group has one missed item | summary action | `Current-group review: 1 / 1`, `Reviewing misses from the group you just finished.` | answer review item | raw group ids are not exposed | `m10-current-group-review` screenshot attachment |
+| Recent mistake review | desktop and mobile | recent review source has one item | summary action | `Recent mistake review: 1 / 1`, `Reviewing recent mistakes from earlier practice.` | answer review item | current-group source copy is not reused | `m10-recent-review` screenshot attachment |
+| Progress focus entry | desktop and mobile | Entry weak phoneme `/ʃ/` | Progress tab | `Progress`, `Needs practice in Entry`, `day streak` | `Focus /ʃ/`, `Clear focus` after focused practice starts | manual IPA entry is not required | `m10-progress-focus-entry` screenshot attachment |
+| Settings level switch | desktop and mobile | active Entry group; selected level changes to Mid | Settings tab | `Saved`, `Mid selected`, `You selected Mid. This Entry group is still in progress.` | `Resume Entry group`, `End this Entry group and start Mid` | Mid content does not replace the active Entry group without explicit action | `m10-settings-mid-pending` screenshot attachment |
+| Mid transition | desktop and mobile | active Entry group; Mid selected; confirmation accepted | Today hub action | `Practice group: 1 / 1`, `Mid practice group.`, `remember` | answer Mid item | old Entry item is no longer shown after the intentional switch | `m10-mid-active` screenshot attachment |
+| Recent-review empty state | desktop and mobile | no active group; Mid selected; recent-review queue empty | Today hub | `No recent incorrect attempts are available for review.` | `Start Mid group` remains available | empty review does not replace the hub with a fatal error | `m10-recent-review-empty` screenshot attachment |
+| Audio confidence signal | desktop and mobile | first Entry item has no static audio URL | active Entry group | audio button exposes `Play pronunciation (TTS)` | TTS-labeled audio button is visible | static-audio-only assumption is not required | covered in wrong-answer flow |
+| Mobile Today and Settings | Pixel 5 Chromium | same mocked learner states as above | `/` and Settings tab | hub/settings copy remains visible; `Advanced/debug: manual IPA focus entry` remains observable | same actions as desktop | mobile does not hide core actions | `m10-mobile-today`, `m10-mobile-settings` screenshot attachments |
+
+The M10 harness is a workflow-evidence harness, not a production API contract test. Backend scheduling, persistence, and import behavior remain covered by backend tests and by the live manual audit path recorded on #174.
+
 ## M10 Child Issue Pattern
 
 Each M10 child issue should include:

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -14,6 +14,16 @@ The harness uses `@playwright/test`, Chromium, a mobile viewport, and route-mock
 
 Some contract assertions are marked as expected failures until the later M7 v2 implementation issues add the scoped next-group, current-group review, recent-review, and focused-practice behavior. Tooling/bootstrap failures are still surfaced by the passing smoke and summary tests.
 
+## M10 UX Walkthrough
+
+Run the M10 UX evidence harness from this directory:
+
+```bash
+pnpm test:e2e:m10
+```
+
+The harness uses desktop and Pixel 5 Chromium projects with route-mocked disposable API data. It preserves the #174 audit scenarios as repeatable evidence: Today start, wrong-answer feedback, current-group review, recent mistakes, Entry/Mid switching, Progress focus entry, Settings changes, audio/TTS visible status, mobile Today, and mobile Settings. It does not connect to the local backend or mutate `backend/tiny_ipa.sqlite`. Screenshots are attached to Playwright test results under `test-results/m10-walkthrough`; the HTML report is written under `playwright-report/m10`.
+
 Currently, two official plugins are available:
 
 - [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Oxc](https://oxc.rs)

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "test:e2e:m7": "playwright test -c playwright.m7.config.ts tests/e2e/m7-walkthrough.spec.ts",
-    "test:e2e:m8": "playwright test -c playwright.m7.config.ts tests/e2e/m8-level-selection.spec.ts"
+    "test:e2e:m8": "playwright test -c playwright.m7.config.ts tests/e2e/m8-level-selection.spec.ts",
+    "test:e2e:m10": "playwright test -c playwright.m10.config.ts tests/e2e/m10-ux-walkthrough.spec.ts"
   },
   "dependencies": {
     "react": "^19.2.6",

--- a/frontend/playwright.m10.config.ts
+++ b/frontend/playwright.m10.config.ts
@@ -1,0 +1,39 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const port = process.env.M10_WALKTHROUGH_PORT ?? "5180";
+const baseURL = `http://127.0.0.1:${port}`;
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  outputDir: "./test-results/m10-walkthrough",
+  reporter: [["list"], ["html", { open: "never", outputFolder: "playwright-report/m10" }]],
+  fullyParallel: false,
+  use: {
+    baseURL,
+    screenshot: "only-on-failure",
+    trace: "retain-on-failure",
+    video: "retain-on-failure",
+  },
+  projects: [
+    {
+      name: "m10-desktop-chromium",
+      use: {
+        ...devices["Desktop Chrome"],
+        viewport: { width: 1280, height: 900 },
+      },
+    },
+    {
+      name: "m10-mobile-chromium",
+      use: {
+        ...devices["Pixel 5"],
+        browserName: "chromium",
+      },
+    },
+  ],
+  webServer: {
+    command: `pnpm exec vite --host 127.0.0.1 --port ${port} --strictPort`,
+    url: baseURL,
+    reuseExistingServer: false,
+    timeout: 120_000,
+  },
+});

--- a/frontend/tests/e2e/m10-ux-walkthrough.spec.ts
+++ b/frontend/tests/e2e/m10-ux-walkthrough.spec.ts
@@ -1,0 +1,537 @@
+import { expect, type Page, type Route, test } from "@playwright/test";
+
+type LearnerLevel = "entry" | "mid";
+type GroupKey = "none" | "entry" | "mid" | "currentReview" | "recentReview" | "focused";
+type GroupType = "normal" | "mistake_review" | "weak_focus";
+
+interface MockItem {
+  session_item_id: string;
+  word_id: string;
+  display_ipa: string;
+  word: string;
+  meaning_zh: string | null;
+  target_phonemes: string[];
+  choices: string[];
+  audio_url: string | null;
+}
+
+interface MockState {
+  selectedLevel: LearnerLevel;
+  activeGroup: GroupKey;
+  completed: Record<LearnerLevel, number>;
+  focusPhonemes: string[];
+  recentReviewEmpty: boolean;
+}
+
+const items: Record<Exclude<GroupKey, "none">, MockItem[]> = {
+  entry: [
+    {
+      session_item_id: "entry-ship",
+      word_id: "ship",
+      display_ipa: "/ʃɪp/",
+      word: "ship",
+      meaning_zh: "船",
+      target_phonemes: ["/ʃ/"],
+      choices: ["/sɪp/", "/ʃɪp/"],
+      audio_url: null,
+    },
+    {
+      session_item_id: "entry-thin",
+      word_id: "thin",
+      display_ipa: "/θɪn/",
+      word: "thin",
+      meaning_zh: "薄的",
+      target_phonemes: ["/θ/"],
+      choices: ["/θɪn/", "/sɪn/"],
+      audio_url: "/audio/us/thin.mp3",
+    },
+  ],
+  mid: [
+    {
+      session_item_id: "mid-remember",
+      word_id: "remember",
+      display_ipa: "/rɪˈmembɚ/",
+      word: "remember",
+      meaning_zh: "记得",
+      target_phonemes: ["/r/", "/ɚ/"],
+      choices: ["/rɪˈmembɚ/", "/rɪˈmembə/"],
+      audio_url: "/audio/us/remember.mp3",
+    },
+  ],
+  currentReview: [
+    {
+      session_item_id: "review-current-ship",
+      word_id: "ship",
+      display_ipa: "/ʃɪp/",
+      word: "ship",
+      meaning_zh: "船",
+      target_phonemes: ["/ʃ/"],
+      choices: ["/sɪp/", "/ʃɪp/"],
+      audio_url: null,
+    },
+  ],
+  recentReview: [
+    {
+      session_item_id: "review-recent-thin",
+      word_id: "thin",
+      display_ipa: "/θɪn/",
+      word: "thin",
+      meaning_zh: "薄的",
+      target_phonemes: ["/θ/"],
+      choices: ["/θɪn/", "/sɪn/"],
+      audio_url: "/audio/us/thin.mp3",
+    },
+  ],
+  focused: [
+    {
+      session_item_id: "focus-ship",
+      word_id: "ship",
+      display_ipa: "/ʃɪp/",
+      word: "ship",
+      meaning_zh: "船",
+      target_phonemes: ["/ʃ/"],
+      choices: ["/sɪp/", "/ʃɪp/"],
+      audio_url: null,
+    },
+  ],
+};
+
+function levelLabel(level: LearnerLevel) {
+  return level === "mid" ? "Mid" : "Entry";
+}
+
+function groupLevel(group: GroupKey): LearnerLevel {
+  return group === "mid" ? "mid" : "entry";
+}
+
+function groupType(group: GroupKey): GroupType {
+  if (group === "currentReview" || group === "recentReview") return "mistake_review";
+  if (group === "focused") return "weak_focus";
+  return "normal";
+}
+
+function todayResponse(state: MockState) {
+  if (state.activeGroup === "none") {
+    return {
+      group_type: "normal",
+      learner_level: state.selectedLevel,
+      learner_level_label: levelLabel(state.selectedLevel),
+      selected_learner_level: state.selectedLevel,
+      selected_learner_level_label: levelLabel(state.selectedLevel),
+      pending_level_change: false,
+      completed_normal_groups_today: {
+        entry: state.completed.entry,
+        mid: state.completed.mid,
+        total: state.completed.entry + state.completed.mid,
+      },
+      date: "2026-06-18",
+      primary_accent: "US",
+      origin: "normal_empty",
+      source_scope: "normal_none",
+      focus_phonemes: state.focusPhonemes,
+      action_label: `Start ${levelLabel(state.selectedLevel)} group`,
+      daily_word_count: 2,
+      word_count: 0,
+      status: "idle",
+      source_session_item_ids: [],
+      items: [],
+    };
+  }
+
+  const level = groupLevel(state.activeGroup);
+  const review = state.activeGroup === "currentReview" || state.activeGroup === "recentReview";
+  const focus = state.activeGroup === "focused";
+  return {
+    session_id: `${state.activeGroup}-session`,
+    group_id: `${state.activeGroup}-group`,
+    group_index: state.activeGroup === "mid" ? 2 : 1,
+    group_type: groupType(state.activeGroup),
+    learner_level: level,
+    learner_level_label: levelLabel(level),
+    selected_learner_level: state.selectedLevel,
+    selected_learner_level_label: levelLabel(state.selectedLevel),
+    pending_level_change: !review && !focus && state.selectedLevel !== level,
+    completed_normal_groups_today: {
+      entry: state.completed.entry,
+      mid: state.completed.mid,
+      total: state.completed.entry + state.completed.mid,
+    },
+    date: "2026-06-18",
+    primary_accent: "US",
+    origin: focus ? "focus_start" : review ? "current_group_review_start" : "normal_start",
+    source_scope:
+      state.activeGroup === "currentReview"
+        ? "current_group"
+        : state.activeGroup === "recentReview"
+          ? "recent_global"
+          : focus
+            ? "focus_selection"
+            : "normal_current",
+    source_group_id: review ? "entry-group" : undefined,
+    focus_phonemes: focus ? state.focusPhonemes : [],
+    daily_word_count: items[state.activeGroup].length,
+    word_count: items[state.activeGroup].length,
+    status: "active",
+    source_session_item_ids: review ? ["entry-ship"] : [],
+    source_count: review ? 1 : 0,
+    items: items[state.activeGroup].map((item) => ({
+      session_item_id: item.session_item_id,
+      word_id: item.word_id,
+      display_ipa: item.display_ipa,
+      word: item.word,
+      meaning_zh: item.meaning_zh,
+      audio_url: item.audio_url,
+      target_phonemes: item.target_phonemes,
+      question: {
+        type: "ipa_choice",
+        prompt: "Which IPA matches this word?",
+        choices: item.choices,
+      },
+    })),
+  };
+}
+
+function settingsResponse(state: MockState) {
+  return {
+    primary_accent: "US",
+    daily_word_count: 2,
+    show_translation: true,
+    show_accent_compare: false,
+    practice_mode: "ipa_first",
+    review_strength: "normal",
+    learner_level: state.selectedLevel,
+    focus_phonemes: state.focusPhonemes,
+  };
+}
+
+function progressResponse(state: MockState) {
+  return {
+    today_completed: false,
+    today_status: state.activeGroup === "none" ? "none" : "in_progress",
+    streak_days: state.completed.entry > 0 ? 0 : 0,
+    total_attempts: state.completed.entry > 0 ? 2 : 0,
+    total_sessions: state.completed.entry + state.completed.mid,
+    total_normal_groups: state.completed.entry + state.completed.mid + (state.activeGroup === "mid" ? 1 : 0),
+    stat_scope: "global",
+    level_stats: {
+      entry: {
+        learner_level: "entry",
+        label: "Entry",
+        attempts: state.completed.entry > 0 ? 2 : 0,
+        correct_attempts: state.completed.entry > 0 ? 1 : 0,
+        accuracy: state.completed.entry > 0 ? 0.5 : null,
+        normal_groups: state.completed.entry,
+        completed_normal_groups: state.completed.entry,
+        completed_normal_groups_today: state.completed.entry,
+        weak_phonemes: [
+          {
+            phoneme: "/ʃ/",
+            accuracy: 0.5,
+            attempt_count: 2,
+            correct_count: 1,
+            mastery_status: "weak",
+          },
+        ],
+        strong_phonemes: [],
+      },
+      mid: {
+        learner_level: "mid",
+        label: "Mid",
+        attempts: 0,
+        correct_attempts: 0,
+        accuracy: null,
+        normal_groups: state.activeGroup === "mid" ? 1 : 0,
+        completed_normal_groups: state.completed.mid,
+        completed_normal_groups_today: state.completed.mid,
+        weak_phonemes: [],
+        strong_phonemes: [],
+      },
+    },
+    weak_phonemes: [
+      {
+        phoneme: "/ʃ/",
+        accuracy: 0.5,
+        attempt_count: 2,
+        correct_count: 1,
+        mastery_status: "weak",
+      },
+    ],
+    strong_phonemes: [],
+  };
+}
+
+async function setupM10Api(page: Page, options: Partial<MockState> = {}) {
+  const state: MockState = {
+    selectedLevel: options.selectedLevel ?? "entry",
+    activeGroup: options.activeGroup ?? "none",
+    completed: options.completed ?? { entry: 0, mid: 0 },
+    focusPhonemes: options.focusPhonemes ?? [],
+    recentReviewEmpty: options.recentReviewEmpty ?? false,
+  };
+
+  await page.route("**/api/**", async (route) => {
+    await routeMock(route, state);
+  });
+  return state;
+}
+
+async function routeMock(route: Route, state: MockState) {
+  const request = route.request();
+  const path = new URL(request.url()).pathname.replace(/^\/api/, "");
+
+  if (path === "/health") {
+    await route.fulfill({
+      json: { status: "ok", content_version: "m10-walkthrough", db_ready: true },
+    });
+    return;
+  }
+
+  if (path === "/today") {
+    await route.fulfill({ json: todayResponse(state) });
+    return;
+  }
+
+  if (path === "/settings") {
+    if (request.method() === "PUT") {
+      const body = request.postDataJSON() as {
+        learner_level?: LearnerLevel;
+        focus_phonemes?: string[];
+        daily_word_count?: number;
+      };
+      if (body.learner_level) state.selectedLevel = body.learner_level;
+      if (body.focus_phonemes) state.focusPhonemes = body.focus_phonemes;
+    }
+    await route.fulfill({ json: settingsResponse(state) });
+    return;
+  }
+
+  if (path === "/progress") {
+    await route.fulfill({ json: progressResponse(state) });
+    return;
+  }
+
+  if (path === "/practice/next-normal") {
+    state.activeGroup = state.selectedLevel;
+    await route.fulfill({ json: todayResponse(state) });
+    return;
+  }
+
+  if (path === "/practice/abandon-current-and-next") {
+    state.activeGroup = state.selectedLevel;
+    await route.fulfill({
+      json: {
+        ...todayResponse(state),
+        detail: `Ended Entry Group 1 and started ${levelLabel(state.selectedLevel)} Group 1.`,
+      },
+    });
+    return;
+  }
+
+  if (path === "/attempt") {
+    const body = request.postDataJSON() as {
+      session_item_id: string;
+      selected_answer: string;
+    };
+    const item = Object.values(items)
+      .flat()
+      .find((candidate) => candidate.session_item_id === body.session_item_id);
+    if (!item) {
+      await route.fulfill({ status: 404, json: { detail: "Unknown item" } });
+      return;
+    }
+    const currentItems = state.activeGroup === "none" ? [] : items[state.activeGroup];
+    if (currentItems.at(-1)?.session_item_id === body.session_item_id) {
+      if (state.activeGroup === "entry") state.completed.entry += 1;
+      if (state.activeGroup === "mid") state.completed.mid += 1;
+    }
+    await route.fulfill({
+      json: {
+        is_correct: body.selected_answer === item.display_ipa,
+        correct_answer: item.display_ipa,
+        updated_phonemes: item.target_phonemes.map((phoneme) => ({
+          phoneme,
+          attempt_count: 1,
+          correct_count: body.selected_answer === item.display_ipa ? 1 : 0,
+          mastery_status: body.selected_answer === item.display_ipa ? "strong" : "weak",
+        })),
+        next_action: "continue",
+      },
+    });
+    return;
+  }
+
+  if (path === "/review/current-group") {
+    state.activeGroup = "currentReview";
+    await route.fulfill({ json: todayResponse(state) });
+    return;
+  }
+
+  if (path === "/review/recent-mistakes") {
+    if (state.recentReviewEmpty) {
+      await route.fulfill({
+        json: {
+          ...todayResponse(state),
+          status: "empty",
+          items: [],
+          detail: "No recent incorrect attempts are available for review.",
+        },
+      });
+      return;
+    }
+    state.activeGroup = "recentReview";
+    await route.fulfill({ json: todayResponse(state) });
+    return;
+  }
+
+  if (path === "/practice/focus") {
+    const body = request.postDataJSON() as { focus_phonemes?: string[] };
+    state.focusPhonemes = body.focus_phonemes ?? ["/ʃ/"];
+    state.activeGroup = "focused";
+    await route.fulfill({ json: todayResponse(state) });
+    return;
+  }
+
+  if (path === "/practice/clear-focus") {
+    state.focusPhonemes = [];
+    state.activeGroup = "none";
+    await route.fulfill({
+      json: {
+        ...todayResponse(state),
+        detail: "Focus cleared. Back to normal practice.",
+      },
+    });
+    return;
+  }
+
+  await route.fallback();
+}
+
+async function answer(page: Page, choice: string) {
+  await page.getByRole("button", { name: `Select ${choice}` }).click();
+}
+
+async function attachScreenshot(page: Page, name: string) {
+  const path = test.info().outputPath(`${name}.png`);
+  await page.screenshot({ fullPage: true, path });
+  await test.info().attach(name, { path, contentType: "image/png" });
+}
+
+test.describe("M10 UX walkthrough evidence", () => {
+  test("Today practice, wrong-answer recovery, reviews, and Progress focus are observable", async ({ page }) => {
+    await setupM10Api(page);
+
+    await test.step("Today start orientation", async () => {
+      await page.goto("/");
+      await expect(page.getByText("Today practice hub")).toBeVisible();
+      await expect(page.getByRole("heading", { name: "Entry selected" })).toBeVisible();
+      await expect(page.getByText("No active group")).toBeVisible();
+      await expect(page.getByRole("button", { name: "Start Entry group" })).toBeVisible();
+      await expect(page.getByRole("button", { name: "Review recent mistakes" })).toBeVisible();
+      await attachScreenshot(page, "m10-today-start");
+    });
+
+    await test.step("Wrong answer feedback remains inspectable before auto-advance", async () => {
+      await page.getByRole("button", { name: "Start Entry group" }).click();
+      await expect(page.getByText("Practice group: 1 / 2")).toBeVisible();
+      await expect(page.getByRole("button", { name: "Play pronunciation (TTS)" })).toBeVisible();
+      await answer(page, "/sɪp/");
+      await expect(page.getByText("Not quite")).toBeVisible();
+      await expect(page.getByText("You picked")).toBeVisible();
+      await expect(page.getByText("Correct IPA")).toBeVisible();
+      await expect(page.getByText("Target sound")).toBeVisible();
+      await attachScreenshot(page, "m10-wrong-answer-feedback");
+      await expect(page.getByRole("button", { name: "Select /θɪn/" })).toBeVisible({
+        timeout: 6_000,
+      });
+    });
+
+    await test.step("Completion summary exposes current-group recovery and next choices", async () => {
+      await answer(page, "/θɪn/");
+      await expect(page.getByRole("heading", { name: "Practice group complete" })).toBeVisible({
+        timeout: 4_000,
+      });
+      await expect(page.getByText("1 / 2 correct")).toBeVisible();
+      await expect(page.getByRole("heading", { name: "Misses from this group" })).toBeVisible();
+      await expect(page.getByRole("button", { name: "Review misses from this group" })).toBeVisible();
+      await expect(page.getByRole("button", { name: "Review recent mistakes" })).toBeVisible();
+      await attachScreenshot(page, "m10-completion-recovery-actions");
+    });
+
+    await test.step("Current-group review and recent review use different source copy", async () => {
+      await page.getByRole("button", { name: "Review misses from this group" }).click();
+      await expect(page.getByText("Current-group review: 1 / 1")).toBeVisible();
+      await expect(page.getByText("Reviewing misses from the group you just finished.")).toBeVisible();
+      await attachScreenshot(page, "m10-current-group-review");
+      await answer(page, "/ʃɪp/");
+      await expect(page.getByRole("heading", { name: "Current-group review complete" })).toBeVisible();
+      await page.getByRole("button", { name: "Review recent mistakes" }).click();
+      await expect(page.getByText("Recent mistake review: 1 / 1")).toBeVisible();
+      await expect(page.getByText("Reviewing recent mistakes from earlier practice.")).toBeVisible();
+      await attachScreenshot(page, "m10-recent-review");
+    });
+
+    await test.step("Progress focus entry can launch and clear focused practice", async () => {
+      await page.getByRole("button", { name: "Progress" }).click();
+      await expect(page.getByRole("heading", { name: "Progress" })).toBeVisible();
+      await expect(page.getByRole("heading", { name: "Needs practice in Entry" })).toBeVisible();
+      await expect(page.getByText("day streak")).toBeVisible();
+      await expect(page.locator(".stat-card").filter({ hasText: "day streak" }).getByText("0")).toBeVisible();
+      await page.getByRole("button", { name: "Focus /ʃ/" }).first().click();
+      await expect(page.getByText("Focused group: 1 / 1")).toBeVisible();
+      await expect(page.getByText("Entry focused practice for /ʃ/.")).toBeVisible();
+      await expect(page.getByRole("button", { name: "Clear focus" })).toBeVisible();
+      await attachScreenshot(page, "m10-progress-focus-entry");
+    });
+  });
+
+  test("Settings level switching, empty review state, audio signal, and mobile views are observable", async ({ page }, testInfo) => {
+    const state = await setupM10Api(page, { activeGroup: "entry", recentReviewEmpty: true });
+
+    await test.step("Settings changes future practice level while preserving active group", async () => {
+      await page.goto("/");
+      await expect(page.getByText("Today practice hub")).toBeVisible();
+      await expect(page.getByRole("button", { name: "Resume Entry group" })).toBeVisible();
+      await page.getByRole("button", { name: "Resume Entry group" }).click();
+      await expect(page.getByText("Practice group: 1 / 2")).toBeVisible();
+      await page.getByRole("button", { name: "Settings" }).click();
+      await expect(page.getByRole("heading", { name: "Settings" })).toBeVisible();
+      await expect(page.getByRole("button", { name: /Mid\s+Broader word practice/ })).toBeVisible();
+      await page.getByRole("button", { name: /Mid\s+Broader word practice/ }).click();
+      await expect(page.getByText("Saved")).toBeVisible();
+      await page.getByRole("button", { name: "Today", exact: true }).click();
+      await expect(page.getByRole("heading", { name: "Mid selected" })).toBeVisible();
+      await expect(page.getByText("You selected Mid. This Entry group is still in progress.")).toBeVisible();
+      await expect(page.getByRole("button", { name: "Resume Entry group" })).toBeVisible();
+      await attachScreenshot(page, "m10-settings-mid-pending");
+    });
+
+    await test.step("Intentional switch starts Mid and keeps level-specific copy visible", async () => {
+      page.once("dialog", (dialog) => dialog.accept());
+      await page.getByRole("button", { name: "End this Entry group and start Mid" }).click();
+      await expect(page.getByText("Practice group: 1 / 1")).toBeVisible();
+      await expect(page.getByText("Mid practice group.")).toBeVisible();
+      await expect(page.getByText("remember")).toBeVisible();
+      await attachScreenshot(page, "m10-mid-active");
+    });
+
+    await test.step("Recent-review empty state keeps the hub actionable", async () => {
+      state.activeGroup = "none";
+      await page.goto("/");
+      await expect(page.getByText("Today practice hub")).toBeVisible();
+      await page.getByRole("button", { name: "Review recent mistakes" }).click();
+      await expect(page.getByText("No recent incorrect attempts are available for review.")).toBeVisible();
+      await expect(page.getByRole("button", { name: "Start Mid group" })).toBeVisible();
+      await attachScreenshot(page, "m10-recent-review-empty");
+    });
+
+    await test.step("Mobile Today and Settings remain available with the same action semantics", async () => {
+      if (!testInfo.project.name.includes("mobile")) return;
+      await expect(page.getByText("Today practice hub")).toBeVisible();
+      await attachScreenshot(page, "m10-mobile-today");
+      await page.getByRole("button", { name: "Settings" }).click();
+      await expect(page.getByRole("heading", { name: "Settings" })).toBeVisible();
+      await expect(page.getByText("Advanced/debug: manual IPA focus entry")).toBeVisible();
+      await attachScreenshot(page, "m10-mobile-settings");
+    });
+  });
+});


### PR DESCRIPTION
## Primary Issue

Closes #176.

## Summary

- Add a dedicated M10 Playwright config and `pnpm test:e2e:m10` script.
- Add a repeatable M10 UX walkthrough spec covering the accepted M10 audit scenarios across desktop and Pixel 5 Chromium.
- Document the M10 evidence matrix in `docs/10-ux-research-and-optimization.md` and frontend run instructions in `frontend/README.md`.

## Scope

Test/evidence infrastructure and docs only. No production UX implementation changes.

Covered flows:

- Today practice start orientation
- wrong-answer feedback and auto-advance evidence point
- completion summary and current-group review
- recent mistake review
- Progress focus entry
- Settings Entry/Mid level switch semantics
- Mid transition
- recent-review empty state
- audio/TTS visible signal
- mobile Today and Settings views

## Verification

- `cd frontend && pnpm test:e2e:m10` — 4 passed
- `cd frontend && pnpm test:e2e:m7` — 7 passed
- `cd frontend && pnpm test:e2e:m8` — 1 passed
- `cd frontend && pnpm lint` — passed
- `cd frontend && pnpm build` — passed
- `git diff --check` — passed
- `tools/agents/agent-audit` — clean before PR body routing correction

Note: I initially ran M7 and M8 in parallel and hit a local port collision on the shared M7 config port. Rerunning them serially passed.

## Evidence paths

- `frontend/test-results/m10-walkthrough/`
- `frontend/playwright-report/m10/`

These are generated locally by Playwright and are not committed.

## Residual risks

- The M10 harness uses route-mocked disposable API data for deterministic UX evidence; backend scheduling/persistence/import behavior remains covered by backend tests and the live manual #174 audit path.
- This does not decide the visual direction. #175 remains the human-participation gate for visual scheme selection.

## Handoff

Completion handoff per #176: to Reviewer.
