### PR TITLE
Improve Today orientation empty states

### DIFF
--- a/backend/app/services/sessions.py
+++ b/backend/app/services/sessions.py
@@ -673,6 +673,22 @@ def _completed_normal_groups_today(conn, user_id: str, session_date: str) -> dic
     }
 
 
+def _recent_mistake_count(
+    conn,
+    *,
+    user_id: str,
+    accent: str,
+    daily_word_count: int,
+) -> int:
+    sources = get_recent_incorrect_attempt_sources(
+        conn,
+        user_id=user_id,
+        primary_accent=accent,
+        limit=max(daily_word_count, 1),
+    )
+    return len(sources)
+
+
 def _normal_empty_response(
     conn,
     *,
@@ -696,6 +712,12 @@ def _normal_empty_response(
         "date": session_date,
         "primary_accent": accent,
         "daily_word_count": daily_word_count,
+        "recent_mistake_count": _recent_mistake_count(
+            conn,
+            user_id=user_id,
+            accent=accent,
+            daily_word_count=daily_word_count,
+        ),
         "word_count": 0,
         "status": "idle",
         "origin": "normal_empty",
@@ -774,6 +796,12 @@ def _build_response(
         "date": session.session_date,
         "primary_accent": session.primary_accent,
         "daily_word_count": daily_word_count,
+        "recent_mistake_count": _recent_mistake_count(
+            conn,
+            user_id=session.user_id,
+            accent=session.primary_accent,
+            daily_word_count=daily_word_count,
+        ),
         "word_count": len(item_dicts),
         "status": session.status,
         "source_session_item_ids": session.source_session_item_ids,

--- a/backend/tests/test_today_persistence.py
+++ b/backend/tests/test_today_persistence.py
@@ -150,6 +150,7 @@ class TestTodayPersistence:
         assert data["date"] == date.today().isoformat()
         assert data["primary_accent"] == "US"
         assert data["daily_word_count"] == 10
+        assert data["recent_mistake_count"] == 0
         assert data["items"] == []
         assert data["action_label"] == "Start Entry group"
         conn = get_connection(seeded_db)
@@ -336,6 +337,9 @@ class TestTodayPersistence:
         })
         assert miss_resp.status_code == 200
         assert miss_resp.json()["is_correct"] is False
+
+        refreshed_today = client.get("/api/today").json()
+        assert refreshed_today["recent_mistake_count"] == 1
 
         review_resp = client.post("/api/review/recent-mistakes")
         assert review_resp.status_code == 200

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -90,6 +90,7 @@ export interface TodayResponse {
   date: string;
   primary_accent: string;
   daily_word_count: number;
+  recent_mistake_count?: number;
   word_count?: number;
   status: string;
   source_session_item_ids?: string[];

--- a/frontend/src/pages/TodayPractice.tsx
+++ b/frontend/src/pages/TodayPractice.tsx
@@ -106,7 +106,29 @@ function resumeActionLabel(session: TodayResponse): string {
 
 function completedGroupsCopy(session: TodayResponse): string {
   const counts = session.completed_normal_groups_today ?? { entry: 0, mid: 0, total: 0 };
-  return `${counts.total} normal groups completed today: Entry ${counts.entry}, Mid ${counts.mid}.`;
+  return `Completed today: Entry ${counts.entry}, Mid ${counts.mid}.`;
+}
+
+function completedGroupCount(session: TodayResponse): number {
+  return session.completed_normal_groups_today?.total ?? 0;
+}
+
+function todayHubHeading(session: TodayResponse, hasActiveGroup: boolean): string {
+  if (hasActiveGroup) return `${learnerLevelLabel(session)} practice in progress`;
+  return `Start ${selectedLevelLabel(session)} practice`;
+}
+
+function todayHubCopy(hasActiveGroup: boolean): string {
+  if (hasActiveGroup) {
+    return "Pick up where you left off, or switch intentionally when you are ready.";
+  }
+  return "A short listening group is ready. Listen first, then choose the IPA that matches.";
+}
+
+function recentReviewLabel(session: TodayResponse): string {
+  const count = session.recent_mistake_count ?? 0;
+  if (count <= 0) return "No recent mistakes to review";
+  return count === 1 ? "Review 1 recent mistake" : `Review ${count} recent mistakes`;
 }
 
 export default function TodayPractice({
@@ -358,9 +380,9 @@ export default function TodayPractice({
       <main className="practice-container">
         <section className="today-hub">
           <p className="workflow-kicker">Today practice hub</p>
-          <h1>{selectedLevelLabel(session)} selected</h1>
+          <h1>{todayHubHeading(session, hasActiveGroup)}</h1>
           <p className="section-copy">
-            {completedGroupsCopy(session)}
+            {todayHubCopy(hasActiveGroup)}
           </p>
 
           <div className={`hub-status-card ${pendingLevelChange ? "pending" : ""}`}>
@@ -379,14 +401,18 @@ export default function TodayPractice({
               </>
             ) : (
               <>
-                <span className="focus-panel-label">No active group</span>
-                <strong>Ready to start {selectedLevelLabel(session)}</strong>
+                <span className="focus-panel-label">Ready when you are</span>
+                <strong>{selectedLevelLabel(session)} listening group</strong>
                 <span>
                   {session.daily_word_count} words per normal group · {session.primary_accent}
                 </span>
               </>
             )}
           </div>
+
+          {completedGroupCount(session) > 0 && (
+            <p className="empty-hint">{completedGroupsCopy(session)}</p>
+          )}
 
           {notice && <p className="empty-hint">{notice}</p>}
           {error && <p className="save-error">{error}</p>}
@@ -426,9 +452,9 @@ export default function TodayPractice({
             <button
               className="secondary-action-btn"
               onClick={handleRecentReview}
-              disabled={actionLoading !== null}
+              disabled={actionLoading !== null || (session.recent_mistake_count ?? 0) <= 0}
             >
-              {actionLoading === "recent-review" ? "Loading…" : "Review recent mistakes"}
+              {actionLoading === "recent-review" ? "Loading…" : recentReviewLabel(session)}
             </button>
             <button className="secondary-action-btn" onClick={onOpenProgress}>
               View Progress
@@ -446,6 +472,10 @@ export default function TodayPractice({
     const wrongResults = results.filter((r) => !r.isCorrect);
     const summarySession = lastSummarySession ?? session;
     const hasCurrentGroupMisses = wrongResults.length > 0;
+    const summaryRecentMistakeCount = Math.max(
+      summarySession.recent_mistake_count ?? 0,
+      wrongResults.length,
+    );
     const focusSuggestions = canonicalFocus(
       wrongResults.flatMap((result) => result.targetPhonemes),
     ).slice(0, 3);
@@ -530,7 +560,12 @@ export default function TodayPractice({
               onClick={handleRecentReview}
               disabled={actionLoading !== null}
             >
-              {actionLoading === "recent-review" ? "Loading…" : "Review recent mistakes"}
+              {actionLoading === "recent-review"
+                ? "Loading…"
+                : recentReviewLabel({
+                    ...summarySession,
+                    recent_mistake_count: summaryRecentMistakeCount,
+                  })}
             </button>
             <button className="secondary-action-btn" onClick={onOpenProgress}>
               Return to Progress

--- a/frontend/tests/e2e/m10-ux-walkthrough.spec.ts
+++ b/frontend/tests/e2e/m10-ux-walkthrough.spec.ts
@@ -20,6 +20,7 @@ interface MockState {
   activeGroup: GroupKey;
   completed: Record<LearnerLevel, number>;
   focusPhonemes: string[];
+  recentMistakeCount: number;
   recentReviewEmpty: boolean;
 }
 
@@ -131,6 +132,7 @@ function todayResponse(state: MockState) {
       focus_phonemes: state.focusPhonemes,
       action_label: `Start ${levelLabel(state.selectedLevel)} group`,
       daily_word_count: 2,
+      recent_mistake_count: state.recentMistakeCount,
       word_count: 0,
       status: "idle",
       source_session_item_ids: [],
@@ -170,6 +172,7 @@ function todayResponse(state: MockState) {
     source_group_id: review ? "entry-group" : undefined,
     focus_phonemes: focus ? state.focusPhonemes : [],
     daily_word_count: items[state.activeGroup].length,
+    recent_mistake_count: state.recentMistakeCount,
     word_count: items[state.activeGroup].length,
     status: "active",
     source_session_item_ids: review ? ["entry-ship"] : [],
@@ -266,6 +269,7 @@ async function setupM10Api(page: Page, options: Partial<MockState> = {}) {
     activeGroup: options.activeGroup ?? "none",
     completed: options.completed ?? { entry: 0, mid: 0 },
     focusPhonemes: options.focusPhonemes ?? [],
+    recentMistakeCount: options.recentMistakeCount ?? 0,
     recentReviewEmpty: options.recentReviewEmpty ?? false,
   };
 
@@ -344,6 +348,9 @@ async function routeMock(route: Route, state: MockState) {
       if (state.activeGroup === "entry") state.completed.entry += 1;
       if (state.activeGroup === "mid") state.completed.mid += 1;
     }
+    if (body.selected_answer !== item.display_ipa) {
+      state.recentMistakeCount = Math.max(state.recentMistakeCount, 1);
+    }
     await route.fulfill({
       json: {
         is_correct: body.selected_answer === item.display_ipa,
@@ -367,7 +374,7 @@ async function routeMock(route: Route, state: MockState) {
   }
 
   if (path === "/review/recent-mistakes") {
-    if (state.recentReviewEmpty) {
+    if (state.recentReviewEmpty || state.recentMistakeCount === 0) {
       await route.fulfill({
         json: {
           ...todayResponse(state),
@@ -423,10 +430,11 @@ test.describe("M10 UX walkthrough evidence", () => {
     await test.step("Today start orientation", async () => {
       await page.goto("/");
       await expect(page.getByText("Today practice hub")).toBeVisible();
-      await expect(page.getByRole("heading", { name: "Entry selected" })).toBeVisible();
-      await expect(page.getByText("No active group")).toBeVisible();
+      await expect(page.getByRole("heading", { name: "Start Entry practice" })).toBeVisible();
+      await expect(page.getByText("Ready when you are")).toBeVisible();
+      await expect(page.getByText("A short listening group is ready.")).toBeVisible();
       await expect(page.getByRole("button", { name: "Start Entry group" })).toBeVisible();
-      await expect(page.getByRole("button", { name: "Review recent mistakes" })).toBeVisible();
+      await expect(page.getByRole("button", { name: "No recent mistakes to review" })).toBeDisabled();
       await attachScreenshot(page, "m10-today-start");
     });
 
@@ -453,7 +461,7 @@ test.describe("M10 UX walkthrough evidence", () => {
       await expect(page.getByText("1 / 2 correct")).toBeVisible();
       await expect(page.getByRole("heading", { name: "Misses from this group" })).toBeVisible();
       await expect(page.getByRole("button", { name: "Review misses from this group" })).toBeVisible();
-      await expect(page.getByRole("button", { name: "Review recent mistakes" })).toBeVisible();
+      await expect(page.getByRole("button", { name: "Review 1 recent mistake" })).toBeVisible();
       await attachScreenshot(page, "m10-completion-recovery-actions");
     });
 
@@ -464,7 +472,7 @@ test.describe("M10 UX walkthrough evidence", () => {
       await attachScreenshot(page, "m10-current-group-review");
       await answer(page, "/ʃɪp/");
       await expect(page.getByRole("heading", { name: "Current-group review complete" })).toBeVisible();
-      await page.getByRole("button", { name: "Review recent mistakes" }).click();
+      await page.getByRole("button", { name: "Review 1 recent mistake" }).click();
       await expect(page.getByText("Recent mistake review: 1 / 1")).toBeVisible();
       await expect(page.getByText("Reviewing recent mistakes from earlier practice.")).toBeVisible();
       await attachScreenshot(page, "m10-recent-review");
@@ -499,7 +507,7 @@ test.describe("M10 UX walkthrough evidence", () => {
       await page.getByRole("button", { name: /Mid\s+Broader word practice/ }).click();
       await expect(page.getByText("Saved")).toBeVisible();
       await page.getByRole("button", { name: "Today", exact: true }).click();
-      await expect(page.getByRole("heading", { name: "Mid selected" })).toBeVisible();
+      await expect(page.getByRole("heading", { name: "Entry practice in progress" })).toBeVisible();
       await expect(page.getByText("You selected Mid. This Entry group is still in progress.")).toBeVisible();
       await expect(page.getByRole("button", { name: "Resume Entry group" })).toBeVisible();
       await attachScreenshot(page, "m10-settings-mid-pending");
@@ -516,9 +524,10 @@ test.describe("M10 UX walkthrough evidence", () => {
 
     await test.step("Recent-review empty state keeps the hub actionable", async () => {
       state.activeGroup = "none";
+      state.recentMistakeCount = 1;
       await page.goto("/");
       await expect(page.getByText("Today practice hub")).toBeVisible();
-      await page.getByRole("button", { name: "Review recent mistakes" }).click();
+      await page.getByRole("button", { name: "Review 1 recent mistake" }).click();
       await expect(page.getByText("No recent incorrect attempts are available for review.")).toBeVisible();
       await expect(page.getByRole("button", { name: "Start Mid group" })).toBeVisible();
       await attachScreenshot(page, "m10-recent-review-empty");

--- a/frontend/tests/e2e/m7-walkthrough.spec.ts
+++ b/frontend/tests/e2e/m7-walkthrough.spec.ts
@@ -170,6 +170,7 @@ function toTodayResponse(group: MockGroup) {
     action_label:
       sourceScope === "normal_next" ? `Start Group ${group.group_index}` : undefined,
     daily_word_count: group.items.length,
+    recent_mistake_count: group.group_type === "mistake_review" ? 1 : 0,
     word_count: group.items.length,
     status: "active",
     source_session_item_ids:
@@ -212,6 +213,7 @@ function noActiveTodayResponse() {
     focus_phonemes: [],
     action_label: "Start Entry group",
     daily_word_count: groups.group1.items.length,
+    recent_mistake_count: 0,
     word_count: 0,
     status: "idle",
     source_session_item_ids: [],
@@ -453,7 +455,9 @@ async function routeMock(route: Route, state: MockState) {
 async function openWalkthrough(page: Page) {
   await page.goto("/");
   await expect(page.getByText("Today practice hub")).toBeVisible();
-  await expect(page.getByText("No active group")).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Start Entry practice" })).toBeVisible();
+  await expect(page.getByText("Ready when you are")).toBeVisible();
+  await expect(page.getByRole("button", { name: "No recent mistakes to review" })).toBeDisabled();
   await page.getByRole("button", { name: "Start Entry group" }).click();
   await expect(page.getByText("Practice group: 1 / 2")).toBeVisible();
 }
@@ -492,7 +496,7 @@ test.describe("M7 v2 learner workflow walkthrough", () => {
       await expect(page.getByText("Target sound: /ʃ/")).toBeVisible();
       await expect(page.getByRole("button", { name: "Start next Entry group" })).toBeVisible();
       await expect(page.getByRole("button", { name: "Review misses from this group" })).toBeVisible();
-      await expect(page.getByRole("button", { name: "Review recent mistakes" })).toBeVisible();
+      await expect(page.getByRole("button", { name: "Review 1 recent mistake" })).toBeVisible();
       await expect(page.getByRole("button", { name: "Return to Progress" })).toBeVisible();
     });
   });
@@ -515,7 +519,7 @@ test.describe("M7 v2 learner workflow walkthrough", () => {
     await completeFirstGroupWithOneMiss(page);
 
     await expect(page.getByRole("button", { name: "Review misses from this group" })).toBeVisible();
-    await expect(page.getByRole("button", { name: "Review recent mistakes" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Review 1 recent mistake" })).toBeVisible();
     await page.getByRole("button", { name: "Review misses from this group" }).click();
     await expect(page.getByText("Reviewing misses from the group you just finished.")).toBeVisible();
     await expect(page.getByText("Current-group review: 1 / 1")).toBeVisible();
@@ -533,9 +537,9 @@ test.describe("M7 v2 learner workflow walkthrough", () => {
     await expect(page.getByRole("heading", { name: "Current-group review complete" })).toBeVisible();
     await expect(page.getByText("No misses in this group.")).toBeVisible();
     await expect(page.getByRole("button", { name: /Review misses from/ })).toHaveCount(0);
-    await expect(page.getByRole("button", { name: "Review recent mistakes" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Review 1 recent mistake" })).toBeVisible();
 
-    await page.getByRole("button", { name: "Review recent mistakes" }).click();
+    await page.getByRole("button", { name: "Review 1 recent mistake" }).click();
     await expect(page.getByText("Recent mistake review: 1 / 1")).toBeVisible();
     await answerVisibleItem(page, "/ʃɪp/");
     await expect(page.getByRole("heading", { name: "Recent mistake review complete" })).toBeVisible();
@@ -583,10 +587,10 @@ test.describe("M7 v2 learner workflow walkthrough", () => {
     await setupMockApi(page, { failRecentReview: true });
     await openWalkthrough(page);
     await completeFirstGroupWithOneMiss(page);
-    await page.getByRole("button", { name: "Review recent mistakes" }).click();
+    await page.getByRole("button", { name: "Review 1 recent mistake" }).click();
 
     await expect(page.getByRole("heading", { name: "Practice group complete" })).toBeVisible();
     await expect(page.getByText("REVIEW_FAILED: Review unavailable")).toBeVisible();
-    await expect(page.getByRole("button", { name: "Review recent mistakes" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Review 1 recent mistake" })).toBeVisible();
   });
 });

--- a/frontend/tests/e2e/m8-level-selection.spec.ts
+++ b/frontend/tests/e2e/m8-level-selection.spec.ts
@@ -54,6 +54,7 @@ function todayResponse(state: MockState) {
       focus_phonemes: [],
       action_label: `Start ${levelLabel(state.selectedLevel)} group`,
       daily_word_count: 1,
+      recent_mistake_count: 0,
       word_count: 0,
       status: "idle",
       source_session_item_ids: [],
@@ -83,6 +84,7 @@ function todayResponse(state: MockState) {
     source_scope: "normal_current",
     focus_phonemes: [],
     daily_word_count: 1,
+    recent_mistake_count: 0,
     word_count: 1,
     status: "active",
     source_session_item_ids: [],
@@ -247,9 +249,9 @@ test.describe("M8 learner level selection walkthrough", () => {
     await test.step("Entry default hub context", async () => {
       await page.goto("/");
       await expect(page.getByText("Today practice hub")).toBeVisible();
-      await expect(page.getByRole("heading", { name: "Entry selected" })).toBeVisible();
-      await expect(page.getByText("0 normal groups completed today: Entry 0, Mid 0.")).toBeVisible();
-      await expect(page.getByText("No active group")).toBeVisible();
+      await expect(page.getByRole("heading", { name: "Start Entry practice" })).toBeVisible();
+      await expect(page.getByText("Ready when you are")).toBeVisible();
+      await expect(page.getByRole("button", { name: "No recent mistakes to review" })).toBeDisabled();
       await page.getByRole("button", { name: "Start Entry group" }).click();
       await expect(page.getByText("Practice group: 1 / 1")).toBeVisible();
       await expect(page.getByText("ship")).toBeVisible();
@@ -268,7 +270,7 @@ test.describe("M8 learner level selection walkthrough", () => {
     await test.step("Today explains pending level change and intentional switch", async () => {
       await page.getByRole("button", { name: "Today", exact: true }).click();
       await expect(page.getByText("Today practice hub")).toBeVisible();
-      await expect(page.getByRole("heading", { name: "Mid selected" })).toBeVisible();
+      await expect(page.getByRole("heading", { name: "Entry practice in progress" })).toBeVisible();
       await expect(page.getByText("You selected Mid. This Entry group is still in progress.")).toBeVisible();
       await expect(page.getByRole("button", { name: "Resume Entry group" })).toBeVisible();
       page.once("dialog", (dialog) => dialog.accept());


### PR DESCRIPTION
## Summary
- Add a read-only recent_mistake_count field to Today responses so the learner hub can reflect review availability truthfully.
- Rework the Today hub from metric-first copy to start/resume-oriented copy.
- Disable the recent mistakes action in fresh empty states, while preserving stale empty-review handling.
- Update M7/M8/M10 walkthrough expectations and backend Today persistence coverage.

## Verification
- UV_CACHE_DIR=/private/tmp/uv-cache uv run pytest tests/test_today_persistence.py
- cd frontend && pnpm lint
- cd frontend && pnpm build
- cd frontend && pnpm test:e2e:m7
- cd frontend && pnpm test:e2e:m8
- cd frontend && pnpm test:e2e:m10
- tools/agents/agent-audit

Closes #181