### PR TITLE
Clean up roadmap and helper dogfood docs

### DIFF
--- a/docs/06-epic-roadmap.md
+++ b/docs/06-epic-roadmap.md
@@ -15,8 +15,8 @@ Tiny IPA uses Epic issues as the primary planning and multi-agent coordination u
 | M6 Core 300 Content and Coverage | #26 | Done |
 | M7 Practice Loop and Review UX | #114 | Done |
 | M8 Level-based Content Expansion and Core 1000 Rebalance | #108 | Done |
-| M9 UK Accent Compare and Specialty Practice | #28 | Backlog |
-| M10 UX Research and Practice Experience Optimization | #102 | Backlog |
+| M9 UK Accent Compare and Specialty Practice | #28 | In progress |
+| M10 UX Research and Practice Experience Optimization | #102 | Done |
 | M11 VPS Deployment and Backup | #27 | Backlog |
 
 ## M0：Feasibility and Architecture Skeleton
@@ -300,14 +300,24 @@ Dependency plan:
 
 Goal: open optional UK comparison and specialty practice without changing core boundaries.
 
-Expected child issue areas:
+Roadmap status:
 
 ```text
-UK reviewed subset
-show_accent_compare
-minimal pair practice
-target phoneme practice
-accent-specific stats checks
+Current milestone. The Architect contract gate is complete, and foundational
+content/stat separation work is released before UK comparison UI or specialty
+runtime practice.
+```
+
+Current child issue sequence:
+
+```text
+#193 Define M9 accent and specialty practice contract
+#196 Build reviewed UK-ready content subset and accent coverage report
+#197 Add accent-specific stats separation regression checks
+UK comparison UI/API after content and stats gates
+minimal-pair specialty practice after content and stats gates
+target-phoneme specialty practice after content and shared specialty semantics
+final M9 readiness review with trial evidence
 ```
 
 Acceptance:
@@ -320,16 +330,25 @@ specialty practice reuses question/grading/progress boundaries
 
 ## M10：UX Research and Practice Experience Optimization
 
-Goal: improve the learning experience after the core practice loop, level model, and specialty practice foundations are in place.
+Goal: improve the learning experience after the core practice loop and level model, before the later UK comparison and specialty practice runtime work.
 
-Expected child issue areas:
+Roadmap status:
 
 ```text
-manual observation of learner practice sessions
-question wording and feedback comprehension
-audio playback ergonomics
-mobile layout and child-friendly interaction checks
-progress motivation and fatigue controls
+Done. Epic #102 closed after the accepted UX methodology, learner-paced feedback,
+recovery and level-switch copy, progress motivation copy, audio confidence
+states, and 小音标 Morandi visual direction were completed and verified.
+```
+
+Completed child issue areas:
+
+```text
+UX methodology and repeatable design workflow
+learner-paced wrong-answer feedback
+recovery and level-switch copy clarification
+progress motivation and fatigue-aware copy
+audio confidence and unavailable-playback states
+小音标 Morandi visual direction and placeholder login/account affordance
 ```
 
 Acceptance:
@@ -338,6 +357,7 @@ Acceptance:
 UX findings are recorded as evidence, not ad hoc redesign impulses
 high-impact interaction fixes are split into scoped child issues
 practice experience changes preserve existing scheduling and progress boundaries
+final closeout is recorded on #102
 ```
 
 ## M11：VPS Deployment and Backup

--- a/docs/09-role-generic-agent-helpers.md
+++ b/docs/09-role-generic-agent-helpers.md
@@ -10,6 +10,19 @@ fast REST-based reads, `needs:*` labels, and local audit scripts can make a
 GitHub Project feel like a lightweight agent scheduler. The next step is to make
 that scheduler role-generic before adding more write automation.
 
+## Dogfood Evidence
+
+The helper migration-readiness evaluation is preserved in closed issue
+[#146](https://github.com/farmerhunter/tiny-ipa/issues/146). Treat it as
+historical evidence for the staged-migration decision, blocker analysis, and
+Tiny IPA-local exclusions, not as a live source of truth for current helper
+state.
+
+Current reusable workflow rules should live in the harvested practices, skills,
+and the stable docs in this repository. New migration or portability decisions
+should be recorded in fresh issues rather than reopening #146 as an active
+tracking surface.
+
 ## Design Constraints and Principles
 
 The helper model is a lightweight multi-agent scheduler built on GitHub under


### PR DESCRIPTION
## Summary

Closes #194.

- Update `docs/06-epic-roadmap.md` so M9/#28 is current/in progress, M10/#102 is Done, and M11/#27 remains Backlog.
- Refresh the M9 and M10 roadmap sections to match durable GitHub state after #193 acceptance and #102 closeout.
- Add a stable `docs/09-role-generic-agent-helpers.md` reference to closed dogfood issue #146 as historical evidence, not a live source of truth.
- Update #28 Roadmap Status/body directly so it no longer says M9 was previously M8 and now M10.

## PR #147 Disposition

The useful part of closed PR #147 was rewritten rather than merged as-is:
- #147's dynamic-source wording is obsolete because #146 is closed.
- This PR treats #146 as stable closed evidence and directs future decisions to fresh issues/practices/skills.

## Verification

- Docs diff review.
- `git diff --check`.
- `tools/agents/agent-audit`.
- Changed files are docs only; no product runtime files changed.

## Boundaries

- No product behavior changes.
- No Project mutation.
- No downstream M9 implementation release.
- #194 remains separate from #193.
