### PR TITLE
Clarify recovery and level switch copy

### DIFF
--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -32,12 +32,12 @@ const LEVEL_OPTIONS: Array<{
   {
     value: "entry",
     title: "Entry",
-    description: "Starter practice with the current core word set.",
+    description: "Starter word pool for the next new normal group.",
   },
   {
     value: "mid",
     title: "Mid",
-    description: "Broader word practice for longer words; translations and audio are still under review.",
+    description: "Broader word pool for the next new normal group.",
   },
 ];
 
@@ -162,8 +162,8 @@ export default function SettingsPage({
         <section className="settings-panel">
           <h2>Practice level</h2>
           <p className="section-copy">
-            Choose the word pool for the next new normal group. Your current group
-            stays unchanged until you finish it.
+            Choose the level for the next new normal group. If a group is already
+            in progress, Today will keep it active and offer an explicit switch.
           </p>
           <div className="level-choice-list">
             {LEVEL_OPTIONS.map((option) => (

--- a/frontend/src/pages/TodayPractice.tsx
+++ b/frontend/src/pages/TodayPractice.tsx
@@ -66,10 +66,10 @@ function groupReason(session: TodayResponse): string {
     return `${learnerLevelLabel(session)} focused practice for ${focus}.`;
   }
   if (session.source_scope === "current_group") {
-    return "Reviewing misses from the group you just finished.";
+    return "Reviewing misses from the group you just finished, before older mistakes.";
   }
   if (session.source_scope === "recent_global") {
-    return "Reviewing recent mistakes from earlier practice.";
+    return "Reviewing older mistakes from earlier practice.";
   }
   if (session.source_scope === "normal_next") {
     return `A new ${learnerLevelLabel(session)} practice group.`;
@@ -89,9 +89,9 @@ function buildFocusHint(targetPhonemes: string[]): string {
 
 function currentReviewActionLabel(session: TodayResponse): string {
   if (session.group_type === "mistake_review") {
-    return "Review misses from this review";
+    return "Review this review's misses";
   }
-  return "Review misses from this group";
+  return "Review this group's misses";
 }
 
 function nextNormalActionLabel(session: TodayResponse): string {
@@ -127,8 +127,8 @@ function todayHubCopy(hasActiveGroup: boolean): string {
 
 function recentReviewLabel(session: TodayResponse): string {
   const count = session.recent_mistake_count ?? 0;
-  if (count <= 0) return "No recent mistakes to review";
-  return count === 1 ? "Review 1 recent mistake" : `Review ${count} recent mistakes`;
+  if (count <= 0) return "No older mistakes to review";
+  return count === 1 ? "Review 1 older mistake" : `Review ${count} older mistakes`;
 }
 
 export default function TodayPractice({
@@ -247,8 +247,8 @@ export default function TodayPractice({
     const isPending = Boolean(session.pending_level_change);
     const ok = window.confirm(
       isPending
-        ? `End this ${learnerLevelLabel(session)} group and start ${selectedLevelLabel(session)}?`
-        : `End this ${learnerLevelLabel(session)} group and start a fresh ${selectedLevelLabel(session)} group?`,
+        ? `End this ${learnerLevelLabel(session)} group and switch to ${selectedLevelLabel(session)} now?`
+        : `End this ${learnerLevelLabel(session)} group and start another ${selectedLevelLabel(session)} group?`,
     );
     if (!ok) return;
     setActionLoading("abandon-next");
@@ -376,6 +376,7 @@ export default function TodayPractice({
       session.group_id && session.items.length > 0 && session.status !== "idle",
     );
     const pendingLevelChange = hasActiveGroup && Boolean(session.pending_level_change);
+    const showSwitchAction = hasActiveGroup && pendingLevelChange;
     return (
       <main className="practice-container">
         <section className="today-hub">
@@ -395,7 +396,7 @@ export default function TodayPractice({
                 </span>
                 {pendingLevelChange && (
                   <p className="pending-copy">
-                    You selected {selectedLevelLabel(session)}. This {learnerLevelLabel(session)} group is still in progress.
+                    {selectedLevelLabel(session)} is selected for your next new group. Your current {learnerLevelLabel(session)} group stays active until you finish it or switch now.
                   </p>
                 )}
               </>
@@ -436,7 +437,7 @@ export default function TodayPractice({
                   ? resumeActionLabel(session)
                   : session.action_label ?? `Start ${selectedLevelLabel(session)} group`}
             </button>
-            {hasActiveGroup && (
+            {showSwitchAction && (
               <button
                 className="secondary-action-btn"
                 onClick={() => void handleAbandonAndNext()}
@@ -444,9 +445,7 @@ export default function TodayPractice({
               >
                 {actionLoading === "abandon-next"
                   ? "Loading…"
-                  : pendingLevelChange
-                    ? `End this ${learnerLevelLabel(session)} group and start ${selectedLevelLabel(session)}`
-                    : `End this group and start fresh ${selectedLevelLabel(session)}`}
+                  : `Switch to ${selectedLevelLabel(session)} now`}
               </button>
             )}
             <button
@@ -489,7 +488,7 @@ export default function TodayPractice({
           </p>
           {wrongResults.length > 0 ? (
             <section className="summary-section">
-              <h3>Misses from this group</h3>
+              <h3>This group's misses</h3>
               <ul className="summary-list">
                 {wrongResults.map((r) => (
                   <li key={r.sessionItemId} className="summary-wrong">
@@ -517,7 +516,7 @@ export default function TodayPractice({
             <section className="summary-section focus-choice-panel">
               <h3>Focus a weak sound next</h3>
               <p className="section-copy">
-                Start a focused group weighted toward one of the sounds missed here.
+                Start a focused group weighted toward one of the sounds missed in this group.
               </p>
               <div className="phoneme-chip-list">
                 {focusSuggestions.map((phoneme) => (

--- a/frontend/tests/e2e/m10-ux-walkthrough.spec.ts
+++ b/frontend/tests/e2e/m10-ux-walkthrough.spec.ts
@@ -434,7 +434,8 @@ test.describe("M10 UX walkthrough evidence", () => {
       await expect(page.getByText("Ready when you are")).toBeVisible();
       await expect(page.getByText("A short listening group is ready.")).toBeVisible();
       await expect(page.getByRole("button", { name: "Start Entry group" })).toBeVisible();
-      await expect(page.getByRole("button", { name: "No recent mistakes to review" })).toBeDisabled();
+      await expect(page.getByRole("button", { name: "No older mistakes to review" })).toBeDisabled();
+      await expect(page.getByRole("button", { name: "End this group and start fresh Entry" })).toHaveCount(0);
       await attachScreenshot(page, "m10-today-start");
     });
 
@@ -463,22 +464,22 @@ test.describe("M10 UX walkthrough evidence", () => {
         timeout: 4_000,
       });
       await expect(page.getByText("1 / 2 correct")).toBeVisible();
-      await expect(page.getByRole("heading", { name: "Misses from this group" })).toBeVisible();
-      await expect(page.getByRole("button", { name: "Review misses from this group" })).toBeVisible();
-      await expect(page.getByRole("button", { name: "Review 1 recent mistake" })).toBeVisible();
+      await expect(page.getByRole("heading", { name: "This group's misses" })).toBeVisible();
+      await expect(page.getByRole("button", { name: "Review this group's misses" })).toBeVisible();
+      await expect(page.getByRole("button", { name: "Review 1 older mistake" })).toBeVisible();
       await attachScreenshot(page, "m10-completion-recovery-actions");
     });
 
     await test.step("Current-group review and recent review use different source copy", async () => {
-      await page.getByRole("button", { name: "Review misses from this group" }).click();
+      await page.getByRole("button", { name: "Review this group's misses" }).click();
       await expect(page.getByText("Current-group review: 1 / 1")).toBeVisible();
-      await expect(page.getByText("Reviewing misses from the group you just finished.")).toBeVisible();
+      await expect(page.getByText("Reviewing misses from the group you just finished, before older mistakes.")).toBeVisible();
       await attachScreenshot(page, "m10-current-group-review");
       await answer(page, "/ʃɪp/");
       await expect(page.getByRole("heading", { name: "Current-group review complete" })).toBeVisible();
-      await page.getByRole("button", { name: "Review 1 recent mistake" }).click();
+      await page.getByRole("button", { name: "Review 1 older mistake" }).click();
       await expect(page.getByText("Recent mistake review: 1 / 1")).toBeVisible();
-      await expect(page.getByText("Reviewing recent mistakes from earlier practice.")).toBeVisible();
+      await expect(page.getByText("Reviewing older mistakes from earlier practice.")).toBeVisible();
       await attachScreenshot(page, "m10-recent-review");
     });
 
@@ -507,19 +508,21 @@ test.describe("M10 UX walkthrough evidence", () => {
       await expect(page.getByText("Practice group: 1 / 2")).toBeVisible();
       await page.getByRole("button", { name: "Settings" }).click();
       await expect(page.getByRole("heading", { name: "Settings" })).toBeVisible();
-      await expect(page.getByRole("button", { name: /Mid\s+Broader word practice/ })).toBeVisible();
-      await page.getByRole("button", { name: /Mid\s+Broader word practice/ }).click();
+      await expect(page.getByText("Choose the level for the next new normal group.")).toBeVisible();
+      await expect(page.getByRole("button", { name: /Mid\s+Broader word pool/ })).toBeVisible();
+      await page.getByRole("button", { name: /Mid\s+Broader word pool/ }).click();
       await expect(page.getByText("Saved")).toBeVisible();
       await page.getByRole("button", { name: "Today", exact: true }).click();
       await expect(page.getByRole("heading", { name: "Entry practice in progress" })).toBeVisible();
-      await expect(page.getByText("You selected Mid. This Entry group is still in progress.")).toBeVisible();
+      await expect(page.getByText("Mid is selected for your next new group. Your current Entry group stays active until you finish it or switch now.")).toBeVisible();
       await expect(page.getByRole("button", { name: "Resume Entry group" })).toBeVisible();
+      await expect(page.getByRole("button", { name: "Switch to Mid now" })).toBeVisible();
       await attachScreenshot(page, "m10-settings-mid-pending");
     });
 
     await test.step("Intentional switch starts Mid and keeps level-specific copy visible", async () => {
       page.once("dialog", (dialog) => dialog.accept());
-      await page.getByRole("button", { name: "End this Entry group and start Mid" }).click();
+      await page.getByRole("button", { name: "Switch to Mid now" }).click();
       await expect(page.getByText("Practice group: 1 / 1")).toBeVisible();
       await expect(page.getByText("Mid practice group.")).toBeVisible();
       await expect(page.getByText("remember")).toBeVisible();
@@ -531,7 +534,7 @@ test.describe("M10 UX walkthrough evidence", () => {
       state.recentMistakeCount = 1;
       await page.goto("/");
       await expect(page.getByText("Today practice hub")).toBeVisible();
-      await page.getByRole("button", { name: "Review 1 recent mistake" }).click();
+      await page.getByRole("button", { name: "Review 1 older mistake" }).click();
       await expect(page.getByText("No recent incorrect attempts are available for review.")).toBeVisible();
       await expect(page.getByRole("button", { name: "Start Mid group" })).toBeVisible();
       await attachScreenshot(page, "m10-recent-review-empty");

--- a/frontend/tests/e2e/m7-walkthrough.spec.ts
+++ b/frontend/tests/e2e/m7-walkthrough.spec.ts
@@ -457,7 +457,7 @@ async function openWalkthrough(page: Page) {
   await expect(page.getByText("Today practice hub")).toBeVisible();
   await expect(page.getByRole("heading", { name: "Start Entry practice" })).toBeVisible();
   await expect(page.getByText("Ready when you are")).toBeVisible();
-  await expect(page.getByRole("button", { name: "No recent mistakes to review" })).toBeDisabled();
+  await expect(page.getByRole("button", { name: "No older mistakes to review" })).toBeDisabled();
   await page.getByRole("button", { name: "Start Entry group" }).click();
   await expect(page.getByText("Practice group: 1 / 2")).toBeVisible();
 }
@@ -496,8 +496,8 @@ test.describe("M7 v2 learner workflow walkthrough", () => {
       await expect(page.getByText("picked")).toBeVisible();
       await expect(page.getByText("Target sound: /ʃ/")).toBeVisible();
       await expect(page.getByRole("button", { name: "Start next Entry group" })).toBeVisible();
-      await expect(page.getByRole("button", { name: "Review misses from this group" })).toBeVisible();
-      await expect(page.getByRole("button", { name: "Review 1 recent mistake" })).toBeVisible();
+      await expect(page.getByRole("button", { name: "Review this group's misses" })).toBeVisible();
+      await expect(page.getByRole("button", { name: "Review 1 older mistake" })).toBeVisible();
       await expect(page.getByRole("button", { name: "Return to Progress" })).toBeVisible();
     });
   });
@@ -519,10 +519,10 @@ test.describe("M7 v2 learner workflow walkthrough", () => {
     await openWalkthrough(page);
     await completeFirstGroupWithOneMiss(page);
 
-    await expect(page.getByRole("button", { name: "Review misses from this group" })).toBeVisible();
-    await expect(page.getByRole("button", { name: "Review 1 recent mistake" })).toBeVisible();
-    await page.getByRole("button", { name: "Review misses from this group" }).click();
-    await expect(page.getByText("Reviewing misses from the group you just finished.")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Review this group's misses" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Review 1 older mistake" })).toBeVisible();
+    await page.getByRole("button", { name: "Review this group's misses" }).click();
+    await expect(page.getByText("Reviewing misses from the group you just finished, before older mistakes.")).toBeVisible();
     await expect(page.getByText("Current-group review: 1 / 1")).toBeVisible();
     await expect(page.getByText(/Group 5/)).toHaveCount(0);
   });
@@ -532,15 +532,15 @@ test.describe("M7 v2 learner workflow walkthrough", () => {
     await openWalkthrough(page);
     await completeFirstGroupWithOneMiss(page);
 
-    await page.getByRole("button", { name: "Review misses from this group" }).click();
+    await page.getByRole("button", { name: "Review this group's misses" }).click();
     await expect(page.getByText("Current-group review: 1 / 1")).toBeVisible();
     await answerVisibleItem(page, "/ʃɪp/");
     await expect(page.getByRole("heading", { name: "Current-group review complete" })).toBeVisible();
     await expect(page.getByText("No misses in this group.")).toBeVisible();
     await expect(page.getByRole("button", { name: /Review misses from/ })).toHaveCount(0);
-    await expect(page.getByRole("button", { name: "Review 1 recent mistake" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Review 1 older mistake" })).toBeVisible();
 
-    await page.getByRole("button", { name: "Review 1 recent mistake" }).click();
+    await page.getByRole("button", { name: "Review 1 older mistake" }).click();
     await expect(page.getByText("Recent mistake review: 1 / 1")).toBeVisible();
     await answerVisibleItem(page, "/ʃɪp/");
     await expect(page.getByRole("heading", { name: "Recent mistake review complete" })).toBeVisible();
@@ -588,10 +588,10 @@ test.describe("M7 v2 learner workflow walkthrough", () => {
     await setupMockApi(page, { failRecentReview: true });
     await openWalkthrough(page);
     await completeFirstGroupWithOneMiss(page);
-    await page.getByRole("button", { name: "Review 1 recent mistake" }).click();
+    await page.getByRole("button", { name: "Review 1 older mistake" }).click();
 
     await expect(page.getByRole("heading", { name: "Practice group complete" })).toBeVisible();
     await expect(page.getByText("REVIEW_FAILED: Review unavailable")).toBeVisible();
-    await expect(page.getByRole("button", { name: "Review 1 recent mistake" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Review 1 older mistake" })).toBeVisible();
   });
 });

--- a/frontend/tests/e2e/m8-level-selection.spec.ts
+++ b/frontend/tests/e2e/m8-level-selection.spec.ts
@@ -251,7 +251,7 @@ test.describe("M8 learner level selection walkthrough", () => {
       await expect(page.getByText("Today practice hub")).toBeVisible();
       await expect(page.getByRole("heading", { name: "Start Entry practice" })).toBeVisible();
       await expect(page.getByText("Ready when you are")).toBeVisible();
-      await expect(page.getByRole("button", { name: "No recent mistakes to review" })).toBeDisabled();
+      await expect(page.getByRole("button", { name: "No older mistakes to review" })).toBeDisabled();
       await page.getByRole("button", { name: "Start Entry group" }).click();
       await expect(page.getByText("Practice group: 1 / 1")).toBeVisible();
       await expect(page.getByText("ship")).toBeVisible();
@@ -271,10 +271,10 @@ test.describe("M8 learner level selection walkthrough", () => {
       await page.getByRole("button", { name: "Today", exact: true }).click();
       await expect(page.getByText("Today practice hub")).toBeVisible();
       await expect(page.getByRole("heading", { name: "Entry practice in progress" })).toBeVisible();
-      await expect(page.getByText("You selected Mid. This Entry group is still in progress.")).toBeVisible();
+      await expect(page.getByText("Mid is selected for your next new group. Your current Entry group stays active until you finish it or switch now.")).toBeVisible();
       await expect(page.getByRole("button", { name: "Resume Entry group" })).toBeVisible();
       page.once("dialog", (dialog) => dialog.accept());
-      await page.getByRole("button", { name: "End this Entry group and start Mid" }).click();
+      await page.getByRole("button", { name: "Switch to Mid now" }).click();
       await expect(page.getByText("Practice group: 1 / 1")).toBeVisible();
       await expect(page.getByText("Mid practice group.")).toBeVisible();
       await expect(page.getByText("remember")).toBeVisible();


### PR DESCRIPTION
## Summary

- Clarify recovery hierarchy by naming just-finished-group misses separately from older mistakes.
- Clarify Settings and Today copy for selected level vs active group.
- Hide the redundant same-level fresh-start action; when a pending level change exists, show `Switch to <level> now`.
- Update M10, M8, and M7 walkthrough expectations for the revised action/copy semantics.

## Verification

- `cd frontend && pnpm exec tsc --noEmit`: passed
- `cd frontend && pnpm test:e2e:m10`: passed (desktop + mobile recovery/settings evidence)
- `cd frontend && pnpm test:e2e:m8`: passed
- `cd frontend && M7_WALKTHROUGH_PORT=5178 pnpm test:e2e:m7`: passed after rerun on a non-conflicting port
- `cd frontend && pnpm run build`: passed
- `tools/agents/agent-audit`: clean

## Helper Dogfood Notes

- Startup helpers used: `git fetch --prune origin`, `agent-inbox implementer`, `agent-ready-queue --role implementer`, `agent-audit`, and `agent-issue-context 183`.
- Initial ready queue/audit saw a missing `Depends on:` line in the Execution Contract; Architect follow-up corrected durable state before implementation proceeded.
- `agent-pickup 183 --role implementer` dry-run showed startable; helper apply remains dry-run only, so pickup comment/label update was done manually.
- Untracked `.pnpm-store/` was present before implementation and intentionally not staged.
- Playwright emitted the existing `NO_COLOR`/`FORCE_COLOR` warning. One parallel M7 attempt also hit a port conflict; the successful rerun used `M7_WALKTHROUGH_PORT=5178`.

Closes #183
