### PR TITLE
Make wrong-answer feedback learner paced

### DIFF
--- a/frontend/src/components/ChoiceQuestion.tsx
+++ b/frontend/src/components/ChoiceQuestion.tsx
@@ -28,9 +28,10 @@ function buildFocusHint(targetPhonemes: string[]): string {
 interface Props {
   item: TodayItem;
   onResult: (result: ChoiceResult) => void;
+  onContinue?: () => void;
 }
 
-export function ChoiceQuestion({ item, onResult }: Props) {
+export function ChoiceQuestion({ item, onResult, onContinue }: Props) {
   const [selected, setSelected] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [feedback, setFeedback] = useState<{
@@ -138,6 +139,15 @@ export function ChoiceQuestion({ item, onResult }: Props) {
                 <strong>{item.target_phonemes.join(" ") || "IPA contrast"}</strong>
               </div>
               <p className="focus-hint">{buildFocusHint(item.target_phonemes)}</p>
+              {onContinue && (
+                <button
+                  className="feedback-continue-btn"
+                  onClick={onContinue}
+                  type="button"
+                >
+                  Continue
+                </button>
+              )}
             </div>
           )}
         </div>

--- a/frontend/src/pages/TodayPractice.tsx
+++ b/frontend/src/pages/TodayPractice.tsx
@@ -619,9 +619,12 @@ export default function TodayPractice({
         item={currentItem}
         onResult={(result) => {
           handleResult(currentItem, result);
-          // Auto-advance after a short delay so the user can read feedback.
-          setTimeout(() => handleNext(), 1500);
+          if (result.isCorrect) {
+            // Correct answers keep the quick flow; misses stay visible until acknowledged.
+            setTimeout(() => handleNext(), 1500);
+          }
         }}
+        onContinue={handleNext}
       />
     </main>
   );

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -280,6 +280,21 @@ button {
   font-size: 0.85rem;
 }
 
+.feedback-continue-btn {
+  background: #1f6fb2;
+  border: 1px solid #174f80;
+  border-radius: 8px;
+  color: #fff;
+  font-weight: 700;
+  margin-top: 4px;
+  padding: 10px 16px;
+  width: 100%;
+}
+
+.feedback-continue-btn:hover {
+  background: #174f80;
+}
+
 /* ---------------------------------------------------------------------------
  * Summary
  * --------------------------------------------------------------------------- */

--- a/frontend/tests/e2e/m10-ux-walkthrough.spec.ts
+++ b/frontend/tests/e2e/m10-ux-walkthrough.spec.ts
@@ -438,7 +438,7 @@ test.describe("M10 UX walkthrough evidence", () => {
       await attachScreenshot(page, "m10-today-start");
     });
 
-    await test.step("Wrong answer feedback remains inspectable before auto-advance", async () => {
+    await test.step("Wrong answer feedback remains inspectable until learner continues", async () => {
       await page.getByRole("button", { name: "Start Entry group" }).click();
       await expect(page.getByText("Practice group: 1 / 2")).toBeVisible();
       await expect(page.getByRole("button", { name: "Play pronunciation (TTS)" })).toBeVisible();
@@ -447,10 +447,14 @@ test.describe("M10 UX walkthrough evidence", () => {
       await expect(page.getByText("You picked")).toBeVisible();
       await expect(page.getByText("Correct IPA")).toBeVisible();
       await expect(page.getByText("Target sound")).toBeVisible();
+      await expect(page.getByRole("button", { name: "Play pronunciation (TTS)" })).toBeVisible();
+      await expect(page.getByRole("button", { name: "Continue" })).toBeVisible();
       await attachScreenshot(page, "m10-wrong-answer-feedback");
-      await expect(page.getByRole("button", { name: "Select /θɪn/" })).toBeVisible({
-        timeout: 6_000,
-      });
+      await page.waitForTimeout(1_800);
+      await expect(page.getByText("Practice group: 1 / 2")).toBeVisible();
+      await expect(page.getByText("Not quite")).toBeVisible();
+      await page.getByRole("button", { name: "Continue" }).click();
+      await expect(page.getByRole("button", { name: "Select /θɪn/" })).toBeVisible();
     });
 
     await test.step("Completion summary exposes current-group recovery and next choices", async () => {

--- a/frontend/tests/e2e/m7-walkthrough.spec.ts
+++ b/frontend/tests/e2e/m7-walkthrough.spec.ts
@@ -471,9 +471,10 @@ async function completeFirstGroupWithOneMiss(page: Page) {
   await expect(page.getByText("Not quite")).toBeVisible();
   await expect(page.getByText("Target sound")).toBeVisible();
   await page.getByText("Focus on /ʃ/ before choosing.").waitFor();
-  await expect(page.getByRole("button", { name: "Select /θɪn/" })).toBeVisible({
-    timeout: 6_000,
-  });
+  await page.waitForTimeout(1_800);
+  await expect(page.getByText("Practice group: 1 / 2")).toBeVisible();
+  await page.getByRole("button", { name: "Continue" }).click();
+  await expect(page.getByRole("button", { name: "Select /θɪn/" })).toBeVisible();
 
   await answerVisibleItem(page, "/θɪn/");
   await expect(page.getByRole("heading", { name: "Practice group complete" })).toBeVisible({


### PR DESCRIPTION
## Summary

- Keep wrong-answer feedback visible until the learner explicitly clicks `Continue`.
- Preserve the quick 1.5s auto-advance for correct answers.
- Update M10 and M7 walkthroughs to assert learner-paced wrong-answer feedback and audio replay availability.

## Verification

- `cd frontend && pnpm exec tsc --noEmit`: passed
- `cd frontend && pnpm test:e2e:m10`: passed (desktop + mobile wrong-answer evidence)
- `cd frontend && pnpm test:e2e:m7`: passed
- `cd frontend && pnpm run build`: passed
- `tools/agents/agent-audit`: clean

## Helper Dogfood Notes

- Startup helpers used: `git fetch --prune origin`, `tools/agents/agent-inbox implementer`, `tools/agents/agent-ready-queue --role implementer`, `tools/agents/agent-audit`, and `tools/agents/agent-issue-context 182`.
- Durable state showed #182 already picked up on `codex/182-learner-paced-feedback`; no new pickup mutation was needed.
- Current worktree had untracked `.pnpm-store/` from prior pnpm/Playwright runs; it was intentionally left untracked and not staged.
- Sandbox/runtime note: Playwright emitted the existing `NO_COLOR` ignored because `FORCE_COLOR` is set warning; tests still passed.

Closes #182
