### PR TITLE
[#205] Add target-phoneme specialty practice

### DIFF
--- a/backend/app/routes/practice.py
+++ b/backend/app/routes/practice.py
@@ -11,6 +11,7 @@ from app.services.sessions import (
     build_minimal_pair_group_response,
     build_next_normal_group_response,
     build_recent_mistake_review_response,
+    build_target_phoneme_group_response,
     build_today_response,
 )
 
@@ -54,6 +55,23 @@ def minimal_pair_group():
     """Create or resume a confusing-sound comparison specialty group."""
     with get_db() as conn:
         return build_minimal_pair_group_response(conn)
+
+
+@router.post("/practice/target-phoneme")
+async def target_phoneme_group(request: Request):
+    """Create or resume an intentional chosen-sound specialty group."""
+    body = await request.json()
+    phoneme = body.get("phoneme")
+    if not isinstance(phoneme, str) or not phoneme.strip():
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": "INVALID_TARGET_PHONEME",
+                "detail": "phoneme must be one approved sound string.",
+            },
+        )
+    with get_db() as conn:
+        return build_target_phoneme_group_response(conn, phoneme=phoneme.strip())
 
 
 @router.post("/review/current-group")

--- a/backend/app/services/sessions.py
+++ b/backend/app/services/sessions.py
@@ -37,6 +37,10 @@ _MINIMAL_PAIR_EMPTY_DETAIL = (
     "Sound Compare practice is not available yet. It needs at least two safe "
     "words with pair metadata."
 )
+_TARGET_PHONEME_EMPTY_DETAIL = (
+    "Sound Practice is not available for this sound yet. It needs safe words "
+    "tagged with the selected American sound."
+)
 
 
 def _today_date_str() -> str:
@@ -669,6 +673,118 @@ def build_minimal_pair_group_response(
     )
 
 
+def build_target_phoneme_group_response(
+    conn,
+    *,
+    phoneme: str,
+    user_id: str = "default",
+    accent: str = "US",
+) -> dict:
+    """Create or resume learner-directed specialty practice for one sound."""
+    session_date = _today_date_str()
+    settings = get_settings(conn, user_id)
+    if settings is None:
+        return {
+            "error": "CONTENT_NOT_READY",
+            "detail": "Settings not initialised. Run import_words.py first.",
+        }
+
+    options = _target_phoneme_options(
+        conn,
+        accent=accent,
+        learner_level=settings.learner_level,
+    )
+    approved = {option["phoneme"] for option in options}
+    if phoneme not in approved:
+        return _target_phoneme_empty_response(
+            conn,
+            user_id=user_id,
+            session_date=session_date,
+            accent=accent,
+            settings=settings,
+            phoneme=phoneme,
+            options=options,
+            origin="target_phoneme_empty",
+            detail=_TARGET_PHONEME_EMPTY_DETAIL,
+        )
+
+    existing = get_active_session_for_date(
+        conn,
+        user_id,
+        session_date,
+        accent,
+        "target_phoneme",
+        source_scope="specialty_target_phoneme",
+        focus_phonemes=[phoneme],
+        learner_level=settings.learner_level,
+    )
+    if existing is not None:
+        items = get_session_items(conn, existing.id)
+        return _build_response(
+            session=existing,
+            items=items,
+            daily_word_count=settings.daily_word_count,
+            conn=conn,
+            accent=accent,
+            origin="target_phoneme_resume",
+            source_scope="specialty_target_phoneme",
+            focus_phonemes=[phoneme],
+            selected_learner_level=settings.learner_level,
+            action_label=f"Resume Sound Practice Group {existing.group_index}",
+        )
+
+    group_index = get_next_session_group_index(conn, user_id, session_date, accent)
+    words = _select_target_phoneme_words(
+        conn,
+        accent=accent,
+        learner_level=settings.learner_level,
+        phoneme=phoneme,
+        limit=settings.daily_word_count,
+        seed=_seed_from_group(
+            session_date,
+            group_index,
+            f"target_phoneme:{phoneme}",
+        ),
+    )
+    if not words:
+        return _target_phoneme_empty_response(
+            conn,
+            user_id=user_id,
+            session_date=session_date,
+            accent=accent,
+            settings=settings,
+            phoneme=phoneme,
+            options=options,
+            origin="target_phoneme_empty",
+            detail=_TARGET_PHONEME_EMPTY_DETAIL,
+        )
+
+    session, items = _create_group_from_words(
+        conn,
+        words=words,
+        user_id=user_id,
+        session_date=session_date,
+        accent=accent,
+        group_index=group_index,
+        group_type="target_phoneme",
+        learner_level=settings.learner_level,
+        source_scope="specialty_target_phoneme",
+        focus_phonemes=[phoneme],
+    )
+    return _build_response(
+        session=session,
+        items=items,
+        daily_word_count=settings.daily_word_count,
+        conn=conn,
+        accent=accent,
+        origin="target_phoneme_start",
+        source_scope="specialty_target_phoneme",
+        focus_phonemes=[phoneme],
+        selected_learner_level=settings.learner_level,
+        action_label=f"Start Sound Practice Group {session.group_index}",
+    )
+
+
 def build_clear_focus_response(
     conn,
     *,
@@ -742,6 +858,144 @@ def _select_minimal_pair_words(
         (*level_values, *level_values, max(limit, 2)),
     ).fetchall()
     return [get_word_by_id(conn, row["id"]) for row in rows if row["id"]]
+
+
+def _level_values(learner_level: str) -> list[str]:
+    return ["entry", "beginner"] if learner_level == "entry" else [learner_level]
+
+
+def _target_phoneme_options(
+    conn,
+    *,
+    accent: str,
+    learner_level: str,
+) -> list[dict]:
+    if accent != "US":
+        return []
+    level_values = _level_values(learner_level)
+    rows = conn.execute(
+        """
+        SELECT id, symbol, example_word
+        FROM phonemes
+        WHERE accent_scope IN ('US', 'both')
+        ORDER BY priority, symbol
+        """,
+    ).fetchall()
+    options = []
+    for row in rows:
+        phoneme = row["id"]
+        count = _target_phoneme_candidate_count(
+            conn,
+            phoneme=phoneme,
+            level_values=level_values,
+        )
+        if count > 0:
+            options.append(
+                {
+                    "phoneme": phoneme,
+                    "symbol": row["symbol"],
+                    "example_word": row["example_word"],
+                    "candidate_count": count,
+                }
+            )
+    return options[:8]
+
+
+def _target_phoneme_candidate_count(
+    conn,
+    *,
+    phoneme: str,
+    level_values: list[str],
+) -> int:
+    level_placeholders = ", ".join("?" for _ in level_values)
+    row = conn.execute(
+        f"""
+        SELECT COUNT(*) AS cnt
+        FROM words
+        WHERE content_status != 'disabled'
+          AND level IN ({level_placeholders})
+          AND ipa_us IS NOT NULL
+          AND ipa_us != ''
+          AND phoneme_tags_us IS NOT NULL
+          AND phoneme_tags_us != ''
+          AND phoneme_tags_us LIKE ?
+        """,
+        (*level_values, f'%"{phoneme}"%'),
+    ).fetchone()
+    return int(row["cnt"]) if row else 0
+
+
+def _select_target_phoneme_words(
+    conn,
+    *,
+    accent: str,
+    learner_level: str,
+    phoneme: str,
+    limit: int,
+    seed: int,
+) -> list:
+    if accent != "US":
+        return []
+    level_values = _level_values(learner_level)
+    level_placeholders = ", ".join("?" for _ in level_values)
+    rows = conn.execute(
+        f"""
+        SELECT id
+        FROM words
+        WHERE content_status != 'disabled'
+          AND level IN ({level_placeholders})
+          AND ipa_us IS NOT NULL
+          AND ipa_us != ''
+          AND phoneme_tags_us IS NOT NULL
+          AND phoneme_tags_us != ''
+          AND phoneme_tags_us LIKE ?
+        ORDER BY word
+        """,
+        (*level_values, f'%"{phoneme}"%'),
+    ).fetchall()
+    candidates = [get_word_by_id(conn, row["id"]) for row in rows if row["id"]]
+    candidates = [word for word in candidates if word is not None]
+    candidates.sort(key=lambda word: (_stable_hash(f"{seed}:{word.id}"), word.word))
+    return candidates[: max(limit, 1)]
+
+
+def _target_phoneme_empty_response(
+    conn,
+    *,
+    user_id: str,
+    session_date: str,
+    accent: str,
+    settings,
+    phoneme: str,
+    options: list[dict],
+    origin: str,
+    detail: str,
+) -> dict:
+    return {
+        "group_type": "target_phoneme",
+        "learner_level": settings.learner_level,
+        "learner_level_label": learner_level_label(settings.learner_level),
+        "selected_learner_level": settings.learner_level,
+        "selected_learner_level_label": learner_level_label(settings.learner_level),
+        "date": session_date,
+        "primary_accent": accent,
+        "daily_word_count": settings.daily_word_count,
+        "recent_mistake_count": _recent_mistake_count(
+            conn,
+            user_id=user_id,
+            accent=accent,
+            daily_word_count=settings.daily_word_count,
+        ),
+        "word_count": 0,
+        "status": "empty",
+        "origin": origin,
+        "source_scope": "specialty_target_phoneme",
+        "source_session_item_ids": [],
+        "focus_phonemes": [phoneme] if phoneme else [],
+        "target_phoneme_options": options,
+        "items": [],
+        "detail": detail,
+    }
 
 
 def _create_group_from_words(
@@ -885,6 +1139,11 @@ def _normal_empty_response(
         "source_scope": "normal_none",
         "source_session_item_ids": [],
         "focus_phonemes": focus_phonemes or [],
+        "target_phoneme_options": _target_phoneme_options(
+            conn,
+            accent=accent,
+            learner_level=selected_level,
+        ),
         "action_label": f"Start {learner_level_label(selected_level)} group",
         "items": [],
     }
@@ -1026,4 +1285,9 @@ def _build_response(
         response["focus_phonemes"] = response_focus_phonemes
     if action_label is not None:
         response["action_label"] = action_label
+    response["target_phoneme_options"] = _target_phoneme_options(
+        conn,
+        accent=session.primary_accent,
+        learner_level=selected_learner_level or session.learner_level,
+    )
     return response

--- a/backend/tests/test_today_persistence.py
+++ b/backend/tests/test_today_persistence.py
@@ -407,6 +407,140 @@ class TestTodayPersistence:
             ("US", len(data["updated_phonemes"]))
         ]
 
+    def test_today_exposes_guided_target_phoneme_options(self, client, seeded_db):
+        data = client.get("/api/today").json()
+
+        options = data["target_phoneme_options"]
+        option_ids = {option["phoneme"] for option in options}
+        assert "/ʃ/" in option_ids
+        assert "/æ/" in option_ids
+        assert all(option["candidate_count"] > 0 for option in options)
+
+    def test_target_phoneme_group_uses_selected_approved_us_sound(
+        self, client, seeded_db
+    ):
+        data = client.post("/api/practice/target-phoneme", json={
+            "phoneme": "/ʃ/",
+        }).json()
+
+        assert "error" not in data, data
+        assert data["group_type"] == "target_phoneme"
+        assert data["origin"] == "target_phoneme_start"
+        assert data["source_scope"] == "specialty_target_phoneme"
+        assert data["focus_phonemes"] == ["/ʃ/"]
+        assert data["primary_accent"] == "US"
+        assert data["action_label"].startswith("Start Sound Practice Group")
+        assert data["items"]
+        assert all("/ʃ/" in item["target_phonemes"] for item in data["items"])
+
+        conn = get_connection(seeded_db)
+        row = conn.execute(
+            """
+            SELECT group_type, source_scope, focus_phonemes
+            FROM daily_sessions
+            WHERE id = ?
+            """,
+            (data["session_id"],),
+        ).fetchone()
+        item_rows = conn.execute(
+            """
+            SELECT target_phonemes
+            FROM session_items
+            WHERE session_id = ?
+            ORDER BY order_index
+            """,
+            (data["session_id"],),
+        ).fetchall()
+        conn.close()
+
+        assert row["group_type"] == "target_phoneme"
+        assert row["source_scope"] == "specialty_target_phoneme"
+        assert json.loads(row["focus_phonemes"]) == ["/ʃ/"]
+        assert all("/ʃ/" in json.loads(item["target_phonemes"]) for item in item_rows)
+
+    def test_target_phoneme_group_resumes_same_selected_sound(self, client, seeded_db):
+        first = client.post("/api/practice/target-phoneme", json={
+            "phoneme": "/ʃ/",
+        }).json()
+        second = client.post("/api/practice/target-phoneme", json={
+            "phoneme": "/ʃ/",
+        }).json()
+
+        assert second["origin"] == "target_phoneme_resume"
+        assert second["session_id"] == first["session_id"]
+        assert second["focus_phonemes"] == ["/ʃ/"]
+
+    def test_target_phoneme_empty_for_unapproved_or_empty_sound(
+        self, client, seeded_db
+    ):
+        data = client.post("/api/practice/target-phoneme", json={
+            "phoneme": "/not-approved/",
+        }).json()
+
+        assert data["group_type"] == "target_phoneme"
+        assert data["status"] == "empty"
+        assert data["origin"] == "target_phoneme_empty"
+        assert data["items"] == []
+        assert "selected American sound" in data["detail"]
+
+        conn = get_connection(seeded_db)
+        count = conn.execute(
+            "SELECT COUNT(*) AS cnt FROM daily_sessions WHERE group_type = 'target_phoneme'"
+        ).fetchone()["cnt"]
+        conn.close()
+        assert count == 0
+
+    def test_target_phoneme_rejects_missing_payload(self, client):
+        resp = client.post("/api/practice/target-phoneme", json={
+            "phoneme": "",
+        })
+        assert resp.status_code == 400
+        assert resp.json()["detail"]["error"] == "INVALID_TARGET_PHONEME"
+
+    def test_target_phoneme_attempt_reuses_us_attempt_and_stats_path(
+        self, client, seeded_db
+    ):
+        group = client.post("/api/practice/target-phoneme", json={
+            "phoneme": "/ʃ/",
+        }).json()
+        item = group["items"][0]
+        resp = client.post("/api/attempt", json={
+            "session_item_id": item["session_item_id"],
+            "selected_answer": item["display_ipa"],
+        })
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["is_correct"] is True
+        assert data["correct_answer"] == item["display_ipa"]
+        assert data["updated_phonemes"]
+
+        conn = get_connection(seeded_db)
+        attempt = conn.execute(
+            """
+            SELECT primary_accent, question_type, correct_answer, is_correct
+            FROM attempts
+            WHERE session_item_id = ?
+            """,
+            (item["session_item_id"],),
+        ).fetchone()
+        stats = conn.execute(
+            """
+            SELECT primary_accent, COUNT(*) AS cnt
+            FROM phoneme_stats
+            GROUP BY primary_accent
+            """
+        ).fetchall()
+        conn.close()
+        assert dict(attempt) == {
+            "primary_accent": "US",
+            "question_type": "choose_ipa",
+            "correct_answer": item["display_ipa"],
+            "is_correct": 1,
+        }
+        assert [(row["primary_accent"], row["cnt"]) for row in stats] == [
+            ("US", len(data["updated_phonemes"]))
+        ]
+
     def test_disabled_words_not_scheduled(self, client, seeded_db):
         # Mark one word as disabled and verify it's excluded.
         conn = get_connection(seeded_db)

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -109,6 +109,12 @@ export interface TodayResponse {
   word_count?: number;
   status: string;
   source_session_item_ids?: string[];
+  target_phoneme_options?: {
+    phoneme: string;
+    symbol: string;
+    example_word: string | null;
+    candidate_count: number;
+  }[];
   items: TodayItem[];
   source_count?: number;
   error?: string;
@@ -170,6 +176,20 @@ export async function startRecentMistakeReview(): Promise<TodayResponse> {
 export async function startMinimalPairPractice(): Promise<TodayResponse> {
   const res = await fetch(`${API_BASE}/practice/minimal-pairs`, {
     method: "POST",
+  });
+  if (!res.ok) {
+    throw new Error(await normalizeApiError(res));
+  }
+  return res.json();
+}
+
+export async function startTargetPhonemePractice(
+  phoneme: string,
+): Promise<TodayResponse> {
+  const res = await fetch(`${API_BASE}/practice/target-phoneme`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ phoneme }),
   });
   if (!res.ok) {
     throw new Error(await normalizeApiError(res));

--- a/frontend/src/pages/TodayPractice.tsx
+++ b/frontend/src/pages/TodayPractice.tsx
@@ -18,6 +18,7 @@ import {
   startMinimalPairPractice,
   startNextNormalGroup,
   startRecentMistakeReview,
+  startTargetPhonemePractice,
 } from "../api";
 import type { ChoiceResult } from "../components/ChoiceQuestion";
 import { ChoiceQuestion } from "../components/ChoiceQuestion";
@@ -46,6 +47,7 @@ function canonicalFocus(phonemes: string[]): string[] {
 
 function groupLabel(session: TodayResponse): string {
   if (session.group_type === "minimal_pair") return "Sound Compare group";
+  if (session.group_type === "target_phoneme") return "Sound Practice group";
   if (session.group_type === "weak_focus") return "Focused group";
   if (session.source_scope === "current_group") return "Current-group review";
   if (session.source_scope === "recent_global") return "Recent mistake review";
@@ -65,6 +67,10 @@ function selectedLevelLabel(session: TodayResponse): string {
 function groupReason(session: TodayResponse): string {
   if (session.group_type === "minimal_pair") {
     return "Compare words with easily confused sounds. This is specialty practice, not mistake review or weak-sound recovery.";
+  }
+  if (session.group_type === "target_phoneme") {
+    const target = session.focus_phonemes?.[0] ?? "your chosen sound";
+    return `Intentional practice for ${target}. This is a chosen-sound specialty group, not weak-sound recovery.`;
   }
   if (session.group_type === "weak_focus") {
     const focus = session.focus_phonemes?.join(" ") || "selected sounds";
@@ -322,6 +328,23 @@ export default function TodayPractice({
     }
   };
 
+  const handleTargetPhonemePractice = async (phoneme: string) => {
+    setActionLoading(`target-${phoneme}`);
+    setError(null);
+    try {
+      const data = await startTargetPhonemePractice(phoneme);
+      if (data.status === "empty" || data.items.length === 0) {
+        setNotice(data.detail ?? "Sound Practice is not available for that sound yet.");
+      } else {
+        resetPractice(data);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to start Sound Practice");
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
   const handleFocusPractice = async (phonemes: string[]) => {
     const nextFocus = canonicalFocus(phonemes);
     if (nextFocus.length === 0) return;
@@ -453,6 +476,36 @@ export default function TodayPractice({
             >
               {actionLoading === "minimal-pair" ? "Loading…" : "Start Sound Compare"}
             </button>
+          </div>
+
+          <div className="specialty-panel target-phoneme-panel">
+            <div>
+              <span className="focus-panel-label">Specialty practice</span>
+              <strong>Sound Practice</strong>
+              <span>
+                Pick one approved American sound for intentional practice. This is separate from weak-sound recovery.
+              </span>
+            </div>
+            <div className="phoneme-chip-list">
+              {(session.target_phoneme_options ?? []).slice(0, 6).map((option) => (
+                <button
+                  className="phoneme-chip selectable"
+                  key={option.phoneme}
+                  onClick={() => void handleTargetPhonemePractice(option.phoneme)}
+                  disabled={actionLoading !== null}
+                  type="button"
+                >
+                  {actionLoading === `target-${option.phoneme}`
+                    ? "Loading..."
+                    : `Practice ${option.phoneme}`}
+                </button>
+              ))}
+              {(session.target_phoneme_options ?? []).length === 0 && (
+                <span className="empty-hint">
+                  Sound Practice will appear when approved sounds have enough words.
+                </span>
+              )}
+            </div>
           </div>
 
           {notice && <p className="empty-hint">{notice}</p>}
@@ -634,7 +687,9 @@ export default function TodayPractice({
       </div>
       {(session.focus_phonemes?.length || focusPhonemes.length > 0) && (
         <div className="active-focus-banner">
-          <span>Current focus</span>
+          <span>
+            {session.group_type === "target_phoneme" ? "Chosen sound" : "Current focus"}
+          </span>
           {(session.focus_phonemes ?? focusPhonemes).map((phoneme) => (
             <span className="phoneme-chip" key={phoneme}>{phoneme}</span>
           ))}

--- a/frontend/tests/e2e/m10-ux-walkthrough.spec.ts
+++ b/frontend/tests/e2e/m10-ux-walkthrough.spec.ts
@@ -1,8 +1,8 @@
 import { expect, type Page, type Route, test } from "@playwright/test";
 
 type LearnerLevel = "entry" | "mid";
-type GroupKey = "none" | "entry" | "mid" | "currentReview" | "recentReview" | "focused" | "minimalPair";
-type GroupType = "normal" | "mistake_review" | "weak_focus" | "minimal_pair";
+type GroupKey = "none" | "entry" | "mid" | "currentReview" | "recentReview" | "focused" | "minimalPair" | "targetPhoneme";
+type GroupType = "normal" | "mistake_review" | "weak_focus" | "minimal_pair" | "target_phoneme";
 
 interface MockItem {
   session_item_id: string;
@@ -148,6 +148,18 @@ const items: Record<Exclude<GroupKey, "none">, MockItem[]> = {
       audio_url: null,
     },
   ],
+  targetPhoneme: [
+    {
+      session_item_id: "target-ship",
+      word_id: "ship",
+      display_ipa: "/ʃɪp/",
+      word: "ship",
+      meaning_zh: "船",
+      target_phonemes: ["/ʃ/", "/ɪ/", "/p/"],
+      choices: ["/sɪp/", "/ʃɪp/"],
+      audio_url: null,
+    },
+  ],
 };
 
 function levelLabel(level: LearnerLevel) {
@@ -162,6 +174,7 @@ function groupType(group: GroupKey): GroupType {
   if (group === "currentReview" || group === "recentReview") return "mistake_review";
   if (group === "focused") return "weak_focus";
   if (group === "minimalPair") return "minimal_pair";
+  if (group === "targetPhoneme") return "target_phoneme";
   return "normal";
 }
 
@@ -190,6 +203,20 @@ function todayResponse(state: MockState) {
       word_count: 0,
       status: "idle",
       source_session_item_ids: [],
+      target_phoneme_options: [
+        {
+          phoneme: "/ʃ/",
+          symbol: "ʃ",
+          example_word: "ship",
+          candidate_count: 2,
+        },
+        {
+          phoneme: "/θ/",
+          symbol: "θ",
+          example_word: "thin",
+          candidate_count: 1,
+        },
+      ],
       items: [],
     };
   }
@@ -198,6 +225,7 @@ function todayResponse(state: MockState) {
   const review = state.activeGroup === "currentReview" || state.activeGroup === "recentReview";
   const focus = state.activeGroup === "focused";
   const minimalPair = state.activeGroup === "minimalPair";
+  const targetPhoneme = state.activeGroup === "targetPhoneme";
   return {
     session_id: `${state.activeGroup}-session`,
     group_id: `${state.activeGroup}-group`,
@@ -207,7 +235,7 @@ function todayResponse(state: MockState) {
     learner_level_label: levelLabel(level),
     selected_learner_level: state.selectedLevel,
     selected_learner_level_label: levelLabel(state.selectedLevel),
-    pending_level_change: !review && !focus && !minimalPair && state.selectedLevel !== level,
+    pending_level_change: !review && !focus && !minimalPair && !targetPhoneme && state.selectedLevel !== level,
     completed_normal_groups_today: {
       entry: state.completed.entry,
       mid: state.completed.mid,
@@ -215,7 +243,9 @@ function todayResponse(state: MockState) {
     },
     date: "2026-06-18",
     primary_accent: "US",
-    origin: minimalPair
+    origin: targetPhoneme
+      ? "target_phoneme_start"
+      : minimalPair
       ? "minimal_pair_start"
       : focus
         ? "focus_start"
@@ -231,16 +261,36 @@ function todayResponse(state: MockState) {
             ? "focus_selection"
             : minimalPair
               ? "specialty_minimal_pair"
+              : targetPhoneme
+                ? "specialty_target_phoneme"
               : "normal_current",
     source_group_id: review ? "entry-group" : undefined,
-    focus_phonemes: focus ? state.focusPhonemes : [],
+    focus_phonemes: focus || targetPhoneme ? state.focusPhonemes : [],
     daily_word_count: items[state.activeGroup].length,
     recent_mistake_count: state.recentMistakeCount,
     word_count: items[state.activeGroup].length,
     status: "active",
     source_session_item_ids: review ? ["entry-ship"] : [],
     source_count: review ? 1 : 0,
-    action_label: minimalPair ? "Start Sound Compare Group 1" : undefined,
+    action_label: targetPhoneme
+      ? "Start Sound Practice Group 1"
+      : minimalPair
+        ? "Start Sound Compare Group 1"
+        : undefined,
+    target_phoneme_options: [
+      {
+        phoneme: "/ʃ/",
+        symbol: "ʃ",
+        example_word: "ship",
+        candidate_count: 2,
+      },
+      {
+        phoneme: "/θ/",
+        symbol: "θ",
+        example_word: "thin",
+        candidate_count: 1,
+      },
+    ],
     items: items[state.activeGroup].map((item) => ({
       session_item_id: item.session_item_id,
       word_id: item.word_id,
@@ -396,6 +446,14 @@ async function routeMock(route: Route, state: MockState) {
     return;
   }
 
+  if (path === "/practice/target-phoneme") {
+    const body = request.postDataJSON() as { phoneme?: string };
+    state.focusPhonemes = body.phoneme ? [body.phoneme] : ["/ʃ/"];
+    state.activeGroup = "targetPhoneme";
+    await route.fulfill({ json: todayResponse(state) });
+    return;
+  }
+
   if (path === "/practice/abandon-current-and-next") {
     state.activeGroup = state.selectedLevel;
     await route.fulfill({
@@ -501,6 +559,7 @@ async function attachScreenshot(page: Page, name: string) {
 
 test.describe("M10 UX walkthrough evidence", () => {
   test("Today practice, wrong-answer recovery, reviews, and Progress focus are observable", async ({ page }) => {
+    test.setTimeout(60_000);
     await setupM10Api(page);
 
     await test.step("Today start orientation", async () => {
@@ -541,7 +600,7 @@ test.describe("M10 UX walkthrough evidence", () => {
     await test.step("Completion summary exposes current-group recovery and next choices", async () => {
       await answer(page, "/θɪn/");
       await expect(page.getByRole("heading", { name: "Practice group complete" })).toBeVisible({
-        timeout: 4_000,
+        timeout: 10_000,
       });
       await expect(page.getByText("1 / 2 correct")).toBeVisible();
       await expect(page.getByRole("heading", { name: "This group's misses" })).toBeVisible();
@@ -585,7 +644,7 @@ test.describe("M10 UX walkthrough evidence", () => {
 
     await page.goto("/");
     await expect(page.getByText("Today practice hub")).toBeVisible();
-    await expect(page.getByText("Specialty practice")).toBeVisible();
+    await expect(page.getByText("Specialty practice").first()).toBeVisible();
     await expect(page.getByText("Sound Compare", { exact: true })).toBeVisible();
     await expect(page.getByText("Compare words with easily confused sounds. This is separate from mistake review and weak-sound focus.")).toBeVisible();
     await expect(page.getByRole("button", { name: "Start Sound Compare" })).toBeVisible();
@@ -599,6 +658,28 @@ test.describe("M10 UX walkthrough evidence", () => {
     await expect(page.getByText("Focused group:")).toHaveCount(0);
     await expect(page.getByRole("button", { name: "Select /ʃɪp/" })).toBeVisible();
     await attachScreenshot(page, "m9-minimal-pair-active");
+  });
+
+  test("Sound Practice uses guided chosen-sound entry distinct from weak focus", async ({ page }) => {
+    await setupM10Api(page);
+
+    await page.goto("/");
+    await expect(page.getByText("Today practice hub")).toBeVisible();
+    await expect(page.getByText("Sound Practice", { exact: true })).toBeVisible();
+    await expect(page.getByText("Pick one approved American sound for intentional practice. This is separate from weak-sound recovery.")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Practice /ʃ/" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Practice /θ/" })).toBeVisible();
+    await attachScreenshot(page, "m9-target-phoneme-entry");
+
+    await page.getByRole("button", { name: "Practice /ʃ/" }).click();
+    await expect(page.getByText("Sound Practice group: 1 / 1")).toBeVisible();
+    await expect(page.getByText("Intentional practice for /ʃ/. This is a chosen-sound specialty group, not weak-sound recovery.")).toBeVisible();
+    await expect(page.getByText("Chosen sound")).toBeVisible();
+    await expect(page.getByText("Current focus")).toHaveCount(0);
+    await expect(page.getByText("Focused group:")).toHaveCount(0);
+    await expect(page.getByText("Current-group review:")).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "Select /ʃɪp/" })).toBeVisible();
+    await attachScreenshot(page, "m9-target-phoneme-active");
   });
 
   test("Settings level switching, empty review state, audio signal, and mobile views are observable", async ({ page }, testInfo) => {


### PR DESCRIPTION
## Summary

Implements #205 target-phoneme specialty practice as learner-facing Sound Practice.

- Adds `POST /api/practice/target-phoneme` for creating/resuming `daily_sessions.group_type = "target_phoneme"` groups.
- Exposes backend-approved US sound options from active phoneme tags and content candidate counts, so learners pick guided buttons instead of typing raw IPA.
- Persists the chosen sound in existing `daily_sessions.focus_phonemes`, creates ordinary `session_items`, and reuses `POST /api/attempt`, attempts, and US-first `phoneme_stats`.
- Adds safe empty behavior for unapproved/insufficient sounds without creating an unanswerable group.
- Adds Today hub Sound Practice copy and active-group copy distinct from mistake review and remedial `weak_focus`.

## Boundaries preserved

- No schema migration.
- No new scoring/stat tables.
- No frontend-only grading.
- No UK primary-accent learner path or UK answer acceptance.
- No minimal-pair behavior changes beyond e2e fixture compatibility.
- Existing review and weak-focus flows remain separate.

## Verification

- `UV_CACHE_DIR=.uv-cache uv run --project backend pytest backend/tests/test_today_persistence.py backend/tests/test_attempts.py -q` -> 69 passed
- `UV_CACHE_DIR=.uv-cache uv run --project backend pytest backend/tests -q` -> 209 passed
- `pnpm test:e2e:m10` -> 12 passed, desktop/mobile
- `pnpm test:e2e:m7` -> 7 passed, mobile
- `pnpm build` -> passed
- `git diff --check` -> passed
- `tools/agents/agent-audit` -> no contract handoff route issues; #205 shown as unrouted before handoff

## Browser evidence

M10 Playwright screenshots include:

- `m9-target-phoneme-entry` for the learner-facing guided Sound Practice entry point
- `m9-target-phoneme-active` for an active chosen-sound group view
- Existing Sound Compare, review, focus, settings, audio, and UK comparison screenshots still pass

## Residual risks

- Runtime availability depends on enough imported words carrying active US phoneme tags for the selected learner level.
- Specialty copy/UX and selected-sound source still need Reviewer evidence and Architect acceptance under #205's contract.
