### PR TITLE
Add interactive M10 visual direction prototypes

### DIFF
--- a/docs/design/m10-visual-direction-prototypes.html
+++ b/docs/design/m10-visual-direction-prototypes.html
@@ -1,0 +1,1037 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Tiny IPA M10 Visual Direction Prototypes</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --page: #f6f7fb;
+      --ink: #161a22;
+      --muted: #657084;
+      --line: #d9deea;
+      --panel: #ffffff;
+      --focus: #2563eb;
+      --radius: 8px;
+      --shadow: 0 18px 45px rgba(18, 24, 38, 0.12);
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      background: var(--page);
+      color: var(--ink);
+      min-height: 100vh;
+    }
+
+    button {
+      font: inherit;
+    }
+
+    .shell {
+      max-width: 1480px;
+      margin: 0 auto;
+      padding: 20px;
+    }
+
+    .review-top {
+      display: grid;
+      grid-template-columns: minmax(280px, 1fr) auto;
+      gap: 18px;
+      align-items: end;
+      margin-bottom: 18px;
+    }
+
+    .review-top h1 {
+      margin: 0 0 6px;
+      font-size: clamp(1.35rem, 2vw, 2rem);
+      letter-spacing: 0;
+    }
+
+    .review-top p {
+      margin: 0;
+      color: var(--muted);
+      line-height: 1.5;
+      max-width: 820px;
+    }
+
+    .controls {
+      display: flex;
+      gap: 8px;
+      flex-wrap: wrap;
+      justify-content: flex-end;
+    }
+
+    .segmented {
+      display: inline-flex;
+      gap: 4px;
+      padding: 4px;
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      background: #fff;
+    }
+
+    .segmented button {
+      min-height: 34px;
+      border: 0;
+      border-radius: 6px;
+      padding: 0 12px;
+      background: transparent;
+      color: var(--muted);
+      cursor: pointer;
+      font-weight: 700;
+    }
+
+    .segmented button[aria-pressed="true"] {
+      background: var(--ink);
+      color: #fff;
+    }
+
+    .review-grid {
+      display: grid;
+      grid-template-columns: 320px minmax(0, 1fr);
+      gap: 18px;
+      align-items: start;
+    }
+
+    .decision-panel {
+      position: sticky;
+      top: 16px;
+      background: #fff;
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      padding: 16px;
+      box-shadow: 0 10px 24px rgba(18, 24, 38, 0.08);
+    }
+
+    .decision-panel h2,
+    .decision-panel h3 {
+      margin: 0 0 10px;
+      font-size: 1rem;
+    }
+
+    .decision-panel p,
+    .decision-panel li {
+      color: var(--muted);
+      line-height: 1.45;
+      font-size: 0.92rem;
+    }
+
+    .decision-panel ul {
+      padding-left: 18px;
+      margin: 8px 0 14px;
+    }
+
+    .vote-list {
+      display: grid;
+      gap: 8px;
+      margin: 12px 0;
+    }
+
+    .vote-list button {
+      width: 100%;
+      min-height: 40px;
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      background: #f8fafc;
+      text-align: left;
+      padding: 8px 10px;
+      cursor: pointer;
+      font-weight: 800;
+    }
+
+    .vote-list button[aria-pressed="true"] {
+      border-color: var(--focus);
+      background: #eff6ff;
+      color: #1d4ed8;
+    }
+
+    .vote-output {
+      border: 1px solid var(--line);
+      background: #f8fafc;
+      border-radius: 8px;
+      padding: 10px;
+      color: var(--ink);
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+      font-size: 0.8rem;
+      white-space: pre-wrap;
+    }
+
+    .preview-stage {
+      display: grid;
+      gap: 18px;
+    }
+
+    .direction-card {
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      background: #fff;
+      box-shadow: var(--shadow);
+      overflow: hidden;
+    }
+
+    .direction-header {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) auto;
+      gap: 12px;
+      padding: 16px;
+      border-bottom: 1px solid var(--line);
+      background: #fff;
+    }
+
+    .direction-header h2 {
+      margin: 0 0 4px;
+      font-size: 1.2rem;
+    }
+
+    .direction-header p {
+      margin: 0;
+      color: var(--muted);
+      line-height: 1.45;
+    }
+
+    .swatches {
+      display: flex;
+      gap: 5px;
+      align-items: center;
+    }
+
+    .swatch {
+      width: 26px;
+      height: 26px;
+      border-radius: 6px;
+      border: 1px solid rgba(0, 0, 0, 0.12);
+    }
+
+    .proto-wrap {
+      padding: 18px;
+      background: var(--proto-bg);
+    }
+
+    .screen-grid {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(230px, 1fr));
+      gap: 14px;
+      transition: grid-template-columns 180ms ease;
+    }
+
+    .viewport-mobile .screen-grid {
+      grid-template-columns: minmax(260px, 390px);
+      justify-content: center;
+    }
+
+    .viewport-mobile .proto-screen {
+      min-height: 740px;
+    }
+
+    .proto-screen {
+      position: relative;
+      overflow: hidden;
+      min-height: 560px;
+      border-radius: var(--screen-radius);
+      border: var(--screen-border);
+      background: var(--screen-bg);
+      color: var(--screen-ink);
+      box-shadow: var(--screen-shadow);
+    }
+
+    .proto-screen::before {
+      content: "";
+      position: absolute;
+      inset: 0;
+      pointer-events: none;
+      opacity: var(--texture-opacity);
+      background: var(--texture);
+    }
+
+    .proto-inner {
+      position: relative;
+      z-index: 1;
+      padding: var(--screen-pad);
+      min-height: inherit;
+      display: flex;
+      flex-direction: column;
+      gap: 14px;
+    }
+
+    .proto-nav {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 6px;
+      align-items: center;
+      margin-bottom: 4px;
+    }
+
+    .proto-nav span {
+      text-align: center;
+      padding: 8px 6px;
+      border-radius: var(--chip-radius);
+      color: var(--nav-muted);
+      font-weight: 800;
+      font-size: 0.84rem;
+    }
+
+    .proto-nav .active {
+      color: var(--accent);
+      background: var(--chip-bg);
+      box-shadow: var(--chip-shadow);
+    }
+
+    .mini-label {
+      color: var(--muted-copy);
+      font-size: 0.76rem;
+      font-weight: 800;
+      text-transform: var(--label-transform);
+      letter-spacing: var(--label-spacing);
+    }
+
+    .hero-line {
+      display: flex;
+      justify-content: space-between;
+      gap: 12px;
+      align-items: end;
+    }
+
+    .hero-line h3 {
+      margin: 0;
+      font-size: var(--title-size);
+      letter-spacing: 0;
+      line-height: 1;
+    }
+
+    .status-pill {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 32px;
+      padding: 0 10px;
+      border-radius: var(--pill-radius);
+      background: var(--pill-bg);
+      color: var(--pill-ink);
+      font-weight: 900;
+      font-size: 0.78rem;
+      border: var(--pill-border);
+    }
+
+    .info-box,
+    .feedback-box,
+    .progress-box,
+    .settings-box,
+    .choice,
+    .action-shelf {
+      border-radius: var(--card-radius);
+      border: var(--card-border);
+      background: var(--card-bg);
+      box-shadow: var(--card-shadow);
+    }
+
+    .info-box {
+      padding: 14px;
+      display: grid;
+      gap: 8px;
+    }
+
+    .info-box strong {
+      font-size: 1rem;
+    }
+
+    .info-box span {
+      color: var(--muted-copy);
+      line-height: 1.35;
+      font-size: 0.9rem;
+    }
+
+    .primary-action,
+    .secondary-action {
+      min-height: 46px;
+      border-radius: var(--button-radius);
+      border: 0;
+      font-weight: 900;
+      cursor: default;
+    }
+
+    .primary-action {
+      background: var(--accent);
+      color: var(--accent-ink);
+      box-shadow: var(--button-shadow);
+    }
+
+    .secondary-action {
+      background: var(--secondary-bg);
+      color: var(--secondary-ink);
+      border: var(--secondary-border);
+    }
+
+    .word-zone {
+      display: grid;
+      justify-items: center;
+      gap: 8px;
+      padding: 18px 0 6px;
+    }
+
+    .word {
+      font-size: var(--word-size);
+      font-weight: 950;
+      line-height: 1;
+      letter-spacing: 0;
+      color: var(--word-ink);
+    }
+
+    .meaning {
+      color: var(--muted-copy);
+      font-size: 1.1rem;
+      font-weight: 800;
+    }
+
+    .audio-mark {
+      display: inline-grid;
+      place-items: center;
+      min-width: 42px;
+      height: 42px;
+      border-radius: 50%;
+      margin-left: 8px;
+      color: var(--accent);
+      background: var(--audio-bg);
+      border: var(--audio-border);
+      font-size: 0.72rem;
+      font-weight: 950;
+      vertical-align: middle;
+    }
+
+    .choice-list {
+      display: grid;
+      gap: 10px;
+    }
+
+    .choice {
+      min-height: 58px;
+      display: grid;
+      place-items: center;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+      font-size: 1.45rem;
+      font-weight: 900;
+    }
+
+    .choice.wrong {
+      border-color: var(--wrong);
+      color: var(--wrong);
+      background: var(--wrong-bg);
+    }
+
+    .choice.correct {
+      border-color: var(--correct);
+      color: var(--correct);
+      background: var(--correct-bg);
+    }
+
+    .feedback-box {
+      padding: 14px;
+      display: grid;
+      gap: 8px;
+      border-color: var(--feedback-border);
+      background: var(--feedback-bg);
+    }
+
+    .feedback-title {
+      font-size: 1.1rem;
+      font-weight: 950;
+      color: var(--feedback-ink);
+    }
+
+    .compare-grid {
+      display: grid;
+      grid-template-columns: auto 1fr;
+      gap: 7px 12px;
+      align-items: baseline;
+    }
+
+    .compare-grid span {
+      color: var(--muted-copy);
+      font-weight: 800;
+    }
+
+    .compare-grid code {
+      color: var(--feedback-ink);
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+      font-weight: 950;
+      font-size: 1.05rem;
+    }
+
+    .action-shelf {
+      display: grid;
+      gap: 8px;
+      padding: 12px;
+    }
+
+    .progress-row {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 8px;
+    }
+
+    .progress-box {
+      padding: 12px;
+      min-height: 74px;
+    }
+
+    .progress-box strong {
+      display: block;
+      font-size: 1.45rem;
+      color: var(--accent);
+    }
+
+    .progress-box span {
+      color: var(--muted-copy);
+      font-size: 0.76rem;
+      font-weight: 800;
+    }
+
+    .phoneme-list {
+      display: grid;
+      gap: 8px;
+    }
+
+    .phoneme-row {
+      display: grid;
+      grid-template-columns: auto 1fr auto;
+      gap: 8px;
+      align-items: center;
+      padding: 10px;
+      border-radius: var(--card-radius);
+      border: var(--card-border);
+      background: var(--row-bg);
+    }
+
+    .phoneme-symbol {
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+      font-weight: 950;
+      font-size: 1.2rem;
+      color: var(--accent);
+    }
+
+    .settings-box {
+      padding: 12px;
+      display: grid;
+      gap: 10px;
+    }
+
+    .level-choice {
+      display: grid;
+      grid-template-columns: auto 1fr;
+      gap: 8px;
+      align-items: start;
+      padding: 10px;
+      border-radius: var(--button-radius);
+      border: var(--secondary-border);
+      background: var(--secondary-bg);
+    }
+
+    .level-choice strong {
+      color: var(--accent);
+    }
+
+    .level-choice span {
+      color: var(--muted-copy);
+      font-size: 0.82rem;
+      line-height: 1.35;
+    }
+
+    .notes {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 12px;
+      padding: 14px 16px 16px;
+      border-top: 1px solid var(--line);
+      background: #fff;
+    }
+
+    .notes h3 {
+      margin: 0 0 6px;
+      font-size: 0.88rem;
+    }
+
+    .notes p {
+      margin: 0;
+      color: var(--muted);
+      font-size: 0.84rem;
+      line-height: 1.45;
+    }
+
+    .direction-card[data-direction="sound"] {
+      --proto-bg: #eaf7fb;
+      --screen-bg: #f8fafc;
+      --screen-ink: #172033;
+      --screen-radius: 8px;
+      --screen-border: 1px solid #b8d8ef;
+      --screen-shadow: 0 20px 42px rgba(23, 32, 51, 0.16);
+      --screen-pad: 18px;
+      --accent: #2563eb;
+      --accent-ink: #ffffff;
+      --muted-copy: #627086;
+      --nav-muted: #77839b;
+      --chip-bg: #dbeafe;
+      --chip-radius: 6px;
+      --chip-shadow: none;
+      --pill-bg: #e0f2fe;
+      --pill-ink: #075985;
+      --pill-border: 1px solid #7dd3fc;
+      --pill-radius: 6px;
+      --card-bg: rgba(255, 255, 255, 0.86);
+      --card-border: 1px solid #bfdbfe;
+      --card-shadow: none;
+      --card-radius: 8px;
+      --button-radius: 8px;
+      --button-shadow: 0 10px 20px rgba(37, 99, 235, 0.22);
+      --secondary-bg: #eff6ff;
+      --secondary-ink: #1d4ed8;
+      --secondary-border: 1px solid #bfdbfe;
+      --word-size: 3rem;
+      --word-ink: #172033;
+      --audio-bg: #ecfeff;
+      --audio-border: 1px solid #67e8f9;
+      --wrong: #dc2626;
+      --wrong-bg: #fff1f2;
+      --correct: #16a34a;
+      --correct-bg: #f0fdf4;
+      --feedback-bg: #fffbeb;
+      --feedback-border: #f59e0b;
+      --feedback-ink: #b45309;
+      --row-bg: #f8fafc;
+      --title-size: 1.6rem;
+      --label-transform: uppercase;
+      --label-spacing: 0.08em;
+      --texture-opacity: 0.2;
+      --texture: repeating-linear-gradient(90deg, transparent 0 14px, rgba(6, 182, 212, 0.2) 14px 16px);
+    }
+
+    .direction-card[data-direction="studio"] {
+      --proto-bg: #f8f7f2;
+      --screen-bg: #fffefa;
+      --screen-ink: #202124;
+      --screen-radius: 8px;
+      --screen-border: 1px solid #ebe5d7;
+      --screen-shadow: 0 22px 46px rgba(32, 33, 36, 0.14);
+      --screen-pad: 18px;
+      --accent: #3b82f6;
+      --accent-ink: #ffffff;
+      --muted-copy: #6f6c65;
+      --nav-muted: #7b786f;
+      --chip-bg: #eef4ff;
+      --chip-radius: 999px;
+      --chip-shadow: inset 0 0 0 1px #d7e4ff;
+      --pill-bg: #fff0ed;
+      --pill-ink: #c2410c;
+      --pill-border: 1px solid #fed7aa;
+      --pill-radius: 999px;
+      --card-bg: #ffffff;
+      --card-border: 1px solid #ebe5d7;
+      --card-shadow: 0 8px 20px rgba(32, 33, 36, 0.08);
+      --card-radius: 8px;
+      --button-radius: 8px;
+      --button-shadow: 0 10px 18px rgba(59, 130, 246, 0.22);
+      --secondary-bg: #f8fafc;
+      --secondary-ink: #2f5fbf;
+      --secondary-border: 1px solid #dbe4f4;
+      --word-size: 3.15rem;
+      --word-ink: #202124;
+      --audio-bg: #fff7ed;
+      --audio-border: 1px solid #fdba74;
+      --wrong: #e11d48;
+      --wrong-bg: #fff1f2;
+      --correct: #31b981;
+      --correct-bg: #ecfdf5;
+      --feedback-bg: #fff7ed;
+      --feedback-border: #fdba74;
+      --feedback-ink: #c2410c;
+      --row-bg: #fffefa;
+      --title-size: 1.75rem;
+      --label-transform: none;
+      --label-spacing: 0;
+      --texture-opacity: 0.08;
+      --texture: radial-gradient(circle at 10% 8%, #f9736b 0 8px, transparent 9px), radial-gradient(circle at 92% 14%, #a78bfa 0 7px, transparent 8px);
+    }
+
+    .direction-card[data-direction="mission"] {
+      --proto-bg: #eef3ff;
+      --screen-bg: #f9fafb;
+      --screen-ink: #171717;
+      --screen-radius: 8px;
+      --screen-border: 1px solid #d7dded;
+      --screen-shadow: 0 18px 38px rgba(29, 78, 216, 0.16);
+      --screen-pad: 16px;
+      --accent: #1d4ed8;
+      --accent-ink: #ffffff;
+      --muted-copy: #5f6571;
+      --nav-muted: #757b86;
+      --chip-bg: #e0e7ff;
+      --chip-radius: 8px;
+      --chip-shadow: none;
+      --pill-bg: #ecfccb;
+      --pill-ink: #3f6212;
+      --pill-border: 1px solid #bef264;
+      --pill-radius: 8px;
+      --card-bg: #ffffff;
+      --card-border: 2px solid #e4e7ee;
+      --card-shadow: none;
+      --card-radius: 8px;
+      --button-radius: 8px;
+      --button-shadow: 0 8px 0 #173a9a;
+      --secondary-bg: #ffffff;
+      --secondary-ink: #1d4ed8;
+      --secondary-border: 2px solid #d7dded;
+      --word-size: 3rem;
+      --word-ink: #171717;
+      --audio-bg: #eef2ff;
+      --audio-border: 2px solid #c7d2fe;
+      --wrong: #e11d48;
+      --wrong-bg: #fff1f2;
+      --correct: #65a30d;
+      --correct-bg: #f7fee7;
+      --feedback-bg: #fff1f2;
+      --feedback-border: #fb7185;
+      --feedback-ink: #be123c;
+      --row-bg: #ffffff;
+      --title-size: 1.55rem;
+      --label-transform: uppercase;
+      --label-spacing: 0.06em;
+      --texture-opacity: 0.12;
+      --texture: linear-gradient(135deg, rgba(124, 58, 237, 0.28) 0 2px, transparent 2px 14px);
+    }
+
+    .direction-card[data-direction="hybrid"] {
+      --proto-bg: #f1fbff;
+      --screen-bg: #fffefa;
+      --screen-ink: #172033;
+      --screen-radius: 8px;
+      --screen-border: 1px solid #d6e7ef;
+      --screen-shadow: 0 24px 48px rgba(23, 32, 51, 0.14);
+      --screen-pad: 18px;
+      --accent: #2f78e8;
+      --accent-ink: #ffffff;
+      --muted-copy: #66717e;
+      --nav-muted: #7c8490;
+      --chip-bg: #ecfeff;
+      --chip-radius: 999px;
+      --chip-shadow: inset 0 0 0 1px #a5f3fc;
+      --pill-bg: #fff7ed;
+      --pill-ink: #c2410c;
+      --pill-border: 1px solid #fed7aa;
+      --pill-radius: 999px;
+      --card-bg: rgba(255, 255, 255, 0.94);
+      --card-border: 1px solid #dbeafe;
+      --card-shadow: 0 8px 20px rgba(23, 32, 51, 0.08);
+      --card-radius: 8px;
+      --button-radius: 8px;
+      --button-shadow: 0 10px 18px rgba(47, 120, 232, 0.22);
+      --secondary-bg: #f8fafc;
+      --secondary-ink: #2563eb;
+      --secondary-border: 1px solid #cfe3f5;
+      --word-size: 3.15rem;
+      --word-ink: #172033;
+      --audio-bg: #ecfeff;
+      --audio-border: 1px solid #67e8f9;
+      --wrong: #e11d48;
+      --wrong-bg: #fff7ed;
+      --correct: #16a34a;
+      --correct-bg: #ecfdf5;
+      --feedback-bg: #fff7ed;
+      --feedback-border: #fdba74;
+      --feedback-ink: #c2410c;
+      --row-bg: #fffefa;
+      --title-size: 1.75rem;
+      --label-transform: none;
+      --label-spacing: 0;
+      --texture-opacity: 0.16;
+      --texture: repeating-linear-gradient(90deg, transparent 0 18px, rgba(6, 182, 212, 0.16) 18px 20px);
+    }
+
+    @media (max-width: 1100px) {
+      .review-grid {
+        grid-template-columns: 1fr;
+      }
+
+      .decision-panel {
+        position: static;
+      }
+
+      .screen-grid {
+        grid-template-columns: repeat(2, minmax(240px, 1fr));
+      }
+    }
+
+    @media (max-width: 720px) {
+      .shell {
+        padding: 12px;
+      }
+
+      .review-top {
+        grid-template-columns: 1fr;
+      }
+
+      .controls {
+        justify-content: flex-start;
+      }
+
+      .screen-grid {
+        grid-template-columns: 1fr;
+      }
+
+      .notes {
+        grid-template-columns: 1fr;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main class="shell">
+    <header class="review-top">
+      <div>
+        <h1>Tiny IPA M10 visual direction prototypes</h1>
+        <p>Interactive review artifact for issue #175. Compare the same learner flows across direction A, B, C, and the recommended B+A hybrid before choosing a production UI direction.</p>
+      </div>
+      <div class="controls" aria-label="Prototype controls">
+        <div class="segmented" aria-label="Direction filter">
+          <button type="button" data-filter="all" aria-pressed="true">All</button>
+          <button type="button" data-filter="sound" aria-pressed="false">A</button>
+          <button type="button" data-filter="studio" aria-pressed="false">B</button>
+          <button type="button" data-filter="mission" aria-pressed="false">C</button>
+          <button type="button" data-filter="hybrid" aria-pressed="false">B+A</button>
+        </div>
+        <div class="segmented" aria-label="Viewport mode">
+          <button type="button" data-viewport="desktop" aria-pressed="true">Desktop</button>
+          <button type="button" data-viewport="mobile" aria-pressed="false">Mobile</button>
+        </div>
+      </div>
+    </header>
+
+    <div class="review-grid">
+      <aside class="decision-panel">
+        <h2>Decision Gate</h2>
+        <p>Pick a visual direction after inspecting the prototype screens. This is not production UI; it is an evaluation artifact.</p>
+        <h3>Recommended</h3>
+        <p><strong>B+A hybrid</strong>: Practice Studio overall, with Sound Lab's restrained IPA/audio signal motif.</p>
+        <h3>Choose</h3>
+        <div class="vote-list">
+          <button type="button" data-vote="A">A - Sound Lab</button>
+          <button type="button" data-vote="B">B - Practice Studio</button>
+          <button type="button" data-vote="C">C - Mission Cards</button>
+          <button type="button" data-vote="B+A hybrid">B+A hybrid</button>
+          <button type="button" data-vote="Defer">Defer for mockups</button>
+        </div>
+        <h3>Response to paste</h3>
+        <div class="vote-output" id="voteOutput">Select visual direction: <pending>
+Optional notes: </div>
+        <h3>Review checks</h3>
+        <ul>
+          <li>Would a teen want to come back?</li>
+          <li>Is IPA easier to read?</li>
+          <li>Does a wrong answer feel recoverable?</li>
+          <li>Does Progress motivate without pressure?</li>
+          <li>Does mobile feel like the primary surface?</li>
+        </ul>
+      </aside>
+
+      <section class="preview-stage" aria-label="Visual direction previews">
+        <article class="direction-card" data-direction="sound">
+          <div class="direction-header">
+            <div>
+              <h2>A. Sound Lab</h2>
+              <p>Precise, signal-driven, and trustworthy. Best for IPA/audio clarity; risk is feeling too clinical.</p>
+            </div>
+            <div class="swatches" aria-label="Sound Lab colors">
+              <span class="swatch" style="background:#172033"></span>
+              <span class="swatch" style="background:#2563eb"></span>
+              <span class="swatch" style="background:#06b6d4"></span>
+              <span class="swatch" style="background:#22c55e"></span>
+              <span class="swatch" style="background:#f59e0b"></span>
+            </div>
+          </div>
+          <div class="proto-wrap">
+            <div class="screen-grid">
+              <div class="proto-screen"><div class="proto-inner" data-screen="today"></div></div>
+              <div class="proto-screen"><div class="proto-inner" data-screen="practice"></div></div>
+              <div class="proto-screen"><div class="proto-inner" data-screen="progress"></div></div>
+              <div class="proto-screen"><div class="proto-inner" data-screen="settings"></div></div>
+            </div>
+          </div>
+          <div class="notes">
+            <div><h3>Best at</h3><p>IPA confidence, audio status, technical trust.</p></div>
+            <div><h3>Watch risk</h3><p>May feel like a diagnostics tool if copy stays dry.</p></div>
+            <div><h3>Useful motif</h3><p>Subtle waveform/phoneme signal treatment.</p></div>
+          </div>
+        </article>
+
+        <article class="direction-card" data-direction="studio">
+          <div class="direction-header">
+            <div>
+              <h2>B. Practice Studio</h2>
+              <p>Warm, tactile, and forgiving. Best broad teen fit; strongest for wrong-answer recovery.</p>
+            </div>
+            <div class="swatches" aria-label="Practice Studio colors">
+              <span class="swatch" style="background:#202124"></span>
+              <span class="swatch" style="background:#3b82f6"></span>
+              <span class="swatch" style="background:#f9736b"></span>
+              <span class="swatch" style="background:#31b981"></span>
+              <span class="swatch" style="background:#a78bfa"></span>
+            </div>
+          </div>
+          <div class="proto-wrap">
+            <div class="screen-grid">
+              <div class="proto-screen"><div class="proto-inner" data-screen="today"></div></div>
+              <div class="proto-screen"><div class="proto-inner" data-screen="practice"></div></div>
+              <div class="proto-screen"><div class="proto-inner" data-screen="progress"></div></div>
+              <div class="proto-screen"><div class="proto-inner" data-screen="settings"></div></div>
+            </div>
+          </div>
+          <div class="notes">
+            <div><h3>Best at</h3><p>Everyday appeal, forgiving feedback, clear action hierarchy.</p></div>
+            <div><h3>Watch risk</h3><p>Needs a distinctive IPA/audio motif to avoid generic app polish.</p></div>
+            <div><h3>Useful motif</h3><p>Practice desk, tactile tiles, recovery shelf.</p></div>
+          </div>
+        </article>
+
+        <article class="direction-card" data-direction="mission">
+          <div class="direction-header">
+            <div>
+              <h2>C. Mission Cards</h2>
+              <p>Goal-oriented and compact. Good for daily momentum; risk is over-emphasizing completion.</p>
+            </div>
+            <div class="swatches" aria-label="Mission Cards colors">
+              <span class="swatch" style="background:#171717"></span>
+              <span class="swatch" style="background:#1d4ed8"></span>
+              <span class="swatch" style="background:#84cc16"></span>
+              <span class="swatch" style="background:#7c3aed"></span>
+              <span class="swatch" style="background:#fb7185"></span>
+            </div>
+          </div>
+          <div class="proto-wrap">
+            <div class="screen-grid">
+              <div class="proto-screen"><div class="proto-inner" data-screen="today"></div></div>
+              <div class="proto-screen"><div class="proto-inner" data-screen="practice"></div></div>
+              <div class="proto-screen"><div class="proto-inner" data-screen="progress"></div></div>
+              <div class="proto-screen"><div class="proto-inner" data-screen="settings"></div></div>
+            </div>
+          </div>
+          <div class="notes">
+            <div><h3>Best at</h3><p>Next-action clarity and short-session momentum.</p></div>
+            <div><h3>Watch risk</h3><p>Can drift into habit-app pressure or reward loops.</p></div>
+            <div><h3>Useful motif</h3><p>Mission state cards: Start, Learn, Review, Next.</p></div>
+          </div>
+        </article>
+
+        <article class="direction-card" data-direction="hybrid">
+          <div class="direction-header">
+            <div>
+              <h2>B+A. Studio Signal</h2>
+              <p>Recommended hybrid: Practice Studio warmth with Sound Lab's IPA/audio signal language.</p>
+            </div>
+            <div class="swatches" aria-label="Studio Signal colors">
+              <span class="swatch" style="background:#172033"></span>
+              <span class="swatch" style="background:#2f78e8"></span>
+              <span class="swatch" style="background:#06b6d4"></span>
+              <span class="swatch" style="background:#f9736b"></span>
+              <span class="swatch" style="background:#31b981"></span>
+            </div>
+          </div>
+          <div class="proto-wrap">
+            <div class="screen-grid">
+              <div class="proto-screen"><div class="proto-inner" data-screen="today"></div></div>
+              <div class="proto-screen"><div class="proto-inner" data-screen="practice"></div></div>
+              <div class="proto-screen"><div class="proto-inner" data-screen="progress"></div></div>
+              <div class="proto-screen"><div class="proto-inner" data-screen="settings"></div></div>
+            </div>
+          </div>
+          <div class="notes">
+            <div><h3>Best at</h3><p>Balanced teen appeal, IPA trust, and recoverable mistakes.</p></div>
+            <div><h3>Watch risk</h3><p>Must stay disciplined; one signature signal, not decoration everywhere.</p></div>
+            <div><h3>Useful motif</h3><p>Warm practice layout plus audio/phoneme signal strip.</p></div>
+          </div>
+        </article>
+      </section>
+    </div>
+  </main>
+
+  <template id="today-template">
+    <nav class="proto-nav"><span class="active">Today</span><span>Progress</span><span>Settings</span></nav>
+    <span class="mini-label">Today practice hub</span>
+    <div class="hero-line"><h3>Entry selected</h3><span class="status-pill">US audio</span></div>
+    <div class="info-box"><strong>Ready to start Entry</strong><span>2 words today. Review appears when there is something useful to replay.</span></div>
+    <button class="primary-action">Start Entry group</button>
+    <button class="secondary-action">Review recent mistakes</button>
+    <button class="secondary-action">View Progress</button>
+  </template>
+
+  <template id="practice-template">
+    <nav class="proto-nav"><span class="active">Today</span><span>Progress</span><span>Settings</span></nav>
+    <div class="hero-line"><span class="mini-label">Practice group 1 / 2</span><span class="status-pill">Entry</span></div>
+    <div class="info-box"><strong>Practice group</strong><span>Listen, compare the sound, then choose the IPA.</span></div>
+    <div class="word-zone"><div><span class="word">ship</span><span class="audio-mark">TTS</span></div><div class="meaning">船</div></div>
+    <div class="choice-list"><div class="choice wrong">/sɪp/</div><div class="choice correct">/ʃɪp/</div></div>
+    <div class="feedback-box"><div class="feedback-title">Not quite. Study the contrast.</div><div class="compare-grid"><span>You picked</span><code>/sɪp/</code><span>Correct IPA</span><code>/ʃɪp/</code><span>Target sound</span><code>/ʃ/</code></div></div>
+  </template>
+
+  <template id="progress-template">
+    <nav class="proto-nav"><span>Today</span><span class="active">Progress</span><span>Settings</span></nav>
+    <span class="mini-label">Progress</span>
+    <div class="progress-row"><div class="progress-box"><strong>0</strong><span>day streak</span></div><div class="progress-box"><strong>2</strong><span>attempts</span></div><div class="progress-box"><strong>1</strong><span>group done</span></div></div>
+    <div class="info-box"><strong>Needs practice in Entry</strong><span>Focus one sound and make the next group easier to understand.</span></div>
+    <div class="phoneme-list"><div class="phoneme-row"><span class="phoneme-symbol">/ʃ/</span><span>50% accuracy</span><button class="secondary-action">Focus /ʃ/</button></div><div class="phoneme-row"><span class="phoneme-symbol">/θ/</span><span>new signal</span><button class="secondary-action">Focus /θ/</button></div></div>
+  </template>
+
+  <template id="settings-template">
+    <nav class="proto-nav"><span>Today</span><span>Progress</span><span class="active">Settings</span></nav>
+    <span class="mini-label">Settings</span>
+    <div class="settings-box"><strong>Practice level</strong><div class="level-choice"><strong>Entry</strong><span>Starter IPA contrasts with short daily groups.</span></div><div class="level-choice"><strong>Mid</strong><span>Longer words. Starts with the next new group.</span></div></div>
+    <div class="settings-box"><strong>Focus practice</strong><div class="phoneme-row"><span class="phoneme-symbol">/ʃ/</span><span>ship, shoe, special</span><button class="secondary-action">Start focus</button></div></div>
+  </template>
+
+  <script>
+    const templates = {
+      today: document.querySelector("#today-template"),
+      practice: document.querySelector("#practice-template"),
+      progress: document.querySelector("#progress-template"),
+      settings: document.querySelector("#settings-template"),
+    };
+
+    document.querySelectorAll("[data-screen]").forEach((target) => {
+      const template = templates[target.dataset.screen];
+      target.append(template.content.cloneNode(true));
+    });
+
+    const directionButtons = document.querySelectorAll("[data-filter]");
+    const cards = document.querySelectorAll(".direction-card");
+    directionButtons.forEach((button) => {
+      button.addEventListener("click", () => {
+        const filter = button.dataset.filter;
+        directionButtons.forEach((item) => item.setAttribute("aria-pressed", String(item === button)));
+        cards.forEach((card) => {
+          card.hidden = filter !== "all" && card.dataset.direction !== filter;
+        });
+      });
+    });
+
+    const viewportButtons = document.querySelectorAll("[data-viewport]");
+    viewportButtons.forEach((button) => {
+      button.addEventListener("click", () => {
+        viewportButtons.forEach((item) => item.setAttribute("aria-pressed", String(item === button)));
+        document.body.classList.toggle("viewport-mobile", button.dataset.viewport === "mobile");
+      });
+    });
+
+    const voteOutput = document.querySelector("#voteOutput");
+    document.querySelectorAll("[data-vote]").forEach((button) => {
+      button.addEventListener("click", () => {
+        document.querySelectorAll("[data-vote]").forEach((item) => {
+          item.setAttribute("aria-pressed", String(item === button));
+        });
+        voteOutput.textContent = `Select visual direction: ${button.dataset.vote}\nOptional notes: `;
+      });
+    });
+  </script>
+</body>
+</html>

--- a/docs/design/m10-visual-direction-prototypes.html
+++ b/docs/design/m10-visual-direction-prototypes.html
@@ -7,16 +7,16 @@
   <style>
     :root {
       color-scheme: light;
-      --page: #f6f7fb;
-      --ink: #161a22;
-      --muted: #657084;
-      --line: #d9deea;
+      --page: #f3f6f6;
+      --ink: #253238;
+      --muted: #65777d;
+      --line: #d7e1e2;
       --panel: #ffffff;
-      --focus: #2563eb;
+      --focus: #6f9fb2;
       --radius: 8px;
-      --shadow: 0 18px 45px rgba(18, 24, 38, 0.12);
+      --shadow: 0 18px 45px rgba(56, 76, 82, 0.1);
       --cn-ui-font: "PingFang SC", "Hiragino Sans GB", "Noto Sans SC", "Source Han Sans SC", "Microsoft YaHei", ui-sans-serif, system-ui, sans-serif;
-      --cn-brand-font: "TsangerYuYangT W05", "HYQiHei 60S", "PingFang SC", "Noto Sans SC", "Microsoft YaHei", sans-serif;
+      --cn-brand-font: "PingFang SC", "Hiragino Sans GB", "Noto Sans SC", "Source Han Sans SC", "Microsoft YaHei", sans-serif;
       font-family: var(--cn-ui-font);
     }
 
@@ -90,7 +90,7 @@
     }
 
     .segmented button[aria-pressed="true"] {
-      background: var(--ink);
+      background: #415e68;
       color: #fff;
     }
 
@@ -144,13 +144,13 @@
       text-align: left;
       padding: 8px 10px;
       cursor: pointer;
-      font-weight: 800;
+      font-weight: 700;
     }
 
     .vote-list button[aria-pressed="true"] {
       border-color: var(--focus);
-      background: #eff6ff;
-      color: #1d4ed8;
+      background: #edf5f6;
+      color: #415e68;
     }
 
     .vote-output {
@@ -178,8 +178,8 @@
     }
 
     .direction-card.is-selected {
-      border-color: #2f78e8;
-      box-shadow: 0 22px 56px rgba(47, 120, 232, 0.2);
+      border-color: #8ab4bd;
+      box-shadow: 0 22px 56px rgba(87, 121, 129, 0.16);
     }
 
     .direction-header {
@@ -257,14 +257,14 @@
     }
 
     .proto-screen::after {
-      content: "小  /ʃ/  /θ/  /ɪ/";
+      content: "/ʃ/  /θ/  /ɪ/";
       position: absolute;
       right: 12px;
       bottom: 10px;
       color: var(--pattern-ink, rgba(47, 120, 232, 0.2));
       font-family: var(--cn-brand-font);
       font-size: 0.78rem;
-      font-weight: 900;
+      font-weight: 700;
       letter-spacing: 0;
       pointer-events: none;
     }
@@ -276,7 +276,7 @@
       min-height: inherit;
       display: flex;
       flex-direction: column;
-      gap: 14px;
+      gap: 12px;
     }
 
     .brand-strip {
@@ -284,32 +284,33 @@
       grid-template-columns: auto 1fr;
       gap: 12px;
       align-items: center;
-      padding: 12px;
+      padding: 10px;
       border-radius: var(--card-radius);
       border: var(--card-border);
-      background: linear-gradient(135deg, rgba(255, 255, 255, 0.96), rgba(236, 254, 255, 0.86));
+      background: linear-gradient(135deg, rgba(255, 255, 255, 0.96), rgba(236, 244, 245, 0.92));
       box-shadow: var(--card-shadow);
     }
 
     .brand-mark {
       display: grid;
       place-items: center;
-      width: 56px;
-      height: 56px;
+      width: 48px;
+      height: 48px;
       border-radius: 8px;
-      background: #172033;
-      color: #fffefa;
+      background: #415e68;
+      color: #f7fbfb;
       font-family: var(--cn-brand-font);
-      font-size: 1.65rem;
-      font-weight: 950;
+      font-size: 1.45rem;
+      font-weight: 700;
       line-height: 1;
-      box-shadow: inset 0 -6px 0 rgba(6, 182, 212, 0.26);
+      box-shadow: inset 0 -5px 0 rgba(174, 207, 209, 0.34);
     }
 
     .brand-copy strong {
       display: block;
       font-family: var(--cn-brand-font);
-      font-size: 1.28rem;
+      font-size: 1.16rem;
+      font-weight: 800;
       line-height: 1.1;
     }
 
@@ -318,6 +319,76 @@
       margin-top: 4px;
       color: var(--muted-copy);
       font-size: 0.82rem;
+      line-height: 1.35;
+    }
+
+    .brand-copy .quiet-note {
+      display: inline;
+      color: #7d8d91;
+    }
+
+    .home-topline {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 8px;
+      align-items: center;
+    }
+
+    .home-brand {
+      grid-template-columns: auto 1fr auto;
+    }
+
+    .home-brand .brand-copy span {
+      display: none;
+    }
+
+    .login-entry {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 32px;
+      padding: 0 10px;
+      border-radius: 999px;
+      border: 1px solid #cbdcde;
+      background: rgba(255, 255, 255, 0.72);
+      color: #526a72;
+      font-size: 0.78rem;
+      font-weight: 700;
+      white-space: nowrap;
+    }
+
+    .account-box {
+      display: grid;
+      grid-template-columns: auto 1fr;
+      gap: 10px;
+      align-items: center;
+      padding: 12px;
+      border-radius: var(--card-radius);
+      border: 1px dashed #b9cdd1;
+      background: rgba(246, 250, 250, 0.82);
+    }
+
+    .account-icon {
+      display: grid;
+      place-items: center;
+      width: 36px;
+      height: 36px;
+      border-radius: 50%;
+      color: #607982;
+      background: #e8f1f2;
+      font-weight: 800;
+    }
+
+    .account-box strong {
+      display: block;
+      font-size: 0.95rem;
+    }
+
+    .account-box span {
+      display: block;
+      margin-top: 2px;
+      color: var(--muted-copy);
+      font-size: 0.8rem;
       line-height: 1.35;
     }
 
@@ -375,8 +446,8 @@
       border-radius: var(--pill-radius);
       background: var(--pill-bg);
       color: var(--pill-ink);
-      font-weight: 900;
-      font-size: 0.78rem;
+      font-weight: 700;
+      font-size: 0.76rem;
       border: var(--pill-border);
     }
 
@@ -393,9 +464,9 @@
     }
 
     .info-box {
-      padding: 14px;
+      padding: 12px;
       display: grid;
-      gap: 8px;
+      gap: 6px;
     }
 
     .info-box strong {
@@ -413,7 +484,7 @@
       min-height: 46px;
       border-radius: var(--button-radius);
       border: 0;
-      font-weight: 900;
+      font-weight: 800;
       cursor: default;
     }
 
@@ -433,12 +504,12 @@
       display: grid;
       justify-items: center;
       gap: 8px;
-      padding: 18px 0 6px;
+      padding: 14px 0 4px;
     }
 
     .word {
       font-size: var(--word-size);
-      font-weight: 950;
+      font-weight: 850;
       line-height: 1;
       letter-spacing: 0;
       color: var(--word-ink);
@@ -446,8 +517,8 @@
 
     .meaning {
       color: var(--muted-copy);
-      font-size: 1.1rem;
-      font-weight: 800;
+      font-size: 1rem;
+      font-weight: 700;
     }
 
     .audio-mark {
@@ -461,7 +532,7 @@
       background: var(--audio-bg);
       border: var(--audio-border);
       font-size: 0.72rem;
-      font-weight: 950;
+      font-weight: 800;
       vertical-align: middle;
     }
 
@@ -473,16 +544,16 @@
       height: 34px;
       padding: 8px 10px;
       border-radius: var(--button-radius);
-      background: #ecfeff;
-      border: 1px solid #a5f3fc;
+      background: #edf5f6;
+      border: 1px solid #c5dadd;
     }
 
     .signal-ribbon span {
       display: block;
       min-height: 7px;
       border-radius: 999px;
-      background: linear-gradient(180deg, #06b6d4, #2f78e8);
-      opacity: 0.82;
+      background: linear-gradient(180deg, #aecfd1, #6f9fb2);
+      opacity: 0.7;
     }
 
     .signal-ribbon span:nth-child(2n) {
@@ -491,7 +562,7 @@
 
     .signal-ribbon span:nth-child(3n) {
       min-height: 25px;
-      background: linear-gradient(180deg, #f9736b, #2f78e8);
+      background: linear-gradient(180deg, #c7d9d2, #6f9fb2);
     }
 
     .brand-preview-gap {
@@ -802,51 +873,51 @@
     }
 
     .direction-card[data-direction="hybrid"] {
-      --proto-bg: #f1fbff;
-      --screen-bg: #fffefa;
-      --screen-ink: #172033;
+      --proto-bg: #edf4f5;
+      --screen-bg: #fbfdfc;
+      --screen-ink: #253238;
       --screen-radius: 8px;
-      --screen-border: 1px solid #d6e7ef;
-      --screen-shadow: 0 24px 48px rgba(23, 32, 51, 0.14);
-      --screen-pad: 18px;
-      --accent: #2f78e8;
+      --screen-border: 1px solid #cadbdd;
+      --screen-shadow: 0 24px 48px rgba(71, 91, 96, 0.13);
+      --screen-pad: 16px;
+      --accent: #6f9fb2;
       --accent-ink: #ffffff;
-      --muted-copy: #66717e;
-      --nav-muted: #7c8490;
-      --chip-bg: #ecfeff;
+      --muted-copy: #68797d;
+      --nav-muted: #819094;
+      --chip-bg: #edf5f6;
       --chip-radius: 999px;
-      --chip-shadow: inset 0 0 0 1px #a5f3fc;
-      --pill-bg: #fff7ed;
-      --pill-ink: #c2410c;
-      --pill-border: 1px solid #fed7aa;
+      --chip-shadow: inset 0 0 0 1px #c5dadd;
+      --pill-bg: #edf5f6;
+      --pill-ink: #526a72;
+      --pill-border: 1px solid #cbdcde;
       --pill-radius: 999px;
-      --card-bg: rgba(255, 255, 255, 0.94);
-      --card-border: 1px solid #dbeafe;
-      --card-shadow: 0 8px 20px rgba(23, 32, 51, 0.08);
+      --card-bg: rgba(255, 255, 255, 0.9);
+      --card-border: 1px solid #d9e5e5;
+      --card-shadow: 0 8px 20px rgba(71, 91, 96, 0.07);
       --card-radius: 8px;
       --button-radius: 8px;
-      --button-shadow: 0 10px 18px rgba(47, 120, 232, 0.22);
-      --secondary-bg: #f8fafc;
-      --secondary-ink: #2563eb;
-      --secondary-border: 1px solid #cfe3f5;
-      --word-size: 3.15rem;
-      --word-ink: #172033;
-      --audio-bg: #ecfeff;
-      --audio-border: 1px solid #67e8f9;
-      --wrong: #e11d48;
-      --wrong-bg: #fff7ed;
-      --correct: #16a34a;
-      --correct-bg: #ecfdf5;
-      --feedback-bg: #fff7ed;
-      --feedback-border: #fdba74;
-      --feedback-ink: #c2410c;
-      --row-bg: #fffefa;
-      --title-size: 1.75rem;
+      --button-shadow: 0 10px 18px rgba(111, 159, 178, 0.2);
+      --secondary-bg: #f7fbfb;
+      --secondary-ink: #55727b;
+      --secondary-border: 1px solid #d1e0e2;
+      --word-size: 3rem;
+      --word-ink: #253238;
+      --audio-bg: #edf5f6;
+      --audio-border: 1px solid #c5dadd;
+      --wrong: #a76660;
+      --wrong-bg: #fbf0ee;
+      --correct: #5f907b;
+      --correct-bg: #eef6f1;
+      --feedback-bg: #f7f1ec;
+      --feedback-border: #d8c2b5;
+      --feedback-ink: #8a5d50;
+      --row-bg: #fbfdfc;
+      --title-size: 1.58rem;
       --label-transform: none;
       --label-spacing: 0;
-      --texture-opacity: 0.16;
-      --texture: radial-gradient(circle at 16% 10%, rgba(249, 115, 107, 0.42) 0 5px, transparent 6px), radial-gradient(circle at 86% 16%, rgba(6, 182, 212, 0.3) 0 7px, transparent 8px), repeating-linear-gradient(90deg, transparent 0 18px, rgba(6, 182, 212, 0.16) 18px 20px);
-      --pattern-ink: rgba(47, 120, 232, 0.24);
+      --texture-opacity: 0.1;
+      --texture: repeating-linear-gradient(90deg, transparent 0 22px, rgba(141, 177, 184, 0.14) 22px 23px), radial-gradient(circle at 86% 14%, rgba(174, 207, 209, 0.32) 0 8px, transparent 9px);
+      --pattern-ink: rgba(96, 121, 130, 0.18);
     }
 
     @media (max-width: 1100px) {
@@ -891,7 +962,7 @@
     <header class="review-top">
       <div>
         <h1>小音标 M10 视觉方向原型</h1>
-        <p>#175 评审用交互原型。已按选择聚焦 B+A：用 B 的温和练习室作为整体体验，再引入 A 的音频信号与 IPA 清晰度。A/B/C 保留作对照。</p>
+              <p>#175 评审用交互原型。已按反馈收敛 B+A：更克制的莫兰迪淡青蓝色系、统一中文字体层级，并预留登录入口。</p>
       </div>
       <div class="controls" aria-label="原型控制">
         <div class="segmented" aria-label="视觉方向筛选">
@@ -1029,11 +1100,11 @@
               <p>已选方向：B 的温和练习体验 + A 的声波/音标信号语言。中文产品名为“小音标”。</p>
             </div>
             <div class="swatches" aria-label="小音标练习室配色">
-              <span class="swatch" style="background:#172033"></span>
-              <span class="swatch" style="background:#2f78e8"></span>
-              <span class="swatch" style="background:#06b6d4"></span>
-              <span class="swatch" style="background:#f9736b"></span>
-              <span class="swatch" style="background:#31b981"></span>
+              <span class="swatch" style="background:#253238"></span>
+              <span class="swatch" style="background:#6f9fb2"></span>
+              <span class="swatch" style="background:#aecfd1"></span>
+              <span class="swatch" style="background:#d8c2b5"></span>
+              <span class="swatch" style="background:#5f907b"></span>
             </div>
           </div>
           <div class="proto-wrap">
@@ -1041,7 +1112,7 @@
               <div class="brand-mark">小</div>
               <div class="brand-copy">
                 <strong>小音标</strong>
-                <span>把 IPA 变成每天几分钟的声音练习。字形方向：圆润、有手写感，但 IPA 使用等宽清晰字形。</span>
+                <span>把 IPA 变成每天几分钟的声音练习。字形方向：统一、清爽、稍带圆润；图案只保留轻声纹。</span>
               </div>
             </div>
             <div class="brand-preview-gap" aria-hidden="true"></div>
@@ -1055,7 +1126,7 @@
           <div class="notes">
             <div><h3>强项</h3><p>青少年吸引力、IPA 可信度、答错后可恢复感之间最平衡。</p></div>
             <div><h3>风险</h3><p>图案必须克制：一个核心声音信号，而不是到处装饰。</p></div>
-            <div><h3>视觉母题</h3><p>“小”字标、声波条、音标碎片、圆角练习卡。</p></div>
+            <div><h3>视觉母题</h3><p>“小”字标、轻声纹、淡青蓝卡片、登录入口占位。</p></div>
           </div>
         </article>
       </section>
@@ -1064,16 +1135,16 @@
 
   <template id="today-template">
     <nav class="proto-nav"><span class="active">今日</span><span>进度</span><span>设置</span></nav>
-    <div class="brand-strip">
-      <div class="brand-mark">小</div>
-      <div class="brand-copy"><strong>小音标</strong><span>每天几分钟，把声音和 IPA 对上号。</span></div>
+    <div class="home-topline">
+      <div class="brand-strip home-brand">
+        <div class="brand-mark">小</div>
+        <div class="brand-copy"><strong>小音标</strong><span>每天几分钟，把声音和 IPA 对上号。</span></div>
+        <span class="login-entry">登录</span>
+      </div>
     </div>
-    <span class="mini-label">今日练习</span>
     <div class="hero-line"><h3>入门已选</h3><span class="status-pill">美式发音</span></div>
-    <div class="info-box"><strong>准备开始入门</strong><span>今天 2 个词。有值得回放的错题时，复习入口会自动出现。</span></div>
-    <div class="signal-ribbon" aria-label="声音信号图案"><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span></div>
+    <div class="info-box"><strong>今天 2 个词</strong><span>先听，再选音标。登录后可同步进度和错题。</span></div>
     <button class="primary-action">开始入门练习</button>
-    <button class="secondary-action">复习最近错题</button>
     <button class="secondary-action">查看进度</button>
   </template>
 
@@ -1097,6 +1168,7 @@
   <template id="settings-template">
     <nav class="proto-nav"><span>今日</span><span>进度</span><span class="active">设置</span></nav>
     <span class="mini-label">设置</span>
+    <div class="account-box"><div class="account-icon">人</div><div><strong>登录后同步练习</strong><span>预留账号入口：保存进度、错题和设备间同步。</span></div></div>
     <div class="settings-box"><strong>练习级别</strong><div class="level-choice"><strong>入门</strong><span>短练习组，先掌握最常见的 IPA 对比。</span></div><div class="level-choice"><strong>进阶</strong><span>更长单词，从下一组开始生效。</span></div></div>
     <div class="settings-box"><strong>专注练习</strong><div class="phoneme-row"><span class="phoneme-symbol">/ʃ/</span><span>ship, shoe, special</span><button class="secondary-action">开始专注</button></div></div>
   </template>

--- a/docs/design/m10-visual-direction-prototypes.html
+++ b/docs/design/m10-visual-direction-prototypes.html
@@ -1,9 +1,9 @@
 <!doctype html>
-<html lang="en">
+<html lang="zh-CN">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Tiny IPA M10 Visual Direction Prototypes</title>
+  <title>小音标 M10 视觉方向原型</title>
   <style>
     :root {
       color-scheme: light;
@@ -15,7 +15,9 @@
       --focus: #2563eb;
       --radius: 8px;
       --shadow: 0 18px 45px rgba(18, 24, 38, 0.12);
-      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      --cn-ui-font: "PingFang SC", "Hiragino Sans GB", "Noto Sans SC", "Source Han Sans SC", "Microsoft YaHei", ui-sans-serif, system-ui, sans-serif;
+      --cn-brand-font: "TsangerYuYangT W05", "HYQiHei 60S", "PingFang SC", "Noto Sans SC", "Microsoft YaHei", sans-serif;
+      font-family: var(--cn-ui-font);
     }
 
     * {
@@ -175,6 +177,11 @@
       overflow: hidden;
     }
 
+    .direction-card.is-selected {
+      border-color: #2f78e8;
+      box-shadow: 0 22px 56px rgba(47, 120, 232, 0.2);
+    }
+
     .direction-header {
       display: grid;
       grid-template-columns: minmax(0, 1fr) auto;
@@ -249,6 +256,19 @@
       background: var(--texture);
     }
 
+    .proto-screen::after {
+      content: "小  /ʃ/  /θ/  /ɪ/";
+      position: absolute;
+      right: 12px;
+      bottom: 10px;
+      color: var(--pattern-ink, rgba(47, 120, 232, 0.2));
+      font-family: var(--cn-brand-font);
+      font-size: 0.78rem;
+      font-weight: 900;
+      letter-spacing: 0;
+      pointer-events: none;
+    }
+
     .proto-inner {
       position: relative;
       z-index: 1;
@@ -257,6 +277,48 @@
       display: flex;
       flex-direction: column;
       gap: 14px;
+    }
+
+    .brand-strip {
+      display: grid;
+      grid-template-columns: auto 1fr;
+      gap: 12px;
+      align-items: center;
+      padding: 12px;
+      border-radius: var(--card-radius);
+      border: var(--card-border);
+      background: linear-gradient(135deg, rgba(255, 255, 255, 0.96), rgba(236, 254, 255, 0.86));
+      box-shadow: var(--card-shadow);
+    }
+
+    .brand-mark {
+      display: grid;
+      place-items: center;
+      width: 56px;
+      height: 56px;
+      border-radius: 8px;
+      background: #172033;
+      color: #fffefa;
+      font-family: var(--cn-brand-font);
+      font-size: 1.65rem;
+      font-weight: 950;
+      line-height: 1;
+      box-shadow: inset 0 -6px 0 rgba(6, 182, 212, 0.26);
+    }
+
+    .brand-copy strong {
+      display: block;
+      font-family: var(--cn-brand-font);
+      font-size: 1.28rem;
+      line-height: 1.1;
+    }
+
+    .brand-copy span {
+      display: block;
+      margin-top: 4px;
+      color: var(--muted-copy);
+      font-size: 0.82rem;
+      line-height: 1.35;
     }
 
     .proto-nav {
@@ -401,6 +463,39 @@
       font-size: 0.72rem;
       font-weight: 950;
       vertical-align: middle;
+    }
+
+    .signal-ribbon {
+      display: grid;
+      grid-template-columns: repeat(12, 1fr);
+      gap: 3px;
+      align-items: end;
+      height: 34px;
+      padding: 8px 10px;
+      border-radius: var(--button-radius);
+      background: #ecfeff;
+      border: 1px solid #a5f3fc;
+    }
+
+    .signal-ribbon span {
+      display: block;
+      min-height: 7px;
+      border-radius: 999px;
+      background: linear-gradient(180deg, #06b6d4, #2f78e8);
+      opacity: 0.82;
+    }
+
+    .signal-ribbon span:nth-child(2n) {
+      min-height: 18px;
+    }
+
+    .signal-ribbon span:nth-child(3n) {
+      min-height: 25px;
+      background: linear-gradient(180deg, #f9736b, #2f78e8);
+    }
+
+    .brand-preview-gap {
+      height: 12px;
     }
 
     .choice-list {
@@ -607,6 +702,7 @@
       --label-spacing: 0.08em;
       --texture-opacity: 0.2;
       --texture: repeating-linear-gradient(90deg, transparent 0 14px, rgba(6, 182, 212, 0.2) 14px 16px);
+      --pattern-ink: rgba(37, 99, 235, 0.18);
     }
 
     .direction-card[data-direction="studio"] {
@@ -654,6 +750,7 @@
       --label-spacing: 0;
       --texture-opacity: 0.08;
       --texture: radial-gradient(circle at 10% 8%, #f9736b 0 8px, transparent 9px), radial-gradient(circle at 92% 14%, #a78bfa 0 7px, transparent 8px);
+      --pattern-ink: rgba(249, 115, 107, 0.2);
     }
 
     .direction-card[data-direction="mission"] {
@@ -701,6 +798,7 @@
       --label-spacing: 0.06em;
       --texture-opacity: 0.12;
       --texture: linear-gradient(135deg, rgba(124, 58, 237, 0.28) 0 2px, transparent 2px 14px);
+      --pattern-ink: rgba(29, 78, 216, 0.16);
     }
 
     .direction-card[data-direction="hybrid"] {
@@ -747,7 +845,8 @@
       --label-transform: none;
       --label-spacing: 0;
       --texture-opacity: 0.16;
-      --texture: repeating-linear-gradient(90deg, transparent 0 18px, rgba(6, 182, 212, 0.16) 18px 20px);
+      --texture: radial-gradient(circle at 16% 10%, rgba(249, 115, 107, 0.42) 0 5px, transparent 6px), radial-gradient(circle at 86% 16%, rgba(6, 182, 212, 0.3) 0 7px, transparent 8px), repeating-linear-gradient(90deg, transparent 0 18px, rgba(6, 182, 212, 0.16) 18px 20px);
+      --pattern-ink: rgba(47, 120, 232, 0.24);
     }
 
     @media (max-width: 1100px) {
@@ -791,48 +890,47 @@
   <main class="shell">
     <header class="review-top">
       <div>
-        <h1>Tiny IPA M10 visual direction prototypes</h1>
-        <p>Interactive review artifact for issue #175. Compare the same learner flows across direction A, B, C, and the recommended B+A hybrid before choosing a production UI direction.</p>
+        <h1>小音标 M10 视觉方向原型</h1>
+        <p>#175 评审用交互原型。已按选择聚焦 B+A：用 B 的温和练习室作为整体体验，再引入 A 的音频信号与 IPA 清晰度。A/B/C 保留作对照。</p>
       </div>
-      <div class="controls" aria-label="Prototype controls">
-        <div class="segmented" aria-label="Direction filter">
-          <button type="button" data-filter="all" aria-pressed="true">All</button>
+      <div class="controls" aria-label="原型控制">
+        <div class="segmented" aria-label="视觉方向筛选">
+          <button type="button" data-filter="all" aria-pressed="false">全部</button>
           <button type="button" data-filter="sound" aria-pressed="false">A</button>
           <button type="button" data-filter="studio" aria-pressed="false">B</button>
           <button type="button" data-filter="mission" aria-pressed="false">C</button>
-          <button type="button" data-filter="hybrid" aria-pressed="false">B+A</button>
+          <button type="button" data-filter="hybrid" aria-pressed="true">B+A</button>
         </div>
-        <div class="segmented" aria-label="Viewport mode">
-          <button type="button" data-viewport="desktop" aria-pressed="true">Desktop</button>
-          <button type="button" data-viewport="mobile" aria-pressed="false">Mobile</button>
+        <div class="segmented" aria-label="视口模式">
+          <button type="button" data-viewport="desktop" aria-pressed="true">桌面</button>
+          <button type="button" data-viewport="mobile" aria-pressed="false">手机</button>
         </div>
       </div>
     </header>
 
     <div class="review-grid">
       <aside class="decision-panel">
-        <h2>Decision Gate</h2>
-        <p>Pick a visual direction after inspecting the prototype screens. This is not production UI; it is an evaluation artifact.</p>
-        <h3>Recommended</h3>
-        <p><strong>B+A hybrid</strong>: Practice Studio overall, with Sound Lab's restrained IPA/audio signal motif.</p>
-        <h3>Choose</h3>
+        <h2>视觉评审门</h2>
+        <p>这不是生产 UI，是用于判断方向的 HTML 原型。当前默认展示已选择的 B+A 方向。</p>
+        <h3>当前选择</h3>
+        <p><strong>B+A 小音标练习室</strong>：整体温和、有练习陪伴感，同时用声波、音标碎片和“小”字标识建立记忆点。</p>
+        <h3>评审结论</h3>
         <div class="vote-list">
-          <button type="button" data-vote="A">A - Sound Lab</button>
-          <button type="button" data-vote="B">B - Practice Studio</button>
-          <button type="button" data-vote="C">C - Mission Cards</button>
-          <button type="button" data-vote="B+A hybrid">B+A hybrid</button>
-          <button type="button" data-vote="Defer">Defer for mockups</button>
+          <button type="button" data-vote="认可 B+A 小音标练习室" aria-pressed="true">认可 B+A</button>
+          <button type="button" data-vote="认可 B+A，但需要调整字体/图案">认可但调字体/图案</button>
+          <button type="button" data-vote="认可 B+A，但需要调整配色">认可但调配色</button>
+          <button type="button" data-vote="暂缓，需要更多视觉稿">暂缓，需要更多视觉稿</button>
         </div>
-        <h3>Response to paste</h3>
-        <div class="vote-output" id="voteOutput">Select visual direction: <pending>
-Optional notes: </div>
-        <h3>Review checks</h3>
+        <h3>可复制回复</h3>
+        <div class="vote-output" id="voteOutput">视觉方向选择：认可 B+A 小音标练习室
+补充意见：</div>
+        <h3>检查点</h3>
         <ul>
-          <li>Would a teen want to come back?</li>
-          <li>Is IPA easier to read?</li>
-          <li>Does a wrong answer feel recoverable?</li>
-          <li>Does Progress motivate without pressure?</li>
-          <li>Does mobile feel like the primary surface?</li>
+          <li>青少年会不会愿意回来练？</li>
+          <li>IPA 是否更容易读？</li>
+          <li>答错后是否感觉可以恢复？</li>
+          <li>进度页是否激励但不施压？</li>
+          <li>手机端是否像第一体验面？</li>
         </ul>
       </aside>
 
@@ -840,10 +938,10 @@ Optional notes: </div>
         <article class="direction-card" data-direction="sound">
           <div class="direction-header">
             <div>
-              <h2>A. Sound Lab</h2>
-              <p>Precise, signal-driven, and trustworthy. Best for IPA/audio clarity; risk is feeling too clinical.</p>
+              <h2>A. 声音实验室</h2>
+              <p>准确、信号化、有可信度。强项是 IPA 与音频清晰；风险是偏工具感。</p>
             </div>
-            <div class="swatches" aria-label="Sound Lab colors">
+            <div class="swatches" aria-label="声音实验室配色">
               <span class="swatch" style="background:#172033"></span>
               <span class="swatch" style="background:#2563eb"></span>
               <span class="swatch" style="background:#06b6d4"></span>
@@ -860,19 +958,19 @@ Optional notes: </div>
             </div>
           </div>
           <div class="notes">
-            <div><h3>Best at</h3><p>IPA confidence, audio status, technical trust.</p></div>
-            <div><h3>Watch risk</h3><p>May feel like a diagnostics tool if copy stays dry.</p></div>
-            <div><h3>Useful motif</h3><p>Subtle waveform/phoneme signal treatment.</p></div>
+            <div><h3>强项</h3><p>IPA 可信度、音频状态、技术清晰度。</p></div>
+            <div><h3>风险</h3><p>文案过冷时会像诊断工具。</p></div>
+            <div><h3>可继承母题</h3><p>克制的声波与音素信号处理。</p></div>
           </div>
         </article>
 
         <article class="direction-card" data-direction="studio">
           <div class="direction-header">
             <div>
-              <h2>B. Practice Studio</h2>
-              <p>Warm, tactile, and forgiving. Best broad teen fit; strongest for wrong-answer recovery.</p>
+              <h2>B. 练习室</h2>
+              <p>温和、有触感、允许犯错。青少年适配度最好，最利于答错后的继续练习。</p>
             </div>
-            <div class="swatches" aria-label="Practice Studio colors">
+            <div class="swatches" aria-label="练习室配色">
               <span class="swatch" style="background:#202124"></span>
               <span class="swatch" style="background:#3b82f6"></span>
               <span class="swatch" style="background:#f9736b"></span>
@@ -889,19 +987,19 @@ Optional notes: </div>
             </div>
           </div>
           <div class="notes">
-            <div><h3>Best at</h3><p>Everyday appeal, forgiving feedback, clear action hierarchy.</p></div>
-            <div><h3>Watch risk</h3><p>Needs a distinctive IPA/audio motif to avoid generic app polish.</p></div>
-            <div><h3>Useful motif</h3><p>Practice desk, tactile tiles, recovery shelf.</p></div>
+            <div><h3>强项</h3><p>日常吸引力、温和反馈、清楚的操作层级。</p></div>
+            <div><h3>风险</h3><p>需要独特的 IPA/音频母题，否则会显得普通。</p></div>
+            <div><h3>可继承母题</h3><p>练习桌、可触摸卡片、恢复型反馈区。</p></div>
           </div>
         </article>
 
         <article class="direction-card" data-direction="mission">
           <div class="direction-header">
             <div>
-              <h2>C. Mission Cards</h2>
-              <p>Goal-oriented and compact. Good for daily momentum; risk is over-emphasizing completion.</p>
+              <h2>C. 任务卡</h2>
+              <p>目标明确、结构紧凑。适合每日推进；风险是过度强调完成和打卡。</p>
             </div>
-            <div class="swatches" aria-label="Mission Cards colors">
+            <div class="swatches" aria-label="任务卡配色">
               <span class="swatch" style="background:#171717"></span>
               <span class="swatch" style="background:#1d4ed8"></span>
               <span class="swatch" style="background:#84cc16"></span>
@@ -918,19 +1016,19 @@ Optional notes: </div>
             </div>
           </div>
           <div class="notes">
-            <div><h3>Best at</h3><p>Next-action clarity and short-session momentum.</p></div>
-            <div><h3>Watch risk</h3><p>Can drift into habit-app pressure or reward loops.</p></div>
-            <div><h3>Useful motif</h3><p>Mission state cards: Start, Learn, Review, Next.</p></div>
+            <div><h3>强项</h3><p>下一步清楚，短练习很有推进感。</p></div>
+            <div><h3>风险</h3><p>容易变成习惯 App 压力或奖励循环。</p></div>
+            <div><h3>可继承母题</h3><p>开始、学习、复习、下一步的状态卡。</p></div>
           </div>
         </article>
 
-        <article class="direction-card" data-direction="hybrid">
+        <article class="direction-card is-selected" data-direction="hybrid">
           <div class="direction-header">
             <div>
-              <h2>B+A. Studio Signal</h2>
-              <p>Recommended hybrid: Practice Studio warmth with Sound Lab's IPA/audio signal language.</p>
+              <h2>B+A. 小音标练习室</h2>
+              <p>已选方向：B 的温和练习体验 + A 的声波/音标信号语言。中文产品名为“小音标”。</p>
             </div>
-            <div class="swatches" aria-label="Studio Signal colors">
+            <div class="swatches" aria-label="小音标练习室配色">
               <span class="swatch" style="background:#172033"></span>
               <span class="swatch" style="background:#2f78e8"></span>
               <span class="swatch" style="background:#06b6d4"></span>
@@ -939,6 +1037,14 @@ Optional notes: </div>
             </div>
           </div>
           <div class="proto-wrap">
+            <div class="brand-strip" aria-label="小音标品牌方向">
+              <div class="brand-mark">小</div>
+              <div class="brand-copy">
+                <strong>小音标</strong>
+                <span>把 IPA 变成每天几分钟的声音练习。字形方向：圆润、有手写感，但 IPA 使用等宽清晰字形。</span>
+              </div>
+            </div>
+            <div class="brand-preview-gap" aria-hidden="true"></div>
             <div class="screen-grid">
               <div class="proto-screen"><div class="proto-inner" data-screen="today"></div></div>
               <div class="proto-screen"><div class="proto-inner" data-screen="practice"></div></div>
@@ -947,9 +1053,9 @@ Optional notes: </div>
             </div>
           </div>
           <div class="notes">
-            <div><h3>Best at</h3><p>Balanced teen appeal, IPA trust, and recoverable mistakes.</p></div>
-            <div><h3>Watch risk</h3><p>Must stay disciplined; one signature signal, not decoration everywhere.</p></div>
-            <div><h3>Useful motif</h3><p>Warm practice layout plus audio/phoneme signal strip.</p></div>
+            <div><h3>强项</h3><p>青少年吸引力、IPA 可信度、答错后可恢复感之间最平衡。</p></div>
+            <div><h3>风险</h3><p>图案必须克制：一个核心声音信号，而不是到处装饰。</p></div>
+            <div><h3>视觉母题</h3><p>“小”字标、声波条、音标碎片、圆角练习卡。</p></div>
           </div>
         </article>
       </section>
@@ -957,37 +1063,42 @@ Optional notes: </div>
   </main>
 
   <template id="today-template">
-    <nav class="proto-nav"><span class="active">Today</span><span>Progress</span><span>Settings</span></nav>
-    <span class="mini-label">Today practice hub</span>
-    <div class="hero-line"><h3>Entry selected</h3><span class="status-pill">US audio</span></div>
-    <div class="info-box"><strong>Ready to start Entry</strong><span>2 words today. Review appears when there is something useful to replay.</span></div>
-    <button class="primary-action">Start Entry group</button>
-    <button class="secondary-action">Review recent mistakes</button>
-    <button class="secondary-action">View Progress</button>
+    <nav class="proto-nav"><span class="active">今日</span><span>进度</span><span>设置</span></nav>
+    <div class="brand-strip">
+      <div class="brand-mark">小</div>
+      <div class="brand-copy"><strong>小音标</strong><span>每天几分钟，把声音和 IPA 对上号。</span></div>
+    </div>
+    <span class="mini-label">今日练习</span>
+    <div class="hero-line"><h3>入门已选</h3><span class="status-pill">美式发音</span></div>
+    <div class="info-box"><strong>准备开始入门</strong><span>今天 2 个词。有值得回放的错题时，复习入口会自动出现。</span></div>
+    <div class="signal-ribbon" aria-label="声音信号图案"><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span><span></span></div>
+    <button class="primary-action">开始入门练习</button>
+    <button class="secondary-action">复习最近错题</button>
+    <button class="secondary-action">查看进度</button>
   </template>
 
   <template id="practice-template">
-    <nav class="proto-nav"><span class="active">Today</span><span>Progress</span><span>Settings</span></nav>
-    <div class="hero-line"><span class="mini-label">Practice group 1 / 2</span><span class="status-pill">Entry</span></div>
-    <div class="info-box"><strong>Practice group</strong><span>Listen, compare the sound, then choose the IPA.</span></div>
-    <div class="word-zone"><div><span class="word">ship</span><span class="audio-mark">TTS</span></div><div class="meaning">船</div></div>
+    <nav class="proto-nav"><span class="active">今日</span><span>进度</span><span>设置</span></nav>
+    <div class="hero-line"><span class="mini-label">练习组 1 / 2</span><span class="status-pill">入门</span></div>
+    <div class="info-box"><strong>跟读单词</strong><span>听一遍，比较声音，再选择对应的音标。</span></div>
+    <div class="word-zone"><div><span class="word">ship</span><span class="audio-mark">听</span></div><div class="meaning">船</div></div>
     <div class="choice-list"><div class="choice wrong">/sɪp/</div><div class="choice correct">/ʃɪp/</div></div>
-    <div class="feedback-box"><div class="feedback-title">Not quite. Study the contrast.</div><div class="compare-grid"><span>You picked</span><code>/sɪp/</code><span>Correct IPA</span><code>/ʃɪp/</code><span>Target sound</span><code>/ʃ/</code></div></div>
+    <div class="feedback-box"><div class="feedback-title">不太对，先看这个差异。</div><div class="compare-grid"><span>你选了</span><code>/sɪp/</code><span>正确音标</span><code>/ʃɪp/</code><span>目标音</span><code>/ʃ/</code></div></div>
   </template>
 
   <template id="progress-template">
-    <nav class="proto-nav"><span>Today</span><span class="active">Progress</span><span>Settings</span></nav>
-    <span class="mini-label">Progress</span>
-    <div class="progress-row"><div class="progress-box"><strong>0</strong><span>day streak</span></div><div class="progress-box"><strong>2</strong><span>attempts</span></div><div class="progress-box"><strong>1</strong><span>group done</span></div></div>
-    <div class="info-box"><strong>Needs practice in Entry</strong><span>Focus one sound and make the next group easier to understand.</span></div>
-    <div class="phoneme-list"><div class="phoneme-row"><span class="phoneme-symbol">/ʃ/</span><span>50% accuracy</span><button class="secondary-action">Focus /ʃ/</button></div><div class="phoneme-row"><span class="phoneme-symbol">/θ/</span><span>new signal</span><button class="secondary-action">Focus /θ/</button></div></div>
+    <nav class="proto-nav"><span>今日</span><span class="active">进度</span><span>设置</span></nav>
+    <span class="mini-label">进度</span>
+    <div class="progress-row"><div class="progress-box"><strong>0</strong><span>连续天数</span></div><div class="progress-box"><strong>2</strong><span>次尝试</span></div><div class="progress-box"><strong>1</strong><span>已完成组</span></div></div>
+    <div class="info-box"><strong>入门还需练</strong><span>先专注一个声音，让下一组更容易听懂。</span></div>
+    <div class="phoneme-list"><div class="phoneme-row"><span class="phoneme-symbol">/ʃ/</span><span>正确率 50%</span><button class="secondary-action">专注 /ʃ/</button></div><div class="phoneme-row"><span class="phoneme-symbol">/θ/</span><span>新声音</span><button class="secondary-action">专注 /θ/</button></div></div>
   </template>
 
   <template id="settings-template">
-    <nav class="proto-nav"><span>Today</span><span>Progress</span><span class="active">Settings</span></nav>
-    <span class="mini-label">Settings</span>
-    <div class="settings-box"><strong>Practice level</strong><div class="level-choice"><strong>Entry</strong><span>Starter IPA contrasts with short daily groups.</span></div><div class="level-choice"><strong>Mid</strong><span>Longer words. Starts with the next new group.</span></div></div>
-    <div class="settings-box"><strong>Focus practice</strong><div class="phoneme-row"><span class="phoneme-symbol">/ʃ/</span><span>ship, shoe, special</span><button class="secondary-action">Start focus</button></div></div>
+    <nav class="proto-nav"><span>今日</span><span>进度</span><span class="active">设置</span></nav>
+    <span class="mini-label">设置</span>
+    <div class="settings-box"><strong>练习级别</strong><div class="level-choice"><strong>入门</strong><span>短练习组，先掌握最常见的 IPA 对比。</span></div><div class="level-choice"><strong>进阶</strong><span>更长单词，从下一组开始生效。</span></div></div>
+    <div class="settings-box"><strong>专注练习</strong><div class="phoneme-row"><span class="phoneme-symbol">/ʃ/</span><span>ship, shoe, special</span><button class="secondary-action">开始专注</button></div></div>
   </template>
 
   <script>
@@ -1005,6 +1116,9 @@ Optional notes: </div>
 
     const directionButtons = document.querySelectorAll("[data-filter]");
     const cards = document.querySelectorAll(".direction-card");
+    cards.forEach((card) => {
+      card.hidden = card.dataset.direction !== "hybrid";
+    });
     directionButtons.forEach((button) => {
       button.addEventListener("click", () => {
         const filter = button.dataset.filter;
@@ -1029,7 +1143,7 @@ Optional notes: </div>
         document.querySelectorAll("[data-vote]").forEach((item) => {
           item.setAttribute("aria-pressed", String(item === button));
         });
-        voteOutput.textContent = `Select visual direction: ${button.dataset.vote}\nOptional notes: `;
+        voteOutput.textContent = `视觉方向选择：${button.dataset.vote}\n补充意见：`;
       });
     });
   </script>

--- a/docs/design/m10-visual-direction-prototypes.html
+++ b/docs/design/m10-visual-direction-prototypes.html
@@ -7,16 +7,17 @@
   <style>
     :root {
       color-scheme: light;
-      --page: #f3f6f6;
-      --ink: #253238;
-      --muted: #65777d;
-      --line: #d7e1e2;
+      --page: #f1eee8;
+      --ink: #2f3533;
+      --muted: #746f68;
+      --line: #d9d2c7;
       --panel: #ffffff;
-      --focus: #6f9fb2;
+      --focus: #8aa0a3;
       --radius: 8px;
-      --shadow: 0 18px 45px rgba(56, 76, 82, 0.1);
+      --shadow: 0 18px 45px rgba(72, 63, 54, 0.11);
       --cn-ui-font: "PingFang SC", "Hiragino Sans GB", "Noto Sans SC", "Source Han Sans SC", "Microsoft YaHei", ui-sans-serif, system-ui, sans-serif;
-      --cn-brand-font: "PingFang SC", "Hiragino Sans GB", "Noto Sans SC", "Source Han Sans SC", "Microsoft YaHei", sans-serif;
+      --cn-brand-font: "Kaiti SC", "STKaiti", "LXGW WenKai Screen", "Songti SC", "Noto Serif CJK SC", serif;
+      --cn-display-font: "Songti SC", "Noto Serif CJK SC", "Source Han Serif SC", "PingFang SC", serif;
       font-family: var(--cn-ui-font);
     }
 
@@ -26,9 +27,37 @@
 
     body {
       margin: 0;
-      background: var(--page);
+      background:
+        linear-gradient(130deg, rgba(255, 255, 255, 0.56), transparent 42%),
+        linear-gradient(180deg, #f4f1eb 0%, var(--page) 54%, #ebe7df 100%);
       color: var(--ink);
       min-height: 100vh;
+    }
+
+    @keyframes tonalDrift {
+      0% {
+        transform: translateX(-34%) skewX(-10deg);
+        opacity: 0.2;
+      }
+
+      48% {
+        opacity: 0.34;
+      }
+
+      100% {
+        transform: translateX(34%) skewX(-10deg);
+        opacity: 0.2;
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      *,
+      *::before,
+      *::after {
+        animation-duration: 0.001ms !important;
+        animation-iteration-count: 1 !important;
+        scroll-behavior: auto !important;
+      }
     }
 
     button {
@@ -51,7 +80,9 @@
 
     .review-top h1 {
       margin: 0 0 6px;
+      font-family: var(--cn-display-font);
       font-size: clamp(1.35rem, 2vw, 2rem);
+      font-weight: 760;
       letter-spacing: 0;
     }
 
@@ -90,7 +121,7 @@
     }
 
     .segmented button[aria-pressed="true"] {
-      background: #415e68;
+      background: #5f6762;
       color: #fff;
     }
 
@@ -149,8 +180,8 @@
 
     .vote-list button[aria-pressed="true"] {
       border-color: var(--focus);
-      background: #edf5f6;
-      color: #415e68;
+      background: #eeebe5;
+      color: #5f6762;
     }
 
     .vote-output {
@@ -178,8 +209,8 @@
     }
 
     .direction-card.is-selected {
-      border-color: #8ab4bd;
-      box-shadow: 0 22px 56px rgba(87, 121, 129, 0.16);
+      border-color: #b9b0a3;
+      box-shadow: 0 22px 56px rgba(72, 63, 54, 0.16);
     }
 
     .direction-header {
@@ -193,7 +224,9 @@
 
     .direction-header h2 {
       margin: 0 0 4px;
+      font-family: var(--cn-display-font);
       font-size: 1.2rem;
+      font-weight: 760;
     }
 
     .direction-header p {
@@ -218,6 +251,23 @@
     .proto-wrap {
       padding: 18px;
       background: var(--proto-bg);
+      position: relative;
+      overflow: hidden;
+    }
+
+    .direction-card[data-direction="hybrid"] .proto-wrap::before {
+      content: "";
+      position: absolute;
+      inset: -30% -18%;
+      pointer-events: none;
+      background: linear-gradient(105deg, transparent 24%, rgba(255, 255, 255, 0.54) 43%, rgba(211, 197, 180, 0.18) 56%, transparent 72%);
+      filter: blur(18px);
+      animation: tonalDrift 10s ease-in-out infinite alternate;
+    }
+
+    .proto-wrap > * {
+      position: relative;
+      z-index: 1;
     }
 
     .screen-grid {
@@ -287,7 +337,7 @@
       padding: 10px;
       border-radius: var(--card-radius);
       border: var(--card-border);
-      background: linear-gradient(135deg, rgba(255, 255, 255, 0.96), rgba(236, 244, 245, 0.92));
+      background: linear-gradient(135deg, rgba(255, 255, 255, 0.9), rgba(235, 229, 219, 0.92));
       box-shadow: var(--card-shadow);
     }
 
@@ -297,20 +347,20 @@
       width: 48px;
       height: 48px;
       border-radius: 8px;
-      background: #415e68;
-      color: #f7fbfb;
+      background: #5f6762;
+      color: #fbf9f3;
       font-family: var(--cn-brand-font);
-      font-size: 1.45rem;
-      font-weight: 700;
+      font-size: 1.62rem;
+      font-weight: 600;
       line-height: 1;
-      box-shadow: inset 0 -5px 0 rgba(174, 207, 209, 0.34);
+      box-shadow: inset 0 -5px 0 rgba(205, 189, 171, 0.34);
     }
 
     .brand-copy strong {
       display: block;
       font-family: var(--cn-brand-font);
-      font-size: 1.16rem;
-      font-weight: 800;
+      font-size: 1.3rem;
+      font-weight: 600;
       line-height: 1.1;
     }
 
@@ -349,9 +399,9 @@
       min-height: 32px;
       padding: 0 10px;
       border-radius: 999px;
-      border: 1px solid #cbdcde;
-      background: rgba(255, 255, 255, 0.72);
-      color: #526a72;
+      border: 1px solid #d2c9bd;
+      background: rgba(255, 255, 255, 0.62);
+      color: #665f57;
       font-size: 0.78rem;
       font-weight: 700;
       white-space: nowrap;
@@ -364,8 +414,8 @@
       align-items: center;
       padding: 12px;
       border-radius: var(--card-radius);
-      border: 1px dashed #b9cdd1;
-      background: rgba(246, 250, 250, 0.82);
+      border: 1px dashed #cbbfb1;
+      background: rgba(250, 248, 243, 0.82);
     }
 
     .account-icon {
@@ -374,8 +424,8 @@
       width: 36px;
       height: 36px;
       border-radius: 50%;
-      color: #607982;
-      background: #e8f1f2;
+      color: #70685f;
+      background: #eee8dd;
       font-weight: 800;
     }
 
@@ -432,7 +482,9 @@
 
     .hero-line h3 {
       margin: 0;
+      font-family: var(--cn-display-font);
       font-size: var(--title-size);
+      font-weight: 760;
       letter-spacing: 0;
       line-height: 1;
     }
@@ -873,51 +925,51 @@
     }
 
     .direction-card[data-direction="hybrid"] {
-      --proto-bg: #edf4f5;
-      --screen-bg: #fbfdfc;
-      --screen-ink: #253238;
+      --proto-bg: #ebe7df;
+      --screen-bg: #fbfaf6;
+      --screen-ink: #2f3533;
       --screen-radius: 8px;
-      --screen-border: 1px solid #cadbdd;
-      --screen-shadow: 0 24px 48px rgba(71, 91, 96, 0.13);
+      --screen-border: 1px solid #d7cfc4;
+      --screen-shadow: 0 24px 48px rgba(72, 63, 54, 0.14);
       --screen-pad: 16px;
-      --accent: #6f9fb2;
+      --accent: #82999d;
       --accent-ink: #ffffff;
-      --muted-copy: #68797d;
-      --nav-muted: #819094;
-      --chip-bg: #edf5f6;
+      --muted-copy: #746f68;
+      --nav-muted: #8b857d;
+      --chip-bg: #eee9df;
       --chip-radius: 999px;
-      --chip-shadow: inset 0 0 0 1px #c5dadd;
-      --pill-bg: #edf5f6;
-      --pill-ink: #526a72;
-      --pill-border: 1px solid #cbdcde;
+      --chip-shadow: inset 0 0 0 1px #d8cfc2;
+      --pill-bg: #eee9df;
+      --pill-ink: #665f57;
+      --pill-border: 1px solid #d2c9bd;
       --pill-radius: 999px;
-      --card-bg: rgba(255, 255, 255, 0.9);
-      --card-border: 1px solid #d9e5e5;
-      --card-shadow: 0 8px 20px rgba(71, 91, 96, 0.07);
+      --card-bg: rgba(255, 255, 255, 0.86);
+      --card-border: 1px solid #dfd8ce;
+      --card-shadow: 0 8px 20px rgba(72, 63, 54, 0.07);
       --card-radius: 8px;
       --button-radius: 8px;
-      --button-shadow: 0 10px 18px rgba(111, 159, 178, 0.2);
-      --secondary-bg: #f7fbfb;
-      --secondary-ink: #55727b;
-      --secondary-border: 1px solid #d1e0e2;
+      --button-shadow: 0 10px 18px rgba(130, 153, 157, 0.22);
+      --secondary-bg: #fbfaf6;
+      --secondary-ink: #665f57;
+      --secondary-border: 1px solid #d9d0c4;
       --word-size: 3rem;
-      --word-ink: #253238;
-      --audio-bg: #edf5f6;
-      --audio-border: 1px solid #c5dadd;
-      --wrong: #a76660;
-      --wrong-bg: #fbf0ee;
-      --correct: #5f907b;
-      --correct-bg: #eef6f1;
-      --feedback-bg: #f7f1ec;
-      --feedback-border: #d8c2b5;
-      --feedback-ink: #8a5d50;
-      --row-bg: #fbfdfc;
+      --word-ink: #2f3533;
+      --audio-bg: #eef1ee;
+      --audio-border: 1px solid #ccd6d3;
+      --wrong: #9b6f66;
+      --wrong-bg: #f6ece8;
+      --correct: #6f8372;
+      --correct-bg: #eef1ea;
+      --feedback-bg: #f3ede5;
+      --feedback-border: #d4c3b4;
+      --feedback-ink: #7d6357;
+      --row-bg: #fbfaf6;
       --title-size: 1.58rem;
       --label-transform: none;
       --label-spacing: 0;
-      --texture-opacity: 0.1;
-      --texture: repeating-linear-gradient(90deg, transparent 0 22px, rgba(141, 177, 184, 0.14) 22px 23px), radial-gradient(circle at 86% 14%, rgba(174, 207, 209, 0.32) 0 8px, transparent 9px);
-      --pattern-ink: rgba(96, 121, 130, 0.18);
+      --texture-opacity: 0.16;
+      --texture: linear-gradient(90deg, rgba(194, 184, 169, 0.18) 0 1px, transparent 1px 22px), linear-gradient(180deg, rgba(255, 255, 255, 0.32), transparent 38%, rgba(173, 154, 137, 0.08));
+      --pattern-ink: rgba(111, 103, 94, 0.18);
     }
 
     @media (max-width: 1100px) {
@@ -962,7 +1014,7 @@
     <header class="review-top">
       <div>
         <h1>小音标 M10 视觉方向原型</h1>
-              <p>#175 评审用交互原型。已按反馈收敛 B+A：更克制的莫兰迪淡青蓝色系、统一中文字体层级，并预留登录入口。</p>
+        <p>#175 评审用交互原型。已按 Morandi 风格重做 B+A：灰调近似色、静物式留白、轻微流动光影，以及更有性格的中文标题/品牌字体。</p>
       </div>
       <div class="controls" aria-label="原型控制">
         <div class="segmented" aria-label="视觉方向筛选">
@@ -984,7 +1036,7 @@
         <h2>视觉评审门</h2>
         <p>这不是生产 UI，是用于判断方向的 HTML 原型。当前默认展示已选择的 B+A 方向。</p>
         <h3>当前选择</h3>
-        <p><strong>B+A 小音标练习室</strong>：整体温和、有练习陪伴感，同时用声波、音标碎片和“小”字标识建立记忆点。</p>
+        <p><strong>B+A 小音标练习室</strong>：整体温和、有练习陪伴感，用灰调空气感、轻光影和“小”字标识建立记忆点。</p>
         <h3>评审结论</h3>
         <div class="vote-list">
           <button type="button" data-vote="认可 B+A 小音标练习室" aria-pressed="true">认可 B+A</button>
@@ -1100,11 +1152,11 @@
               <p>已选方向：B 的温和练习体验 + A 的声波/音标信号语言。中文产品名为“小音标”。</p>
             </div>
             <div class="swatches" aria-label="小音标练习室配色">
-              <span class="swatch" style="background:#253238"></span>
-              <span class="swatch" style="background:#6f9fb2"></span>
-              <span class="swatch" style="background:#aecfd1"></span>
-              <span class="swatch" style="background:#d8c2b5"></span>
-              <span class="swatch" style="background:#5f907b"></span>
+              <span class="swatch" style="background:#2f3533"></span>
+              <span class="swatch" style="background:#82999d"></span>
+              <span class="swatch" style="background:#d7cfc4"></span>
+              <span class="swatch" style="background:#c2b8a9"></span>
+              <span class="swatch" style="background:#6f8372"></span>
             </div>
           </div>
           <div class="proto-wrap">
@@ -1112,7 +1164,7 @@
               <div class="brand-mark">小</div>
               <div class="brand-copy">
                 <strong>小音标</strong>
-                <span>把 IPA 变成每天几分钟的声音练习。字形方向：统一、清爽、稍带圆润；图案只保留轻声纹。</span>
+                <span>把 IPA 变成每天几分钟的声音练习。字形方向：标题有宋楷气质，正文保持清晰；图案只保留轻声纹和流动光影。</span>
               </div>
             </div>
             <div class="brand-preview-gap" aria-hidden="true"></div>
@@ -1126,7 +1178,7 @@
           <div class="notes">
             <div><h3>强项</h3><p>青少年吸引力、IPA 可信度、答错后可恢复感之间最平衡。</p></div>
             <div><h3>风险</h3><p>图案必须克制：一个核心声音信号，而不是到处装饰。</p></div>
-            <div><h3>视觉母题</h3><p>“小”字标、轻声纹、淡青蓝卡片、登录入口占位。</p></div>
+            <div><h3>视觉母题</h3><p>“小”字标、静物灰调、轻声纹、流动光影、登录入口占位。</p></div>
           </div>
         </article>
       </section>


### PR DESCRIPTION
## Primary Issue

Refs #175.

## Summary

- Add `docs/design/m10-visual-direction-prototypes.html`, an interactive local prototype for the #175 visual direction gate.
- Compare A / B / C / B+A across the same Tiny IPA flows: Today hub, wrong-answer practice, Progress, and Settings.
- Include direction filter, desktop/mobile viewport toggle, and selectable decision output.

## Why

The prior #175 gate was text-heavy and did not give the human reviewer a concrete visual surface to evaluate. This PR makes the decision observable and lightly interactive before any production UI rewrite is scoped.

## Scope

Docs/design artifact only. No production frontend code, no runtime UI changes, no visual direction selected.

## How to review locally

Open this file in a browser:

```text
docs/design/m10-visual-direction-prototypes.html
```

Suggested checks:

- Compare All directions in desktop mode.
- Inspect A / B / C / B+A one at a time.
- Toggle Mobile mode.
- Use the Choose buttons and confirm the response text updates.

## Verification

- Opened with Playwright via `file://`.
- Captured screenshots for all directions and hybrid mobile.
- Confirmed direction filters, viewport toggle, and vote output work.
- `git diff --check` — passed.
- `tools/agents/agent-audit` — clean before PR creation.

Generated local screenshots, not committed:

```text
/tmp/tiny-ipa-m10-visual-prototypes/all-directions-desktop.png
/tmp/tiny-ipa-m10-visual-prototypes/sound-desktop.png
/tmp/tiny-ipa-m10-visual-prototypes/studio-desktop.png
/tmp/tiny-ipa-m10-visual-prototypes/mission-desktop.png
/tmp/tiny-ipa-m10-visual-prototypes/hybrid-desktop.png
/tmp/tiny-ipa-m10-visual-prototypes/hybrid-mobile.png
```

## Residual risks

- This is a prototype artifact, not production UI. It is useful for direction selection, not implementation acceptance.
- The selected direction still needs a scoped implementation issue with M10 walkthrough acceptance.
