### PR TITLE
Clarify Progress motivation metrics

### DIFF
--- a/frontend/src/pages/ProgressPage.tsx
+++ b/frontend/src/pages/ProgressPage.tsx
@@ -26,8 +26,46 @@ interface Props {
 }
 
 function formatAccuracy(value: number | null): string {
-  if (value === null) return "No attempts";
+  if (value === null) return "Accuracy appears after answers";
   return `${Math.round(value * 100)}% accuracy`;
+}
+
+function todayMotivation(data: ProgressResponse): { value: string; label: string } {
+  if (data.today_completed) {
+    return { value: "Done", label: "practice completed today" };
+  }
+  if (data.today_status !== "none" || data.total_attempts > 0) {
+    return { value: "Started", label: "practice underway today" };
+  }
+  if (data.streak_days > 0) {
+    return { value: String(data.streak_days), label: "day streak" };
+  }
+  return { value: "Ready", label: "start today's practice" };
+}
+
+function activeGroupCount(stats: LevelProgressStats): number {
+  return Math.max(0, stats.normal_groups - stats.completed_normal_groups);
+}
+
+function levelProgressHint(stats: LevelProgressStats): string {
+  const activeGroups = activeGroupCount(stats);
+  if (stats.attempts === 0 && activeGroups > 0) {
+    return `${stats.label} has an active group. Answer a few items to unlock accuracy and sound signals.`;
+  }
+  if (stats.attempts === 0) {
+    return `${stats.label} has no answered items yet. Start a group when this level is selected.`;
+  }
+  if (stats.weak_phonemes.length > 0) {
+    return `${stats.label} has sounds ready for focused practice.`;
+  }
+  return `${stats.label} is looking steady so far. Keep practicing to confirm strong sounds.`;
+}
+
+function levelWeakEmptyCopy(stats: LevelProgressStats): string {
+  if (stats.attempts === 0) {
+    return `No weak sound signal yet for ${stats.label}; it appears after answered items.`;
+  }
+  return `No weak sound signal right now for ${stats.label}.`;
 }
 
 function LevelStatsSection({
@@ -44,18 +82,20 @@ function LevelStatsSection({
   return (
     <section className="level-progress-panel">
       <div className="level-progress-header">
-        <h2>{stats.label} stats</h2>
+        <h2>{stats.label} progress</h2>
         <span className="level-scope-label">{stats.label}</span>
       </div>
+      <p className="section-copy">{levelProgressHint(stats)}</p>
       <div className="level-stat-grid">
         <span>{stats.completed_normal_groups_today} completed today</span>
-        <span>{stats.normal_groups} normal groups</span>
-        <span>{stats.attempts} attempts</span>
+        <span>{stats.completed_normal_groups} completed groups</span>
+        <span>{activeGroupCount(stats)} active groups</span>
+        <span>{stats.attempts} answered items</span>
         <span>{formatAccuracy(stats.accuracy)}</span>
       </div>
       {stats.weak_phonemes.length > 0 ? (
         <>
-          <h3>Needs practice in {stats.label}</h3>
+          <h3>Sounds to revisit in {stats.label}</h3>
           <ul className="phoneme-list">
             {stats.weak_phonemes.map((p) => (
               <li key={`${stats.learner_level}-${p.phoneme}`} className="phoneme-item weak">
@@ -63,7 +103,7 @@ function LevelStatsSection({
                 <span className="phoneme-acc">
                   {Math.round(p.accuracy * 100)}% accuracy
                 </span>
-                <span className="phoneme-count">{p.attempt_count} attempts</span>
+                <span className="phoneme-count">{p.attempt_count} answered</span>
                 <button
                   className="focus-action-btn"
                   onClick={() => onFocus(p.phoneme)}
@@ -72,14 +112,14 @@ function LevelStatsSection({
                   {activeFocus.includes(p.phoneme) ? "Resume focus" : `Focus ${p.phoneme}`}
                 </button>
                 <span className="phoneme-help">
-                  Focused practice starts at the selected level in Settings.
+                  Focused practice uses the level selected in Settings.
                 </span>
               </li>
             ))}
           </ul>
         </>
       ) : (
-        <p className="section-copy">No weak phoneme signal yet for {stats.label}.</p>
+        <p className="section-copy">{levelWeakEmptyCopy(stats)}</p>
       )}
     </section>
   );
@@ -149,6 +189,13 @@ export default function ProgressPage({
   if (loading) return <main className="practice-container"><p>Loading progress…</p></main>;
   if (error && !data) return <main className="practice-container"><p className="error">Failed: {error}</p></main>;
   if (!data) return null;
+  const todayCard = todayMotivation(data);
+  const completedGroups = data.level_stats
+    ? data.level_stats.entry.completed_normal_groups + data.level_stats.mid.completed_normal_groups
+    : data.total_normal_groups;
+  const activeGroups = data.level_stats
+    ? activeGroupCount(data.level_stats.entry) + activeGroupCount(data.level_stats.mid)
+    : 0;
 
   return (
     <main className="practice-container">
@@ -181,16 +228,19 @@ export default function ProgressPage({
 
       <div className="progress-stats">
         <div className="stat-card">
-          <span className="stat-number">{data.streak_days}</span>
-          <span className="stat-label">day streak</span>
+          <span className="stat-number stat-word">{todayCard.value}</span>
+          <span className="stat-label">{todayCard.label}</span>
         </div>
         <div className="stat-card">
           <span className="stat-number">{data.total_attempts}</span>
-          <span className="stat-label">global attempts</span>
+          <span className="stat-label">answered items</span>
         </div>
         <div className="stat-card">
-          <span className="stat-number">{data.total_normal_groups}</span>
-          <span className="stat-label">normal groups</span>
+          <span className="stat-number">{completedGroups}</span>
+          <span className="stat-label">completed groups</span>
+          {activeGroups > 0 && (
+            <span className="stat-subtext">{activeGroups} active</span>
+          )}
         </div>
       </div>
 
@@ -213,9 +263,9 @@ export default function ProgressPage({
 
       {data.weak_phonemes.length > 0 && (
         <section className="phoneme-section">
-          <h2>Global needs practice</h2>
+          <h2>Sounds to revisit overall</h2>
           <p className="section-copy">
-            All-level weak sounds from your complete history. Use the Entry/Mid
+            Sounds that need more reps across your complete history. Use the Entry/Mid
             sections above when level context matters.
           </p>
           <ul className="phoneme-list">
@@ -226,7 +276,7 @@ export default function ProgressPage({
                   {Math.round(p.accuracy * 100)}% accuracy
                 </span>
                 <span className="phoneme-count">
-                  {p.attempt_count} attempts
+                  {p.attempt_count} answered
                 </span>
                 <button
                   className="focus-action-btn"
@@ -246,13 +296,13 @@ export default function ProgressPage({
 
       {data.strong_phonemes.length > 0 && (
         <section className="phoneme-section">
-          <h2>Global strong sounds</h2>
+          <h2>Sounds going well overall</h2>
           <ul className="phoneme-list">
             {data.strong_phonemes.map((p) => (
               <li key={p.phoneme} className="phoneme-item strong">
                 <span className="phoneme-symbol">{p.phoneme}</span>
                 <span className="phoneme-acc">{Math.round(p.accuracy * 100)}%</span>
-                <span className="phoneme-count">{p.attempt_count} att.</span>
+                <span className="phoneme-count">{p.attempt_count} answered</span>
               </li>
             ))}
           </ul>
@@ -260,7 +310,7 @@ export default function ProgressPage({
       )}
 
       {data.weak_phonemes.length === 0 && data.strong_phonemes.length === 0 && (
-        <p className="empty-hint">Complete some practice to see your phoneme stats.</p>
+        <p className="empty-hint">Answer a few items to see sound-level progress.</p>
       )}
     </main>
   );

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -574,11 +574,23 @@ button {
   color: #4a90d9;
 }
 
+.stat-word {
+  font-size: 1.1rem;
+  line-height: 1.25;
+}
+
 .stat-label {
   display: block;
   font-size: 0.75rem;
   color: #888;
   margin-top: 2px;
+}
+
+.stat-subtext {
+  color: #666;
+  display: block;
+  font-size: 0.72rem;
+  margin-top: 3px;
 }
 
 .phoneme-section {

--- a/frontend/tests/e2e/m10-ux-walkthrough.spec.ts
+++ b/frontend/tests/e2e/m10-ux-walkthrough.spec.ts
@@ -485,10 +485,13 @@ test.describe("M10 UX walkthrough evidence", () => {
 
     await test.step("Progress focus entry can launch and clear focused practice", async () => {
       await page.getByRole("button", { name: "Progress" }).click();
-      await expect(page.getByRole("heading", { name: "Progress" })).toBeVisible();
-      await expect(page.getByRole("heading", { name: "Needs practice in Entry" })).toBeVisible();
-      await expect(page.getByText("day streak")).toBeVisible();
-      await expect(page.locator(".stat-card").filter({ hasText: "day streak" }).getByText("0")).toBeVisible();
+      await expect(page.getByRole("heading", { name: "Progress", exact: true })).toBeVisible();
+      await expect(page.getByRole("heading", { name: "Sounds to revisit in Entry" })).toBeVisible();
+      await expect(page.getByText("practice underway today")).toBeVisible();
+      await expect(page.getByText("answered items", { exact: true })).toBeVisible();
+      await expect(page.getByText("completed groups", { exact: true })).toBeVisible();
+      await expect(page.getByText("Entry has sounds ready for focused practice.")).toBeVisible();
+      await expect(page.getByText("Mid has no answered items yet. Start a group when this level is selected.")).toBeVisible();
       await page.getByRole("button", { name: "Focus /ʃ/" }).first().click();
       await expect(page.getByText("Focused group: 1 / 1")).toBeVisible();
       await expect(page.getByText("Entry focused practice for /ʃ/.")).toBeVisible();
@@ -548,6 +551,11 @@ test.describe("M10 UX walkthrough evidence", () => {
       await expect(page.getByRole("heading", { name: "Settings" })).toBeVisible();
       await expect(page.getByText("Advanced/debug: manual IPA focus entry")).toBeVisible();
       await attachScreenshot(page, "m10-mobile-settings");
+      await page.getByRole("button", { name: "Progress" }).click();
+      await expect(page.getByRole("heading", { name: "Progress", exact: true })).toBeVisible();
+      await expect(page.getByText("start today's practice")).toBeVisible();
+      await expect(page.getByRole("heading", { name: "Sounds to revisit in Entry" })).toBeVisible();
+      await attachScreenshot(page, "m10-mobile-progress");
     });
   });
 });

--- a/frontend/tests/e2e/m7-walkthrough.spec.ts
+++ b/frontend/tests/e2e/m7-walkthrough.spec.ts
@@ -553,9 +553,9 @@ test.describe("M7 v2 learner workflow walkthrough", () => {
     await setupMockApi(page);
     await openWalkthrough(page);
     await page.getByRole("button", { name: "Progress" }).click();
-    await expect(page.getByRole("heading", { name: "Progress" })).toBeVisible();
-    await expect(page.getByRole("heading", { name: "Needs practice in Entry" })).toBeVisible();
-    await expect(page.getByText("Focused practice starts at the selected level in Settings.")).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Progress", exact: true })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Sounds to revisit in Entry" })).toBeVisible();
+    await expect(page.getByText("Focused practice uses the level selected in Settings.")).toBeVisible();
     await page.getByRole("button", { name: "Focus /ʃ/" }).first().click();
 
     await expect(page.getByText("Focused group: 1 / 1")).toBeVisible();
@@ -578,9 +578,9 @@ test.describe("M7 v2 learner workflow walkthrough", () => {
     await completeFirstGroupWithOneMiss(page);
     await page.getByRole("button", { name: "Return to Progress" }).click();
 
-    await expect(page.getByRole("heading", { name: "Progress" })).toBeVisible();
-    await expect(page.getByRole("heading", { name: "Needs practice in Entry" })).toBeVisible();
-    await expect(page.getByRole("heading", { name: "Global needs practice" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Progress", exact: true })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Sounds to revisit in Entry" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Sounds to revisit overall" })).toBeVisible();
     await expect(page.getByRole("button", { name: "Today", exact: true })).toBeVisible();
   });
 

--- a/frontend/tests/e2e/m8-level-selection.spec.ts
+++ b/frontend/tests/e2e/m8-level-selection.spec.ts
@@ -283,10 +283,12 @@ test.describe("M8 learner level selection walkthrough", () => {
 
     await test.step("Progress distinguishes Entry and Mid statistics", async () => {
       await page.getByRole("button", { name: "Progress" }).click();
-      await expect(page.getByRole("heading", { name: "Progress" })).toBeVisible();
-      await expect(page.getByRole("heading", { name: "Entry stats" })).toBeVisible();
-      await expect(page.getByRole("heading", { name: "Mid stats" })).toBeVisible();
-      await expect(page.getByText("Global needs practice")).toHaveCount(0);
+      await expect(page.getByRole("heading", { name: "Progress", exact: true })).toBeVisible();
+      await expect(page.getByRole("heading", { name: "Entry progress" })).toBeVisible();
+      await expect(page.getByRole("heading", { name: "Mid progress" })).toBeVisible();
+      await expect(page.getByText("Sounds to revisit overall")).toHaveCount(0);
+      await expect(page.getByText("Entry has sounds ready for focused practice.")).toBeVisible();
+      await expect(page.getByText("Mid is looking steady so far. Keep practicing to confirm strong sounds.")).toBeVisible();
       const screenshotPath = test.info().outputPath("m8-mid-level-mobile.png");
       await page.screenshot({ fullPage: true, path: screenshotPath });
       await test.info().attach("m8-mid-level-mobile", {


### PR DESCRIPTION
## Summary

- Rework Progress copy/ViewModel semantics into learner-facing status: practice underway/ready, answered items, completed groups, and active group hints.
- Clarify Entry/Mid sections with completed groups vs active groups, answered items, and accuracy availability.
- Rename weak/strong sound sections to motivating copy (`Sounds to revisit`, `Sounds going well`) without changing API data.
- Update M10, M8, and M7 walkthrough expectations, including M10 mobile Progress evidence.

## Verification

- `cd frontend && pnpm exec tsc --noEmit`: passed
- `cd frontend && pnpm test:e2e:m10`: passed (desktop + mobile Progress evidence)
- `cd frontend && pnpm test:e2e:m8`: passed
- `cd frontend && M7_WALKTHROUGH_PORT=5178 pnpm test:e2e:m7`: passed
- `cd frontend && pnpm run build`: passed
- `tools/agents/agent-audit`: clean

## Helper Dogfood Notes

- Startup helpers used: `git fetch --prune origin`, `agent-inbox implementer`, `agent-ready-queue --role implementer`, `agent-audit`, and `agent-issue-context 184`.
- `agent-pickup 184 --role implementer` dry-run showed startable; pickup comment/label update was done manually because helper apply remains dry-run-only.
- Architect correction comment fixed `Depends on: #183` inside the Execution Contract before pickup proceeded.
- Untracked `.pnpm-store/` was present before implementation and intentionally not staged.
- Playwright emitted existing `NO_COLOR`/`FORCE_COLOR` warnings. M7 was run on `M7_WALKTHROUGH_PORT=5178` to avoid local port conflicts.

Closes #184
