### PR TITLE
[#201] Add settings-gated display-only UK comparison UI/API

### DIFF
--- a/backend/app/services/sessions.py
+++ b/backend/app/services/sessions.py
@@ -89,7 +89,10 @@ def build_today_response(
             source_scope="normal_current",
             focus_phonemes=existing.focus_phonemes or settings.focus_phonemes,
             selected_learner_level=selected_level,
-            action_label=f"Resume {learner_level_label(existing.learner_level)} Group {existing.group_index}",
+            action_label=(
+                f"Resume {learner_level_label(existing.learner_level)} "
+                f"Group {existing.group_index}"
+            ),
         )
 
     return _normal_empty_response(
@@ -131,7 +134,10 @@ def build_next_normal_group_response(
             source_scope="normal_current",
             focus_phonemes=existing.focus_phonemes or settings.focus_phonemes,
             selected_learner_level=settings.learner_level,
-            action_label=f"Resume {learner_level_label(existing.learner_level)} Group {existing.group_index}",
+            action_label=(
+                f"Resume {learner_level_label(existing.learner_level)} "
+                f"Group {existing.group_index}"
+            ),
         )
 
     return _create_normal_group_response(
@@ -199,7 +205,10 @@ def _create_normal_group_response(
         source_scope=source_scope,
         focus_phonemes=settings.focus_phonemes,
         selected_learner_level=settings.learner_level,
-        action_label=f"Start {learner_level_label(session.learner_level)} Group {session.group_index}",
+        action_label=(
+            f"Start {learner_level_label(session.learner_level)} "
+            f"Group {session.group_index}"
+        ),
     )
 
 
@@ -505,7 +514,10 @@ def build_focused_group_response(
             source_scope="focus_selection",
             focus_phonemes=focus_phonemes,
             selected_learner_level=settings.learner_level,
-            action_label=f"Resume {learner_level_label(existing.learner_level)} Focus Group {existing.group_index}",
+            action_label=(
+                f"Resume {learner_level_label(existing.learner_level)} "
+                f"Focus Group {existing.group_index}"
+            ),
         )
 
     group_index = get_next_session_group_index(conn, user_id, session_date, accent)
@@ -551,7 +563,10 @@ def build_focused_group_response(
         source_scope="focus_selection",
         focus_phonemes=focus_phonemes,
         selected_learner_level=settings.learner_level,
-        action_label=f"Start {learner_level_label(session.learner_level)} Focus Group {session.group_index}",
+        action_label=(
+            f"Start {learner_level_label(session.learner_level)} "
+            f"Focus Group {session.group_index}"
+        ),
     )
 
 
@@ -733,6 +748,39 @@ def learner_level_label(learner_level: Optional[str]) -> str:
     return _LEARNER_LEVEL_LABELS.get(learner_level or "entry", "Entry")
 
 
+def _uk_comparison_ready(word) -> bool:
+    return bool(
+        word.content_status != "disabled"
+        and word.ipa_us
+        and word.ipa_uk
+        and word.phoneme_tags_us
+        and word.phoneme_tags_uk
+    )
+
+
+def _build_accent_compare(word, *, enabled: bool) -> Optional[dict]:
+    if not enabled or not _uk_comparison_ready(word):
+        return None
+    return {
+        "enabled": True,
+        "primary": {
+            "accent": "US",
+            "label": "American sound",
+            "ipa": word.ipa_us,
+        },
+        "comparison": {
+            "accent": "UK",
+            "label": "British note",
+            "ipa": word.ipa_uk,
+            "phoneme_tags": word.phoneme_tags_uk,
+            "review_note": (
+                "Display-only comparison. Your answer is still graded against "
+                "the American IPA."
+            ),
+        },
+    }
+
+
 def _build_response(
     *,
     session: DailySession,
@@ -748,6 +796,8 @@ def _build_response(
     action_label: Optional[str] = None,
 ) -> dict:
     """Assemble the /api/today JSON response from session + items."""
+    settings = get_settings(conn, session.user_id)
+    show_accent_compare = bool(settings and settings.show_accent_compare)
     distractor_pool = _build_distractor_pool(conn, accent)
     item_dicts: List[dict] = []
     for item in items:
@@ -774,6 +824,12 @@ def _build_response(
                 "question": question,
             }
         )
+        accent_compare = _build_accent_compare(
+            word,
+            enabled=accent == "US" and show_accent_compare,
+        )
+        if accent_compare is not None:
+            item_dicts[-1]["accent_compare"] = accent_compare
 
     response = {
         "session_id": session.id,

--- a/backend/tests/test_attempts.py
+++ b/backend/tests/test_attempts.py
@@ -14,14 +14,9 @@ if str(_SCRIPTS) not in sys.path:
     sys.path.insert(0, str(_SCRIPTS))
 
 from import_words import import_words  # noqa: E402
-from app.main import app  # noqa: E402
+
 from app.db import get_connection  # noqa: E402
-from app.services.db_store import (  # noqa: E402
-    create_attempt,
-    count_phonemes,
-    get_session_items,
-    get_word_by_id,
-)
+from app.main import app  # noqa: E402
 from app.services.progress import _compute_mastery, update_phoneme_stats  # noqa: E402
 
 FIXTURES = Path(__file__).resolve().parent / "fixtures"
@@ -120,6 +115,48 @@ class TestAttemptRoute:
         data = resp.json()
         assert data["is_correct"] is False
         assert data["correct_answer"] == item["display_ipa"]
+
+    def test_uk_comparison_ipa_is_not_accepted_for_us_session(self, client, seeded_db):
+        conn = get_connection(seeded_db)
+        conn.execute(
+            """
+            UPDATE words
+            SET ipa_uk = '/ʃɪp-uk/', phoneme_tags_uk = '["/ʃ/", "/ɪ/", "/p/"]'
+            WHERE id = 'ship'
+            """
+        )
+        conn.execute("UPDATE settings SET show_accent_compare = 1 WHERE user_id = 'default'")
+        conn.commit()
+        conn.close()
+
+        today = client.post("/api/practice/next-normal").json()
+        item = next(item for item in today["items"] if item["word_id"] == "ship")
+        assert item["display_ipa"] == "/ʃɪp/"
+        assert item["accent_compare"]["comparison"]["ipa"] == "/ʃɪp-uk/"
+
+        resp = client.post("/api/attempt", json={
+            "session_item_id": item["session_item_id"],
+            "selected_answer": "/ʃɪp-uk/",
+        })
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["is_correct"] is False
+        assert data["correct_answer"] == "/ʃɪp/"
+
+        conn = get_connection(seeded_db)
+        row = conn.execute(
+            """
+            SELECT selected_answer, correct_answer, is_correct, primary_accent
+            FROM attempts
+            WHERE session_item_id = ?
+            """,
+            (item["session_item_id"],),
+        ).fetchone()
+        conn.close()
+        assert row["selected_answer"] == "/ʃɪp-uk/"
+        assert row["correct_answer"] == "/ʃɪp/"
+        assert row["is_correct"] == 0
+        assert row["primary_accent"] == "US"
 
     def test_attempt_persisted(self, client, seeded_db):
         item = _get_first_item(client)
@@ -248,10 +285,11 @@ class TestAttemptRoute:
         ).fetchall()
         conn.close()
 
-        assert [(row["primary_accent"], row["attempt_count"], row["correct_count"]) for row in rows] == [
-            ("UK", 1, 0),
-            ("US", 7, 7),
+        stats_summary = [
+            (row["primary_accent"], row["attempt_count"], row["correct_count"])
+            for row in rows
         ]
+        assert stats_summary == [("UK", 1, 0), ("US", 7, 7)]
 
     def test_last_wrong_at_preserved_after_correct(self, client, seeded_db):
         """After wrong→correct, last_wrong_at should persist, not be cleared."""

--- a/backend/tests/test_today_persistence.py
+++ b/backend/tests/test_today_persistence.py
@@ -246,6 +246,65 @@ class TestTodayPersistence:
             # display_ipa should match ipa_us
             assert item["display_ipa"] == w.ipa_us
 
+    def test_accent_compare_hidden_when_setting_off(self, client, seeded_db):
+        conn = get_connection(seeded_db)
+        conn.execute(
+            """
+            UPDATE words
+            SET ipa_uk = '/ʃɪp-uk/', phoneme_tags_uk = '["/ʃ/", "/ɪ/", "/p/"]'
+            WHERE id = 'ship'
+            """
+        )
+        conn.execute("UPDATE settings SET show_accent_compare = 0 WHERE user_id = 'default'")
+        conn.commit()
+        conn.close()
+
+        data = client.post("/api/practice/next-normal").json()
+        assert all("accent_compare" not in item for item in data["items"])
+        ship = next(item for item in data["items"] if item["word_id"] == "ship")
+        assert ship["display_ipa"] == "/ʃɪp/"
+        assert "/ʃɪp-uk/" not in ship["question"]["choices"]
+
+    def test_accent_compare_shown_for_eligible_rows_only(self, client, seeded_db):
+        conn = get_connection(seeded_db)
+        conn.execute(
+            """
+            UPDATE words
+            SET ipa_uk = '/ʃɪp-uk/', phoneme_tags_uk = '["/ʃ/", "/ɪ/", "/p/"]'
+            WHERE id = 'ship'
+            """
+        )
+        conn.execute("UPDATE words SET phoneme_tags_uk = NULL WHERE id = 'cat'")
+        conn.execute("UPDATE settings SET show_accent_compare = 1 WHERE user_id = 'default'")
+        conn.commit()
+        conn.close()
+
+        data = client.post("/api/practice/next-normal").json()
+        ship = next(item for item in data["items"] if item["word_id"] == "ship")
+        cat = next(item for item in data["items"] if item["word_id"] == "cat")
+
+        assert ship["display_ipa"] == "/ʃɪp/"
+        assert ship["target_phonemes"] == ["/ʃ/", "/ɪ/", "/p/"]
+        assert ship["accent_compare"] == {
+            "enabled": True,
+            "primary": {
+                "accent": "US",
+                "label": "American sound",
+                "ipa": "/ʃɪp/",
+            },
+            "comparison": {
+                "accent": "UK",
+                "label": "British note",
+                "ipa": "/ʃɪp-uk/",
+                "phoneme_tags": ["/ʃ/", "/ɪ/", "/p/"],
+                "review_note": (
+                    "Display-only comparison. Your answer is still graded against "
+                    "the American IPA."
+                ),
+            },
+        }
+        assert "accent_compare" not in cat
+
     def test_disabled_words_not_scheduled(self, client, seeded_db):
         # Mark one word as disabled and verify it's excluded.
         conn = get_connection(seeded_db)

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -65,6 +65,21 @@ export interface TodayItem {
     prompt: string;
     choices: string[];
   };
+  accent_compare?: {
+    enabled: boolean;
+    primary: {
+      accent: "US";
+      label: string;
+      ipa: string;
+    };
+    comparison: {
+      accent: "UK";
+      label: string;
+      ipa: string;
+      phoneme_tags: string[];
+      review_note: string;
+    };
+  };
 }
 
 export interface TodayResponse {

--- a/frontend/src/components/ChoiceQuestion.tsx
+++ b/frontend/src/components/ChoiceQuestion.tsx
@@ -153,6 +153,16 @@ export function ChoiceQuestion({ item, onResult, onContinue }: Props) {
         </div>
       )}
 
+      {isAnswered && item.accent_compare && (
+        <aside className="accent-compare-note" aria-label="Accent comparison">
+          <span>{item.accent_compare.primary.label}</span>
+          <code>{item.accent_compare.primary.ipa}</code>
+          <span>{item.accent_compare.comparison.label}</span>
+          <code>{item.accent_compare.comparison.ipa}</code>
+          <p>{item.accent_compare.comparison.review_note}</p>
+        </aside>
+      )}
+
       {isError && (
         <div className="feedback feedback-error" role="alert">
           <p>⚠️ Failed to submit: {error}</p>

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,9 +1,7 @@
 /**
  * SettingsPage — display and edit user settings.
  *
- * Only exposes MVP-supported controls.  Future settings (UK accent,
- * reveal_first, accent compare) are intentionally hidden until the practice
- * flow supports them.
+ * Only exposes learner-supported controls. UK remains comparison-only in M9.
  */
 
 import { useEffect, useState } from "react";
@@ -150,6 +148,15 @@ export default function SettingsPage({
         </label>
 
         <label className="setting-row">
+          <span>
+            Accent comparison
+            <small>Show British notes after answering</small>
+          </span>
+          <input type="checkbox" checked={settings.show_accent_compare}
+            onChange={e => update({ show_accent_compare: e.target.checked })} />
+        </label>
+
+        <label className="setting-row">
           <span>Review strength</span>
           <select value={settings.review_strength}
             onChange={e => update({ review_strength: e.target.value })}>
@@ -261,10 +268,6 @@ export default function SettingsPage({
         <label className="setting-row">
           <span>Practice mode</span>
           <select value={settings.practice_mode} … />
-        </label>
-        <label className="setting-row">
-          <span>Show accent compare</span>
-          <input type="checkbox" checked={settings.show_accent_compare} … />
         </label>
         ---- */}
       </div>

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -459,6 +459,36 @@ summary:focus-visible {
   font-size: 0.85rem;
 }
 
+.accent-compare-note {
+  align-items: center;
+  background: #eef3ef;
+  border: 1px solid #cddbd0;
+  border-radius: 8px;
+  color: var(--ink);
+  display: grid;
+  font-size: 0.88rem;
+  gap: 6px 10px;
+  grid-template-columns: minmax(96px, max-content) minmax(0, 1fr);
+  margin-top: 12px;
+  padding: 12px;
+}
+
+.accent-compare-note span {
+  color: var(--muted);
+  font-weight: 750;
+}
+
+.accent-compare-note code {
+  font-family: ui-monospace, "SFMono-Regular", "Menlo", "Consolas", monospace;
+  font-weight: 750;
+}
+
+.accent-compare-note p {
+  color: var(--muted);
+  grid-column: 1 / -1;
+  margin: 2px 0 0;
+}
+
 .feedback-continue-btn {
   background: var(--accent);
   border: 1px solid var(--accent-dark);
@@ -925,6 +955,17 @@ summary:focus-visible {
   border-bottom: 1px solid rgba(217, 210, 199, 0.8);
   font-size: 0.95rem;
   cursor: pointer;
+}
+
+.setting-row span {
+  display: grid;
+  gap: 2px;
+}
+
+.setting-row small {
+  color: var(--muted);
+  font-size: 0.78rem;
+  font-weight: 600;
 }
 
 .setting-row select,

--- a/frontend/tests/e2e/m10-ux-walkthrough.spec.ts
+++ b/frontend/tests/e2e/m10-ux-walkthrough.spec.ts
@@ -13,6 +13,21 @@ interface MockItem {
   target_phonemes: string[];
   choices: string[];
   audio_url: string | null;
+  accent_compare?: {
+    enabled: boolean;
+    primary: {
+      accent: "US";
+      label: string;
+      ipa: string;
+    };
+    comparison: {
+      accent: "UK";
+      label: string;
+      ipa: string;
+      phoneme_tags: string[];
+      review_note: string;
+    };
+  };
 }
 
 interface MockState {
@@ -22,6 +37,7 @@ interface MockState {
   focusPhonemes: string[];
   recentMistakeCount: number;
   recentReviewEmpty: boolean;
+  showAccentCompare: boolean;
 }
 
 const items: Record<Exclude<GroupKey, "none">, MockItem[]> = {
@@ -35,6 +51,21 @@ const items: Record<Exclude<GroupKey, "none">, MockItem[]> = {
       target_phonemes: ["/ʃ/"],
       choices: ["/sɪp/", "/ʃɪp/"],
       audio_url: null,
+      accent_compare: {
+        enabled: true,
+        primary: {
+          accent: "US",
+          label: "American sound",
+          ipa: "/ʃɪp/",
+        },
+        comparison: {
+          accent: "UK",
+          label: "British note",
+          ipa: "/ʃɪp-uk/",
+          phoneme_tags: ["/ʃ/", "/ɪ/", "/p/"],
+          review_note: "Display-only comparison. Your answer is still graded against the American IPA.",
+        },
+      },
     },
     {
       session_item_id: "entry-thin",
@@ -185,6 +216,7 @@ function todayResponse(state: MockState) {
       meaning_zh: item.meaning_zh,
       audio_url: item.audio_url,
       target_phonemes: item.target_phonemes,
+      accent_compare: state.showAccentCompare ? item.accent_compare : undefined,
       question: {
         type: "ipa_choice",
         prompt: "Which IPA matches this word?",
@@ -199,7 +231,7 @@ function settingsResponse(state: MockState) {
     primary_accent: "US",
     daily_word_count: 2,
     show_translation: true,
-    show_accent_compare: false,
+    show_accent_compare: state.showAccentCompare,
     practice_mode: "ipa_first",
     review_strength: "normal",
     learner_level: state.selectedLevel,
@@ -271,6 +303,7 @@ async function setupM10Api(page: Page, options: Partial<MockState> = {}) {
     focusPhonemes: options.focusPhonemes ?? [],
     recentMistakeCount: options.recentMistakeCount ?? 0,
     recentReviewEmpty: options.recentReviewEmpty ?? false,
+    showAccentCompare: options.showAccentCompare ?? false,
   };
 
   await page.route("**/api/**", async (route) => {
@@ -301,9 +334,13 @@ async function routeMock(route: Route, state: MockState) {
         learner_level?: LearnerLevel;
         focus_phonemes?: string[];
         daily_word_count?: number;
+        show_accent_compare?: boolean;
       };
       if (body.learner_level) state.selectedLevel = body.learner_level;
       if (body.focus_phonemes) state.focusPhonemes = body.focus_phonemes;
+      if (typeof body.show_accent_compare === "boolean") {
+        state.showAccentCompare = body.show_accent_compare;
+      }
     }
     await route.fulfill({ json: settingsResponse(state) });
     return;
@@ -578,5 +615,31 @@ test.describe("M10 UX walkthrough evidence", () => {
     await page.getByRole("button", { name: "Play pronunciation with browser voice" }).click();
     await expect(page.getByText("Audio unavailable")).toBeVisible();
     await attachScreenshot(page, "m10-audio-unavailable-state");
+  });
+
+  test("UK comparison is settings-gated and display-only", async ({ page }) => {
+    const state = await setupM10Api(page);
+
+    await page.goto("/");
+    await page.getByRole("button", { name: "Start Entry group" }).click();
+    await answer(page, "/sɪp/");
+    await expect(page.getByLabel("Accent comparison")).toHaveCount(0);
+
+    state.activeGroup = "none";
+    await page.getByRole("button", { name: "Settings" }).click();
+    await page.getByLabel("Accent comparison").click();
+    await expect(page.getByText("Saved")).toBeVisible();
+    await expect(page.getByText("Primary accent")).toHaveCount(0);
+
+    await page.getByRole("button", { name: "Today", exact: true }).click();
+    await page.getByRole("button", { name: "Start Entry group" }).click();
+    await answer(page, "/sɪp/");
+
+    await expect(page.getByLabel("Accent comparison")).toBeVisible();
+    await expect(page.getByText("American sound")).toBeVisible();
+    await expect(page.getByText("British note")).toBeVisible();
+    await expect(page.getByText("/ʃɪp-uk/")).toBeVisible();
+    await expect(page.getByText("Your answer is still graded against the American IPA")).toBeVisible();
+    await attachScreenshot(page, "m9-uk-comparison-note");
   });
 });


### PR DESCRIPTION
## Summary

Implements #201 for M9 UK comparison as display-only support data behind `show_accent_compare`.

- Adds optional `accent_compare` data to practice responses only when the setting is enabled and the runtime word has US/UK IPA, US/UK phoneme tags, and enabled content status.
- Keeps `display_ipa`, answer choices, correct answer, audio, attempts, `primary_accent`, and progress/stat behavior on the existing US-first path.
- Adds a learner Settings toggle for accent comparison without exposing UK as a selectable primary accent.
- Renders a compact post-answer comparison note using `American sound` / `British note` and explicit display-only grading copy.

## Verification

- `UV_CACHE_DIR=.uv-cache uv run --project backend pytest backend/tests/test_today_persistence.py backend/tests/test_settings_api.py backend/tests/test_attempts.py backend/tests/test_progress_api.py` — 83 passed
- `UV_CACHE_DIR=.uv-cache uv run --project backend pytest` — 199 passed
- `UV_CACHE_DIR=.uv-cache uv run --project backend ruff check backend/app/services/sessions.py backend/tests/test_today_persistence.py backend/tests/test_attempts.py backend/tests/test_settings_api.py` — passed
- `npm --prefix frontend run build` — passed
- `npm --prefix frontend run lint` — passed
- `npm --prefix frontend run test:e2e:m10` — 8 passed, desktop/mobile
- `git diff --check` — passed
- `tools/agents/agent-audit` — clean except #201 intentionally unrouted before completion handoff

## UI evidence

Playwright screenshot artifacts:

- `frontend/test-results/m10-walkthrough/m10-ux-walkthrough-M10-UX--820f6-ings-gated-and-display-only-m10-desktop-chromium/m9-uk-comparison-note.png`
- `frontend/test-results/m10-walkthrough/m10-ux-walkthrough-M10-UX--820f6-ings-gated-and-display-only-m10-mobile-chromium/m9-uk-comparison-note.png`

## Residual risks

- Runtime `words` rows do not currently persist `review_status_uk`; no schema migration was allowed by #201. Eligibility therefore uses the accepted #196 runtime gate fields available in the DB: enabled content, US/UK IPA, and US/UK phoneme tags. Content-quality acceptance remains Architect-owned as noted in #196.
- Learner-facing comparison copy/UX remains Architect acceptance-gated by the #201 Execution Contract.

Closes #201 only after reviewer/Architect acceptance and merge per Epic workflow.