### PR TITLE
[#203] Add minimal-pair specialty practice group

### DIFF
--- a/backend/app/routes/practice.py
+++ b/backend/app/routes/practice.py
@@ -8,6 +8,7 @@ from app.services.sessions import (
     build_clear_focus_response,
     build_current_group_review_response,
     build_focused_group_response,
+    build_minimal_pair_group_response,
     build_next_normal_group_response,
     build_recent_mistake_review_response,
     build_today_response,
@@ -46,6 +47,13 @@ def recent_mistake_review():
     """Create or resume a review group from recent wrong answers."""
     with get_db() as conn:
         return build_recent_mistake_review_response(conn)
+
+
+@router.post("/practice/minimal-pairs")
+def minimal_pair_group():
+    """Create or resume a confusing-sound comparison specialty group."""
+    with get_db() as conn:
+        return build_minimal_pair_group_response(conn)
 
 
 @router.post("/review/current-group")

--- a/backend/app/services/sessions.py
+++ b/backend/app/services/sessions.py
@@ -33,6 +33,11 @@ _LEARNER_LEVEL_LABELS = {
     "mid": "Mid",
 }
 
+_MINIMAL_PAIR_EMPTY_DETAIL = (
+    "Sound Compare practice is not available yet. It needs at least two safe "
+    "words with pair metadata."
+)
+
 
 def _today_date_str() -> str:
     return date.today().isoformat()
@@ -570,6 +575,100 @@ def build_focused_group_response(
     )
 
 
+def build_minimal_pair_group_response(
+    conn,
+    *,
+    user_id: str = "default",
+    accent: str = "US",
+) -> dict:
+    """Create or resume a confusing-sound comparison specialty group."""
+    session_date = _today_date_str()
+    settings = get_settings(conn, user_id)
+    if settings is None:
+        return {
+            "error": "CONTENT_NOT_READY",
+            "detail": "Settings not initialised. Run import_words.py first.",
+        }
+
+    existing = get_active_session_for_date(
+        conn,
+        user_id,
+        session_date,
+        accent,
+        "minimal_pair",
+        source_scope="specialty_minimal_pair",
+        learner_level=settings.learner_level,
+    )
+    if existing is not None:
+        items = get_session_items(conn, existing.id)
+        return _build_response(
+            session=existing,
+            items=items,
+            daily_word_count=settings.daily_word_count,
+            conn=conn,
+            accent=accent,
+            origin="minimal_pair_resume",
+            source_scope="specialty_minimal_pair",
+            selected_learner_level=settings.learner_level,
+            action_label=f"Resume Sound Compare Group {existing.group_index}",
+        )
+
+    words = _select_minimal_pair_words(
+        conn,
+        accent=accent,
+        learner_level=settings.learner_level,
+        limit=settings.daily_word_count,
+    )
+    if len(words) < 2:
+        return {
+            "group_type": "minimal_pair",
+            "learner_level": settings.learner_level,
+            "learner_level_label": learner_level_label(settings.learner_level),
+            "selected_learner_level": settings.learner_level,
+            "selected_learner_level_label": learner_level_label(settings.learner_level),
+            "date": session_date,
+            "primary_accent": accent,
+            "daily_word_count": settings.daily_word_count,
+            "recent_mistake_count": _recent_mistake_count(
+                conn,
+                user_id=user_id,
+                accent=accent,
+                daily_word_count=settings.daily_word_count,
+            ),
+            "word_count": 0,
+            "status": "empty",
+            "origin": "minimal_pair_empty",
+            "source_scope": "specialty_minimal_pair",
+            "source_session_item_ids": [],
+            "items": [],
+            "detail": _MINIMAL_PAIR_EMPTY_DETAIL,
+        }
+
+    group_index = get_next_session_group_index(conn, user_id, session_date, accent)
+    session, items = _create_group_from_words(
+        conn,
+        words=words,
+        user_id=user_id,
+        session_date=session_date,
+        accent=accent,
+        group_index=group_index,
+        group_type="minimal_pair",
+        learner_level=settings.learner_level,
+        source_scope="specialty_minimal_pair",
+    )
+    return _build_response(
+        session=session,
+        items=items,
+        daily_word_count=settings.daily_word_count,
+        conn=conn,
+        accent=accent,
+        origin="minimal_pair_start",
+        source_scope="specialty_minimal_pair",
+        selected_learner_level=settings.learner_level,
+        action_label=f"Start Sound Compare Group {session.group_index}",
+    )
+
+
 def build_clear_focus_response(
     conn,
     *,
@@ -596,6 +695,53 @@ def build_clear_focus_response(
         response["focus_phonemes"] = []
         response["detail"] = "Focus selection cleared."
     return response
+
+
+def _select_minimal_pair_words(
+    conn,
+    *,
+    accent: str,
+    learner_level: str,
+    limit: int,
+) -> list:
+    ipa_field = "ipa_us" if accent == "US" else "ipa_uk"
+    tags_field = "phoneme_tags_us" if accent == "US" else "phoneme_tags_uk"
+    level_values = (
+        ["entry", "beginner"] if learner_level == "entry" else [learner_level]
+    )
+    level_placeholders = ", ".join("?" for _ in level_values)
+    rows = conn.execute(
+        f"""
+        SELECT *
+        FROM words
+        WHERE content_status != 'disabled'
+          AND level IN ({level_placeholders})
+          AND minimal_pair_group IS NOT NULL
+          AND minimal_pair_group != ''
+          AND {ipa_field} IS NOT NULL
+          AND {ipa_field} != ''
+          AND {tags_field} IS NOT NULL
+          AND {tags_field} != ''
+          AND minimal_pair_group IN (
+              SELECT minimal_pair_group
+              FROM words
+              WHERE content_status != 'disabled'
+                AND level IN ({level_placeholders})
+                AND minimal_pair_group IS NOT NULL
+                AND minimal_pair_group != ''
+                AND {ipa_field} IS NOT NULL
+                AND {ipa_field} != ''
+                AND {tags_field} IS NOT NULL
+                AND {tags_field} != ''
+              GROUP BY minimal_pair_group
+              HAVING COUNT(*) >= 2
+          )
+        ORDER BY minimal_pair_group, word
+        LIMIT ?
+        """,
+        (*level_values, *level_values, max(limit, 2)),
+    ).fetchall()
+    return [get_word_by_id(conn, row["id"]) for row in rows if row["id"]]
 
 
 def _create_group_from_words(

--- a/backend/tests/test_today_persistence.py
+++ b/backend/tests/test_today_persistence.py
@@ -305,6 +305,108 @@ class TestTodayPersistence:
         }
         assert "accent_compare" not in cat
 
+    def test_minimal_pair_group_uses_explicit_pair_metadata(self, client, seeded_db):
+        data = client.post("/api/practice/minimal-pairs").json()
+        assert "error" not in data, data
+        assert data["group_type"] == "minimal_pair"
+        assert data["origin"] == "minimal_pair_start"
+        assert data["source_scope"] == "specialty_minimal_pair"
+        assert data["primary_accent"] == "US"
+        assert data["action_label"].startswith("Start Sound Compare Group")
+        assert [item["word_id"] for item in data["items"]] == ["sheep", "ship"]
+        assert [item["display_ipa"] for item in data["items"]] == ["/ʃiːp/", "/ʃɪp/"]
+
+        conn = get_connection(seeded_db)
+        row = conn.execute(
+            "SELECT group_type FROM daily_sessions WHERE id = ?",
+            (data["session_id"],),
+        ).fetchone()
+        item_rows = conn.execute(
+            """
+            SELECT word_id, target_phonemes
+            FROM session_items
+            WHERE session_id = ?
+            ORDER BY order_index
+            """,
+            (data["session_id"],),
+        ).fetchall()
+        conn.close()
+
+        assert row["group_type"] == "minimal_pair"
+        assert [row["word_id"] for row in item_rows] == ["sheep", "ship"]
+        assert json.loads(item_rows[0]["target_phonemes"]) == ["/ʃ/", "/iː/", "/p/"]
+
+    def test_minimal_pair_group_resumes_same_day_active_group(self, client, seeded_db):
+        first = client.post("/api/practice/minimal-pairs").json()
+        second = client.post("/api/practice/minimal-pairs").json()
+        assert second["origin"] == "minimal_pair_resume"
+        assert second["session_id"] == first["session_id"]
+        assert [item["session_item_id"] for item in second["items"]] == [
+            item["session_item_id"] for item in first["items"]
+        ]
+
+    def test_minimal_pair_empty_when_metadata_insufficient(self, client, seeded_db):
+        conn = get_connection(seeded_db)
+        conn.execute("UPDATE words SET minimal_pair_group = NULL")
+        conn.commit()
+        conn.close()
+
+        data = client.post("/api/practice/minimal-pairs").json()
+        assert data["group_type"] == "minimal_pair"
+        assert data["status"] == "empty"
+        assert data["origin"] == "minimal_pair_empty"
+        assert data["items"] == []
+        assert "at least two safe words" in data["detail"]
+
+        conn = get_connection(seeded_db)
+        count = conn.execute(
+            "SELECT COUNT(*) AS cnt FROM daily_sessions WHERE group_type = 'minimal_pair'"
+        ).fetchone()["cnt"]
+        conn.close()
+        assert count == 0
+
+    def test_minimal_pair_attempt_reuses_us_attempt_and_stats_path(
+        self, client, seeded_db
+    ):
+        group = client.post("/api/practice/minimal-pairs").json()
+        item = group["items"][0]
+        resp = client.post("/api/attempt", json={
+            "session_item_id": item["session_item_id"],
+            "selected_answer": item["display_ipa"],
+        })
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["is_correct"] is True
+        assert data["correct_answer"] == item["display_ipa"]
+        assert data["updated_phonemes"]
+
+        conn = get_connection(seeded_db)
+        attempt = conn.execute(
+            """
+            SELECT primary_accent, question_type, correct_answer, is_correct
+            FROM attempts
+            WHERE session_item_id = ?
+            """,
+            (item["session_item_id"],),
+        ).fetchone()
+        stats = conn.execute(
+            """
+            SELECT primary_accent, COUNT(*) AS cnt
+            FROM phoneme_stats
+            GROUP BY primary_accent
+            """
+        ).fetchall()
+        conn.close()
+        assert dict(attempt) == {
+            "primary_accent": "US",
+            "question_type": "choose_ipa",
+            "correct_answer": item["display_ipa"],
+            "is_correct": 1,
+        }
+        assert [(row["primary_accent"], row["cnt"]) for row in stats] == [
+            ("US", len(data["updated_phonemes"]))
+        ]
+
     def test_disabled_words_not_scheduled(self, client, seeded_db):
         # Mark one word as disabled and verify it's excluded.
         conn = get_connection(seeded_db)

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -167,6 +167,16 @@ export async function startRecentMistakeReview(): Promise<TodayResponse> {
   return res.json();
 }
 
+export async function startMinimalPairPractice(): Promise<TodayResponse> {
+  const res = await fetch(`${API_BASE}/practice/minimal-pairs`, {
+    method: "POST",
+  });
+  if (!res.ok) {
+    throw new Error(await normalizeApiError(res));
+  }
+  return res.json();
+}
+
 export async function startFocusedPractice(
   focusPhonemes: string[],
 ): Promise<TodayResponse> {

--- a/frontend/src/pages/TodayPractice.tsx
+++ b/frontend/src/pages/TodayPractice.tsx
@@ -15,6 +15,7 @@ import {
   fetchToday,
   startCurrentGroupReview,
   startFocusedPractice,
+  startMinimalPairPractice,
   startNextNormalGroup,
   startRecentMistakeReview,
 } from "../api";
@@ -44,6 +45,7 @@ function canonicalFocus(phonemes: string[]): string[] {
 }
 
 function groupLabel(session: TodayResponse): string {
+  if (session.group_type === "minimal_pair") return "Sound Compare group";
   if (session.group_type === "weak_focus") return "Focused group";
   if (session.source_scope === "current_group") return "Current-group review";
   if (session.source_scope === "recent_global") return "Recent mistake review";
@@ -61,6 +63,9 @@ function selectedLevelLabel(session: TodayResponse): string {
 }
 
 function groupReason(session: TodayResponse): string {
+  if (session.group_type === "minimal_pair") {
+    return "Compare words with easily confused sounds. This is specialty practice, not mistake review or weak-sound recovery.";
+  }
   if (session.group_type === "weak_focus") {
     const focus = session.focus_phonemes?.join(" ") || "selected sounds";
     return `${learnerLevelLabel(session)} focused practice for ${focus}.`;
@@ -300,6 +305,23 @@ export default function TodayPractice({
     }
   };
 
+  const handleMinimalPairPractice = async () => {
+    setActionLoading("minimal-pair");
+    setError(null);
+    try {
+      const data = await startMinimalPairPractice();
+      if (data.status === "empty" || data.items.length === 0) {
+        setNotice(data.detail ?? "Sound Compare practice is not available yet.");
+      } else {
+        resetPractice(data);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to start Sound Compare practice");
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
   const handleFocusPractice = async (phonemes: string[]) => {
     const nextFocus = canonicalFocus(phonemes);
     if (nextFocus.length === 0) return;
@@ -414,6 +436,24 @@ export default function TodayPractice({
           {completedGroupCount(session) > 0 && (
             <p className="empty-hint">{completedGroupsCopy(session)}</p>
           )}
+
+          <div className="specialty-panel">
+            <div>
+              <span className="focus-panel-label">Specialty practice</span>
+              <strong>Sound Compare</strong>
+              <span>
+                Compare words with easily confused sounds. This is separate from mistake review and weak-sound focus.
+              </span>
+            </div>
+            <button
+              className="secondary-action-btn"
+              onClick={() => void handleMinimalPairPractice()}
+              disabled={actionLoading !== null}
+              type="button"
+            >
+              {actionLoading === "minimal-pair" ? "Loading…" : "Start Sound Compare"}
+            </button>
+          </div>
 
           {notice && <p className="empty-hint">{notice}</p>}
           {error && <p className="save-error">{error}</p>}

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -668,6 +668,7 @@ summary:focus-visible {
 }
 
 .hub-status-card,
+.specialty-panel,
 .level-progress-panel {
   background: var(--panel);
   border: 1px solid var(--line);
@@ -681,6 +682,16 @@ summary:focus-visible {
 .hub-status-card.pending {
   background: var(--warning-bg);
   border-color: #d4c3b4;
+}
+
+.specialty-panel {
+  align-items: center;
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.specialty-panel div {
+  display: grid;
+  gap: 5px;
 }
 
 .pending-copy {

--- a/frontend/tests/e2e/m10-ux-walkthrough.spec.ts
+++ b/frontend/tests/e2e/m10-ux-walkthrough.spec.ts
@@ -1,8 +1,8 @@
 import { expect, type Page, type Route, test } from "@playwright/test";
 
 type LearnerLevel = "entry" | "mid";
-type GroupKey = "none" | "entry" | "mid" | "currentReview" | "recentReview" | "focused";
-type GroupType = "normal" | "mistake_review" | "weak_focus";
+type GroupKey = "none" | "entry" | "mid" | "currentReview" | "recentReview" | "focused" | "minimalPair";
+type GroupType = "normal" | "mistake_review" | "weak_focus" | "minimal_pair";
 
 interface MockItem {
   session_item_id: string;
@@ -126,6 +126,28 @@ const items: Record<Exclude<GroupKey, "none">, MockItem[]> = {
       audio_url: null,
     },
   ],
+  minimalPair: [
+    {
+      session_item_id: "minimal-ship",
+      word_id: "ship",
+      display_ipa: "/ʃɪp/",
+      word: "ship",
+      meaning_zh: "船",
+      target_phonemes: ["/ʃ/", "/ɪ/", "/p/"],
+      choices: ["/ʃɪp/", "/ʃiːp/"],
+      audio_url: null,
+    },
+    {
+      session_item_id: "minimal-sheep",
+      word_id: "sheep",
+      display_ipa: "/ʃiːp/",
+      word: "sheep",
+      meaning_zh: "羊",
+      target_phonemes: ["/ʃ/", "/iː/", "/p/"],
+      choices: ["/ʃɪp/", "/ʃiːp/"],
+      audio_url: null,
+    },
+  ],
 };
 
 function levelLabel(level: LearnerLevel) {
@@ -139,6 +161,7 @@ function groupLevel(group: GroupKey): LearnerLevel {
 function groupType(group: GroupKey): GroupType {
   if (group === "currentReview" || group === "recentReview") return "mistake_review";
   if (group === "focused") return "weak_focus";
+  if (group === "minimalPair") return "minimal_pair";
   return "normal";
 }
 
@@ -174,6 +197,7 @@ function todayResponse(state: MockState) {
   const level = groupLevel(state.activeGroup);
   const review = state.activeGroup === "currentReview" || state.activeGroup === "recentReview";
   const focus = state.activeGroup === "focused";
+  const minimalPair = state.activeGroup === "minimalPair";
   return {
     session_id: `${state.activeGroup}-session`,
     group_id: `${state.activeGroup}-group`,
@@ -183,7 +207,7 @@ function todayResponse(state: MockState) {
     learner_level_label: levelLabel(level),
     selected_learner_level: state.selectedLevel,
     selected_learner_level_label: levelLabel(state.selectedLevel),
-    pending_level_change: !review && !focus && state.selectedLevel !== level,
+    pending_level_change: !review && !focus && !minimalPair && state.selectedLevel !== level,
     completed_normal_groups_today: {
       entry: state.completed.entry,
       mid: state.completed.mid,
@@ -191,7 +215,13 @@ function todayResponse(state: MockState) {
     },
     date: "2026-06-18",
     primary_accent: "US",
-    origin: focus ? "focus_start" : review ? "current_group_review_start" : "normal_start",
+    origin: minimalPair
+      ? "minimal_pair_start"
+      : focus
+        ? "focus_start"
+        : review
+          ? "current_group_review_start"
+          : "normal_start",
     source_scope:
       state.activeGroup === "currentReview"
         ? "current_group"
@@ -199,7 +229,9 @@ function todayResponse(state: MockState) {
           ? "recent_global"
           : focus
             ? "focus_selection"
-            : "normal_current",
+            : minimalPair
+              ? "specialty_minimal_pair"
+              : "normal_current",
     source_group_id: review ? "entry-group" : undefined,
     focus_phonemes: focus ? state.focusPhonemes : [],
     daily_word_count: items[state.activeGroup].length,
@@ -208,6 +240,7 @@ function todayResponse(state: MockState) {
     status: "active",
     source_session_item_ids: review ? ["entry-ship"] : [],
     source_count: review ? 1 : 0,
+    action_label: minimalPair ? "Start Sound Compare Group 1" : undefined,
     items: items[state.activeGroup].map((item) => ({
       session_item_id: item.session_item_id,
       word_id: item.word_id,
@@ -353,6 +386,12 @@ async function routeMock(route: Route, state: MockState) {
 
   if (path === "/practice/next-normal") {
     state.activeGroup = state.selectedLevel;
+    await route.fulfill({ json: todayResponse(state) });
+    return;
+  }
+
+  if (path === "/practice/minimal-pairs") {
+    state.activeGroup = "minimalPair";
     await route.fulfill({ json: todayResponse(state) });
     return;
   }
@@ -539,6 +578,27 @@ test.describe("M10 UX walkthrough evidence", () => {
       await expect(page.getByRole("button", { name: "Clear focus" })).toBeVisible();
       await attachScreenshot(page, "m10-progress-focus-entry");
     });
+  });
+
+  test("Sound Compare specialty practice is distinct from review and focus", async ({ page }) => {
+    await setupM10Api(page);
+
+    await page.goto("/");
+    await expect(page.getByText("Today practice hub")).toBeVisible();
+    await expect(page.getByText("Specialty practice")).toBeVisible();
+    await expect(page.getByText("Sound Compare", { exact: true })).toBeVisible();
+    await expect(page.getByText("Compare words with easily confused sounds. This is separate from mistake review and weak-sound focus.")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Start Sound Compare" })).toBeVisible();
+    await attachScreenshot(page, "m9-minimal-pair-entry");
+
+    await page.getByRole("button", { name: "Start Sound Compare" }).click();
+    await expect(page.getByText("Sound Compare group: 1 / 2")).toBeVisible();
+    await expect(page.getByText("Compare words with easily confused sounds. This is specialty practice, not mistake review or weak-sound recovery.")).toBeVisible();
+    await expect(page.getByText("Current-group review:")).toHaveCount(0);
+    await expect(page.getByText("Recent mistake review:")).toHaveCount(0);
+    await expect(page.getByText("Focused group:")).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "Select /ʃɪp/" })).toBeVisible();
+    await attachScreenshot(page, "m9-minimal-pair-active");
   });
 
   test("Settings level switching, empty review state, audio signal, and mobile views are observable", async ({ page }, testInfo) => {


### PR DESCRIPTION
## Summary

Implements #203 minimal-pair specialty practice as learner-facing Sound Compare practice.

- Adds `POST /api/practice/minimal-pairs` to create/resume `daily_sessions.group_type = "minimal_pair"` groups.
- Selects deterministic, bounded rows only when explicit `minimal_pair_group` metadata has at least two safe same-level words for the active accent.
- Reuses existing `session_items`, `POST /api/attempt`, attempts, and `phoneme_stats` paths with US-first M9 behavior.
- Adds Today hub Sound Compare entry copy and active-group copy distinct from current/recent mistake review and weak-focus recovery.
- Returns learner-safe empty state without creating an unanswerable group when pair metadata is insufficient.

## Boundaries preserved

- No schema migration.
- No new scoring/stat tables.
- No frontend-only grading.
- No UK primary-accent learner path or UK answer acceptance.
- No target-phoneme specialty work.
- Runtime selection uses explicit bounded pair metadata and does not claim #196 mechanical candidates are final content-approved metadata.

## Verification

- `UV_CACHE_DIR=.uv-cache uv run --project backend pytest backend/tests/test_today_persistence.py backend/tests/test_attempts.py -q` → 63 passed
- `UV_CACHE_DIR=.uv-cache uv run --project backend pytest backend/tests -q` → 203 passed
- `pnpm test:e2e:m10` → 10 passed, desktop/mobile
- `pnpm test:e2e:m7` → 7 passed, mobile
- `pnpm build` → passed
- `git diff --check` → passed
- `tools/agents/agent-audit` → no contract handoff route issues; #203 shown as unrouted while implementation was in progress

## Browser evidence

M10 Playwright attached screenshots include:

- `m9-minimal-pair-entry` for the learner-facing Sound Compare entry point
- `m9-minimal-pair-active` for an active Sound Compare group view

## Residual risks

- Candidate quality remains limited to existing explicit `minimal_pair_group` metadata and still needs Reviewer/Architect acceptance for learner-facing content quality.
- Empty state is safe, but production availability depends on enough accepted runtime rows carrying pair metadata.
