### PR TITLE
test: separate accent progress stats

### DIFF
--- a/backend/app/services/progress.py
+++ b/backend/app/services/progress.py
@@ -207,14 +207,23 @@ def build_progress_response(
 
     # ---- total attempts ------------------------------------------------------
     total_row = conn.execute(
-        "SELECT COUNT(*) AS cnt FROM attempts WHERE user_id = ?", (user_id,)
+        """
+        SELECT COUNT(*) AS cnt
+        FROM attempts
+        WHERE user_id = ? AND primary_accent = ?
+        """,
+        (user_id, primary_accent),
     ).fetchone()
     total_attempts = total_row["cnt"] if total_row else 0
 
     # ---- total sessions ------------------------------------------------------
     sess_row = conn.execute(
-        "SELECT COUNT(*) AS cnt FROM daily_sessions WHERE user_id = ?",
-        (user_id,),
+        """
+        SELECT COUNT(*) AS cnt
+        FROM daily_sessions
+        WHERE user_id = ? AND primary_accent = ?
+        """,
+        (user_id, primary_accent),
     ).fetchone()
     total_sessions = sess_row["cnt"] if sess_row else 0
 
@@ -222,9 +231,9 @@ def build_progress_response(
         """
         SELECT COUNT(*) AS cnt
         FROM daily_sessions
-        WHERE user_id = ? AND group_type = 'normal'
+        WHERE user_id = ? AND primary_accent = ? AND group_type = 'normal'
         """,
-        (user_id,),
+        (user_id, primary_accent),
     ).fetchone()
     total_normal_groups = normal_row["cnt"] if normal_row else 0
 
@@ -233,9 +242,10 @@ def build_progress_response(
     today_rows = conn.execute(
         """
         SELECT status FROM daily_sessions
-        WHERE user_id = ? AND session_date = ? AND group_type = 'normal'
+        WHERE user_id = ? AND primary_accent = ? AND session_date = ?
+          AND group_type = 'normal'
         """,
-        (user_id, today_str),
+        (user_id, primary_accent, today_str),
     ).fetchall()
     statuses = {row["status"] for row in today_rows}
     if "in_progress" in statuses:
@@ -247,7 +257,7 @@ def build_progress_response(
     today_completed = today_status == "completed"
 
     # ---- streak --------------------------------------------------------------
-    streak_days = _compute_streak(conn, user_id)
+    streak_days = _compute_streak(conn, user_id, primary_accent)
 
     # ---- weak / strong phonemes ----------------------------------------------
     weak_phonemes, strong_phonemes = _compute_phoneme_lists(
@@ -274,7 +284,7 @@ def build_progress_response(
 # ---------------------------------------------------------------------------
 
 
-def _compute_streak(conn: sqlite3.Connection, user_id: str) -> int:
+def _compute_streak(conn: sqlite3.Connection, user_id: str, primary_accent: str) -> int:
     """Count consecutive completed daily sessions.
 
     Walks backwards from yesterday; a gap or incomplete day breaks the streak.
@@ -283,10 +293,11 @@ def _compute_streak(conn: sqlite3.Connection, user_id: str) -> int:
     rows = conn.execute(
         """
         SELECT session_date FROM daily_sessions
-        WHERE user_id = ? AND status = 'completed' AND group_type = 'normal'
+        WHERE user_id = ? AND primary_accent = ? AND status = 'completed'
+          AND group_type = 'normal'
         ORDER BY session_date DESC
         """,
-        (user_id,),
+        (user_id, primary_accent),
     ).fetchall()
     completed_dates = {r["session_date"] for r in rows}
 
@@ -334,10 +345,10 @@ def _compute_level_stats(
         """
         SELECT learner_level, status, session_date, COUNT(*) AS cnt
         FROM daily_sessions
-        WHERE user_id = ? AND group_type = 'normal'
+        WHERE user_id = ? AND primary_accent = ? AND group_type = 'normal'
         GROUP BY learner_level, status, session_date
         """,
-        (user_id,),
+        (user_id, primary_accent),
     ).fetchall()
     for row in group_rows:
         level = row["learner_level"] if row["learner_level"] in result else "entry"

--- a/backend/tests/test_attempts.py
+++ b/backend/tests/test_attempts.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
 
@@ -184,6 +185,73 @@ class TestAttemptRoute:
         assert len(rows) > 0
         for r in rows:
             assert r["primary_accent"] == "US"
+
+    def test_uk_session_attempt_updates_only_uk_phoneme_stats(self, client, seeded_db):
+        """A lower-level UK session writes UK stats without touching US stats."""
+        conn = get_connection(seeded_db)
+        session_id = "uk-session"
+        item_id = f"{session_id}_item_001"
+        conn.execute(
+            """
+            INSERT INTO daily_sessions (
+                id, user_id, session_date, primary_accent, status, created_at,
+                group_index, group_type, learner_level
+            ) VALUES (?, 'default', '2026-06-28', 'UK', 'in_progress',
+                '2026-06-28T10:00:00Z', 1, 'normal', 'entry')
+            """,
+            (session_id,),
+        )
+        conn.execute(
+            """
+            INSERT INTO session_items (
+                id, session_id, word_id, order_index, target_phonemes,
+                question_type, status
+            ) VALUES (?, ?, 'ship', 0, ?, 'choose_ipa', 'pending')
+            """,
+            (item_id, session_id, json.dumps(["/ʃ/"])),
+        )
+        conn.execute(
+            """
+            INSERT INTO phoneme_stats (
+                user_id, primary_accent, phoneme_id, attempt_count, correct_count,
+                last_attempt_at, mastery_status
+            ) VALUES ('default', 'US', '/ʃ/', 7, 7, '2026-06-27T10:00:00Z', 'mastered')
+            """
+        )
+        conn.commit()
+        conn.close()
+
+        resp = client.post("/api/attempt", json={
+            "session_item_id": item_id,
+            "selected_answer": "/wrong/",
+        })
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["is_correct"] is False
+        assert data["updated_phonemes"] == [
+            {
+                "phoneme": "/ʃ/",
+                "attempt_count": 1,
+                "correct_count": 0,
+                "mastery_status": "new",
+            }
+        ]
+
+        conn = get_connection(seeded_db)
+        rows = conn.execute(
+            """
+            SELECT primary_accent, attempt_count, correct_count
+            FROM phoneme_stats
+            WHERE user_id = 'default' AND phoneme_id = '/ʃ/'
+            ORDER BY primary_accent
+            """
+        ).fetchall()
+        conn.close()
+
+        assert [(row["primary_accent"], row["attempt_count"], row["correct_count"]) for row in rows] == [
+            ("UK", 1, 0),
+            ("US", 7, 7),
+        ]
 
     def test_last_wrong_at_preserved_after_correct(self, client, seeded_db):
         """After wrong→correct, last_wrong_at should persist, not be cleared."""

--- a/backend/tests/test_progress_api.py
+++ b/backend/tests/test_progress_api.py
@@ -242,6 +242,106 @@ class TestProgressApi:
         assert resp["level_stats"]["entry"]["weak_phonemes"][0]["phoneme"] == "/æ/"
         assert resp["level_stats"]["mid"]["strong_phonemes"][0]["phoneme"] == "/ʃ/"
 
+    def test_progress_defaults_do_not_blend_uk_stats_into_us_path(self, seeded_db):
+        conn = get_connection(seeded_db)
+        today = date.today().isoformat()
+        yesterday = (date.today() - timedelta(days=1)).isoformat()
+        sessions = [
+            ("us-normal", "US", today, "completed", "entry"),
+            ("uk-normal", "UK", today, "in_progress", "mid"),
+            ("uk-streak", "UK", yesterday, "completed", "mid"),
+        ]
+        for session_id, accent, session_date, status, level in sessions:
+            conn.execute(
+                """
+                INSERT INTO daily_sessions (
+                    id, user_id, session_date, primary_accent,
+                    status, created_at, completed_at, group_index,
+                    group_type, learner_level
+                ) VALUES (?, 'default', ?, ?, ?, ?, ?, 1, 'normal', ?)
+                """,
+                (
+                    session_id,
+                    session_date,
+                    accent,
+                    status,
+                    f"{session_date}T10:00:00Z",
+                    f"{session_date}T10:05:00Z" if status == "completed" else None,
+                    level,
+                ),
+            )
+            conn.execute(
+                """
+                INSERT INTO session_items (
+                    id, session_id, word_id, order_index, target_phonemes,
+                    question_type, status
+                ) VALUES (?, ?, 'ship', 0, ?, 'choose_ipa', 'complete')
+                """,
+                (
+                    f"{session_id}-item",
+                    session_id,
+                    json.dumps(["/ʃ/"] if accent == "US" else ["/θ/"]),
+                ),
+            )
+
+        for index in range(3):
+            conn.execute(
+                """
+                INSERT INTO attempts (
+                    id, user_id, session_item_id, word_id, primary_accent,
+                    question_type, selected_answer, correct_answer, is_correct, created_at
+                ) VALUES (?, 'default', 'us-normal-item', 'ship', 'US',
+                    'choose_ipa', '/ʃɪp/', '/ʃɪp/', 1, ?)
+                """,
+                (f"us-attempt-{index}", f"{today}T11:0{index}:00Z"),
+            )
+            conn.execute(
+                """
+                INSERT INTO attempts (
+                    id, user_id, session_item_id, word_id, primary_accent,
+                    question_type, selected_answer, correct_answer, is_correct, created_at
+                ) VALUES (?, 'default', 'uk-normal-item', 'ship', 'UK',
+                    'choose_ipa', '/wrong/', '/ʃɪp/', 0, ?)
+                """,
+                (f"uk-attempt-{index}", f"{today}T12:0{index}:00Z"),
+            )
+
+        conn.execute(
+            """
+            INSERT INTO phoneme_stats (
+                user_id, primary_accent, phoneme_id, attempt_count, correct_count,
+                last_attempt_at, mastery_status
+            ) VALUES ('default', 'US', '/ʃ/', 3, 3, ?, 'learning')
+            """,
+            (f"{today}T11:02:00Z",),
+        )
+        conn.execute(
+            """
+            INSERT INTO phoneme_stats (
+                user_id, primary_accent, phoneme_id, attempt_count, correct_count,
+                last_attempt_at, mastery_status
+            ) VALUES ('default', 'UK', '/θ/', 3, 0, ?, 'weak')
+            """,
+            (f"{today}T12:02:00Z",),
+        )
+        conn.commit()
+
+        resp = build_progress_response(conn)
+        conn.close()
+
+        assert resp["today_status"] == "completed"
+        assert resp["today_completed"] is True
+        assert resp["streak_days"] == 0
+        assert resp["total_attempts"] == 3
+        assert resp["total_sessions"] == 1
+        assert resp["total_normal_groups"] == 1
+        assert resp["level_stats"]["entry"]["normal_groups"] == 1
+        assert resp["level_stats"]["mid"]["normal_groups"] == 0
+        assert resp["level_stats"]["entry"]["attempts"] == 3
+        assert resp["level_stats"]["mid"]["attempts"] == 0
+        assert resp["weak_phonemes"] == []
+        assert resp["strong_phonemes"][0]["phoneme"] == "/ʃ/"
+
 
 # ---------------------------------------------------------------------------
 # Streak


### PR DESCRIPTION
## Summary
- Scope progress aggregate queries by active `primary_accent` so US progress totals/today/streak/level counts do not blend UK sessions or attempts.
- Add regression coverage for UK session attempts writing only UK phoneme stats while preserving existing US stats.
- Add regression coverage for US Progress/reporting excluding UK sessions, attempts, stats, and weak/strong phoneme lists.

Refs #197.

## Verification
- `cd backend && uv run pytest tests/test_attempts.py tests/test_progress_api.py` — 30 passed
- `cd backend && uv run pytest` — 192 passed
- `git diff --check`
- `tools/agents/agent-audit`

## Boundaries
- No UK learner `primary_accent` selection.
- No UK comparison UI/API.
- No minimal-pair or target-phoneme runtime behavior.
- No schema migration, Project mutation, issue close, or merge.