### PR TITLE
[#185] Add learner-visible audio confidence states

### DIFF
--- a/frontend/src/components/AudioButton.tsx
+++ b/frontend/src/components/AudioButton.tsx
@@ -3,12 +3,12 @@
  * falls back to browser speechSynthesis otherwise.
  *
  * Finger-friendly, no layout shift, handles overlapping taps.
- * Shows a visible indicator when TTS fallback is active.
+ * Shows learner-visible audio source and fallback state.
  */
 
 import { useState, useEffect } from "react";
 
-type PlayStatus = "idle" | "playing" | "fallback" | "error";
+type PlayStatus = "idle" | "playing" | "tts" | "fallback" | "error";
 
 interface Props {
   audioUrl: string | null;
@@ -29,7 +29,7 @@ export function AudioButton({ audioUrl, word, disabled = false }: Props) {
   }, []);
 
   const handleClick = () => {
-    if (disabled || status === "playing" || status === "fallback") return;
+    if (disabled || isBusy(status)) return;
 
     if (audioUrl) {
       // Try static mp3 first; fall back to TTS on failure
@@ -39,21 +39,20 @@ export function AudioButton({ audioUrl, word, disabled = false }: Props) {
         setStatus,
       );
     } else {
-      playTTS(word, () => setStatus("idle"), setStatus);
+      playTTS(word, () => setStatus("tts"), setStatus);
     }
   };
 
-  const disabled_ = disabled || status === "playing" || status === "fallback";
+  const disabled_ = disabled || isBusy(status);
 
   const icon =
     status === "playing" ? "🔊" :
-    status === "fallback" ? "🔈" :
+    status === "fallback" || status === "tts" ? "🔈" :
     status === "error" ? "⚠️" :
     "🔈";
 
-  const ttsLabel = audioUrl
-    ? (status === "fallback" ? "Static audio unavailable — using TTS" : "Play audio")
-    : "Play pronunciation (TTS)";
+  const sourceLabel = getSourceLabel(audioUrl, status);
+  const actionLabel = getActionLabel(audioUrl, status);
 
   return (
     <span className="audio-btn-wrapper">
@@ -61,17 +60,17 @@ export function AudioButton({ audioUrl, word, disabled = false }: Props) {
         className="audio-btn"
         onClick={handleClick}
         disabled={disabled_}
-        aria-label={ttsLabel}
-        title={ttsLabel}
+        aria-label={actionLabel}
+        title={actionLabel}
       >
         {icon}
       </button>
-      {status === "fallback" && (
-        <span className="audio-fallback-badge" aria-live="polite">TTS</span>
-      )}
-      {status === "error" && (
-        <span className="audio-error-badge" aria-live="polite">!</span>
-      )}
+      <span
+        className={`audio-source-label ${status === "error" ? "audio-source-label--error" : ""}`}
+        aria-live="polite"
+      >
+        {sourceLabel}
+      </span>
     </span>
   );
 }
@@ -134,4 +133,28 @@ function playTTS(
   };
 
   speechSynthesis.speak(utterance);
+}
+
+function isBusy(status: PlayStatus) {
+  return status === "playing" || status === "fallback" || status === "tts";
+}
+
+function getActionLabel(audioUrl: string | null, status: PlayStatus) {
+  if (status === "error") return "Audio unavailable";
+  if (audioUrl) {
+    return status === "fallback"
+      ? "Static audio unavailable; using browser voice"
+      : "Play recorded pronunciation";
+  }
+  return status === "tts" ? "Playing browser voice" : "Play pronunciation with browser voice";
+}
+
+function getSourceLabel(audioUrl: string | null, status: PlayStatus) {
+  if (status === "error") return "Audio unavailable";
+  if (audioUrl) {
+    if (status === "playing") return "Playing recorded audio";
+    if (status === "fallback") return "Recorded audio unavailable; using browser voice";
+    return "Recorded audio";
+  }
+  return status === "tts" ? "Playing browser voice" : "Browser voice";
 }

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -145,29 +145,21 @@ button {
 .audio-btn-wrapper {
   display: inline-flex;
   align-items: center;
+  gap: 6px;
   vertical-align: middle;
 }
 
-.audio-fallback-badge {
-  font-size: 0.6rem;
-  font-weight: 700;
-  color: #e65100;
-  background: #fff3e0;
-  border-radius: 3px;
-  padding: 1px 4px;
-  margin-left: 2px;
-  line-height: 1.2;
+.audio-source-label {
+  max-width: 190px;
+  color: #555;
+  font-size: 0.78rem;
+  font-weight: 600;
+  line-height: 1.25;
+  text-align: left;
 }
 
-.audio-error-badge {
-  font-size: 0.6rem;
-  font-weight: 700;
+.audio-source-label--error {
   color: #c62828;
-  background: #ffebee;
-  border-radius: 3px;
-  padding: 1px 4px;
-  margin-left: 2px;
-  line-height: 1.2;
 }
 
 .question-prompt {

--- a/frontend/tests/e2e/m10-ux-walkthrough.spec.ts
+++ b/frontend/tests/e2e/m10-ux-walkthrough.spec.ts
@@ -442,13 +442,15 @@ test.describe("M10 UX walkthrough evidence", () => {
     await test.step("Wrong answer feedback remains inspectable until learner continues", async () => {
       await page.getByRole("button", { name: "Start Entry group" }).click();
       await expect(page.getByText("Practice group: 1 / 2")).toBeVisible();
-      await expect(page.getByRole("button", { name: "Play pronunciation (TTS)" })).toBeVisible();
+      await expect(page.getByRole("button", { name: "Play pronunciation with browser voice" })).toBeVisible();
+      await expect(page.getByText("Browser voice")).toBeVisible();
       await answer(page, "/sɪp/");
       await expect(page.getByText("Not quite")).toBeVisible();
       await expect(page.getByText("You picked")).toBeVisible();
       await expect(page.getByText("Correct IPA")).toBeVisible();
       await expect(page.getByText("Target sound")).toBeVisible();
-      await expect(page.getByRole("button", { name: "Play pronunciation (TTS)" })).toBeVisible();
+      await expect(page.getByRole("button", { name: "Play pronunciation with browser voice" })).toBeVisible();
+      await expect(page.getByText("Browser voice")).toBeVisible();
       await expect(page.getByRole("button", { name: "Continue" })).toBeVisible();
       await attachScreenshot(page, "m10-wrong-answer-feedback");
       await page.waitForTimeout(1_800);
@@ -456,6 +458,8 @@ test.describe("M10 UX walkthrough evidence", () => {
       await expect(page.getByText("Not quite")).toBeVisible();
       await page.getByRole("button", { name: "Continue" }).click();
       await expect(page.getByRole("button", { name: "Select /θɪn/" })).toBeVisible();
+      await expect(page.getByRole("button", { name: "Play recorded pronunciation" })).toBeVisible();
+      await expect(page.getByText("Recorded audio")).toBeVisible();
     });
 
     await test.step("Completion summary exposes current-group recovery and next choices", async () => {
@@ -557,5 +561,22 @@ test.describe("M10 UX walkthrough evidence", () => {
       await expect(page.getByRole("heading", { name: "Sounds to revisit in Entry" })).toBeVisible();
       await attachScreenshot(page, "m10-mobile-progress");
     });
+  });
+
+  test("Audio confidence state explains unavailable playback", async ({ page }) => {
+    await page.addInitScript(() => {
+      Object.defineProperty(window, "speechSynthesis", {
+        configurable: true,
+        value: undefined,
+      });
+    });
+    await setupM10Api(page, { activeGroup: "entry" });
+
+    await page.goto("/");
+    await page.getByRole("button", { name: "Resume Entry group" }).click();
+    await expect(page.getByText("Browser voice")).toBeVisible();
+    await page.getByRole("button", { name: "Play pronunciation with browser voice" }).click();
+    await expect(page.getByText("Audio unavailable")).toBeVisible();
+    await attachScreenshot(page, "m10-audio-unavailable-state");
   });
 });


### PR DESCRIPTION
## Summary
- Adds always-visible audio source/status copy beside playback controls: recorded audio, browser voice, recorded-audio fallback, and unavailable playback.
- Preserves existing audio behavior and API shape: static audio still tries first when `audio_url` exists, then falls back to browser speech; missing `audio_url` still uses browser speech.
- Extends M10 walkthrough coverage for browser voice, recorded audio, and unavailable playback states on desktop/mobile.

## Verification
- `cd frontend && pnpm exec tsc --noEmit`
- `cd frontend && pnpm test:e2e:m10` — 6 passed; includes desktop/mobile audio-confidence evidence and `m10-audio-unavailable-state` screenshot attachment.
- `cd frontend && pnpm run build`
- `git diff --check`
- `tools/agents/agent-audit` — clean after helper retried a transient GitHub TLS timeout.

## Helper Dogfood / Notes
- Used `agent-inbox`, `agent-ready-queue --role implementer`, `agent-audit`, `agent-issue-context 185`, and `agent-pickup 185 --role implementer` before implementation.
- No backend/API changes were needed; the visible states are inferred from existing `audio_url` and playback status.
- Audible output itself was not asserted; the automated evidence verifies learner-visible confidence/failure state, which is the scoped UX signal for #185.
- Left unrelated untracked `.pnpm-store/` unstaged.

## Boundaries Honored
- No broad audio provider rewrite, persistence/schema change, Project mutation, issue closure, merge, force push, or unrelated M10 work.

Refs #185