### PR TITLE
[M9] UK accent compare and specialty practice

### DIFF
--- a/backend/app/routes/practice.py
+++ b/backend/app/routes/practice.py
@@ -11,6 +11,7 @@ from app.services.sessions import (
     build_minimal_pair_group_response,
     build_next_normal_group_response,
     build_recent_mistake_review_response,
+    build_target_phoneme_group_response,
     build_today_response,
 )
 
@@ -54,6 +55,23 @@ def minimal_pair_group():
     """Create or resume a confusing-sound comparison specialty group."""
     with get_db() as conn:
         return build_minimal_pair_group_response(conn)
+
+
+@router.post("/practice/target-phoneme")
+async def target_phoneme_group(request: Request):
+    """Create or resume an intentional chosen-sound specialty group."""
+    body = await request.json()
+    phoneme = body.get("phoneme")
+    if not isinstance(phoneme, str) or not phoneme.strip():
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": "INVALID_TARGET_PHONEME",
+                "detail": "phoneme must be one approved sound string.",
+            },
+        )
+    with get_db() as conn:
+        return build_target_phoneme_group_response(conn, phoneme=phoneme.strip())
 
 
 @router.post("/review/current-group")

--- a/backend/app/routes/practice.py
+++ b/backend/app/routes/practice.py
@@ -8,6 +8,7 @@ from app.services.sessions import (
     build_clear_focus_response,
     build_current_group_review_response,
     build_focused_group_response,
+    build_minimal_pair_group_response,
     build_next_normal_group_response,
     build_recent_mistake_review_response,
     build_today_response,
@@ -46,6 +47,13 @@ def recent_mistake_review():
     """Create or resume a review group from recent wrong answers."""
     with get_db() as conn:
         return build_recent_mistake_review_response(conn)
+
+
+@router.post("/practice/minimal-pairs")
+def minimal_pair_group():
+    """Create or resume a confusing-sound comparison specialty group."""
+    with get_db() as conn:
+        return build_minimal_pair_group_response(conn)
 
 
 @router.post("/review/current-group")

--- a/backend/app/services/progress.py
+++ b/backend/app/services/progress.py
@@ -207,14 +207,23 @@ def build_progress_response(
 
     # ---- total attempts ------------------------------------------------------
     total_row = conn.execute(
-        "SELECT COUNT(*) AS cnt FROM attempts WHERE user_id = ?", (user_id,)
+        """
+        SELECT COUNT(*) AS cnt
+        FROM attempts
+        WHERE user_id = ? AND primary_accent = ?
+        """,
+        (user_id, primary_accent),
     ).fetchone()
     total_attempts = total_row["cnt"] if total_row else 0
 
     # ---- total sessions ------------------------------------------------------
     sess_row = conn.execute(
-        "SELECT COUNT(*) AS cnt FROM daily_sessions WHERE user_id = ?",
-        (user_id,),
+        """
+        SELECT COUNT(*) AS cnt
+        FROM daily_sessions
+        WHERE user_id = ? AND primary_accent = ?
+        """,
+        (user_id, primary_accent),
     ).fetchone()
     total_sessions = sess_row["cnt"] if sess_row else 0
 
@@ -222,9 +231,9 @@ def build_progress_response(
         """
         SELECT COUNT(*) AS cnt
         FROM daily_sessions
-        WHERE user_id = ? AND group_type = 'normal'
+        WHERE user_id = ? AND primary_accent = ? AND group_type = 'normal'
         """,
-        (user_id,),
+        (user_id, primary_accent),
     ).fetchone()
     total_normal_groups = normal_row["cnt"] if normal_row else 0
 
@@ -233,9 +242,10 @@ def build_progress_response(
     today_rows = conn.execute(
         """
         SELECT status FROM daily_sessions
-        WHERE user_id = ? AND session_date = ? AND group_type = 'normal'
+        WHERE user_id = ? AND primary_accent = ? AND session_date = ?
+          AND group_type = 'normal'
         """,
-        (user_id, today_str),
+        (user_id, primary_accent, today_str),
     ).fetchall()
     statuses = {row["status"] for row in today_rows}
     if "in_progress" in statuses:
@@ -247,7 +257,7 @@ def build_progress_response(
     today_completed = today_status == "completed"
 
     # ---- streak --------------------------------------------------------------
-    streak_days = _compute_streak(conn, user_id)
+    streak_days = _compute_streak(conn, user_id, primary_accent)
 
     # ---- weak / strong phonemes ----------------------------------------------
     weak_phonemes, strong_phonemes = _compute_phoneme_lists(
@@ -274,7 +284,7 @@ def build_progress_response(
 # ---------------------------------------------------------------------------
 
 
-def _compute_streak(conn: sqlite3.Connection, user_id: str) -> int:
+def _compute_streak(conn: sqlite3.Connection, user_id: str, primary_accent: str) -> int:
     """Count consecutive completed daily sessions.
 
     Walks backwards from yesterday; a gap or incomplete day breaks the streak.
@@ -283,10 +293,11 @@ def _compute_streak(conn: sqlite3.Connection, user_id: str) -> int:
     rows = conn.execute(
         """
         SELECT session_date FROM daily_sessions
-        WHERE user_id = ? AND status = 'completed' AND group_type = 'normal'
+        WHERE user_id = ? AND primary_accent = ? AND status = 'completed'
+          AND group_type = 'normal'
         ORDER BY session_date DESC
         """,
-        (user_id,),
+        (user_id, primary_accent),
     ).fetchall()
     completed_dates = {r["session_date"] for r in rows}
 
@@ -334,10 +345,10 @@ def _compute_level_stats(
         """
         SELECT learner_level, status, session_date, COUNT(*) AS cnt
         FROM daily_sessions
-        WHERE user_id = ? AND group_type = 'normal'
+        WHERE user_id = ? AND primary_accent = ? AND group_type = 'normal'
         GROUP BY learner_level, status, session_date
         """,
-        (user_id,),
+        (user_id, primary_accent),
     ).fetchall()
     for row in group_rows:
         level = row["learner_level"] if row["learner_level"] in result else "entry"

--- a/backend/app/services/sessions.py
+++ b/backend/app/services/sessions.py
@@ -89,7 +89,10 @@ def build_today_response(
             source_scope="normal_current",
             focus_phonemes=existing.focus_phonemes or settings.focus_phonemes,
             selected_learner_level=selected_level,
-            action_label=f"Resume {learner_level_label(existing.learner_level)} Group {existing.group_index}",
+            action_label=(
+                f"Resume {learner_level_label(existing.learner_level)} "
+                f"Group {existing.group_index}"
+            ),
         )
 
     return _normal_empty_response(
@@ -131,7 +134,10 @@ def build_next_normal_group_response(
             source_scope="normal_current",
             focus_phonemes=existing.focus_phonemes or settings.focus_phonemes,
             selected_learner_level=settings.learner_level,
-            action_label=f"Resume {learner_level_label(existing.learner_level)} Group {existing.group_index}",
+            action_label=(
+                f"Resume {learner_level_label(existing.learner_level)} "
+                f"Group {existing.group_index}"
+            ),
         )
 
     return _create_normal_group_response(
@@ -199,7 +205,10 @@ def _create_normal_group_response(
         source_scope=source_scope,
         focus_phonemes=settings.focus_phonemes,
         selected_learner_level=settings.learner_level,
-        action_label=f"Start {learner_level_label(session.learner_level)} Group {session.group_index}",
+        action_label=(
+            f"Start {learner_level_label(session.learner_level)} "
+            f"Group {session.group_index}"
+        ),
     )
 
 
@@ -505,7 +514,10 @@ def build_focused_group_response(
             source_scope="focus_selection",
             focus_phonemes=focus_phonemes,
             selected_learner_level=settings.learner_level,
-            action_label=f"Resume {learner_level_label(existing.learner_level)} Focus Group {existing.group_index}",
+            action_label=(
+                f"Resume {learner_level_label(existing.learner_level)} "
+                f"Focus Group {existing.group_index}"
+            ),
         )
 
     group_index = get_next_session_group_index(conn, user_id, session_date, accent)
@@ -551,7 +563,10 @@ def build_focused_group_response(
         source_scope="focus_selection",
         focus_phonemes=focus_phonemes,
         selected_learner_level=settings.learner_level,
-        action_label=f"Start {learner_level_label(session.learner_level)} Focus Group {session.group_index}",
+        action_label=(
+            f"Start {learner_level_label(session.learner_level)} "
+            f"Focus Group {session.group_index}"
+        ),
     )
 
 
@@ -733,6 +748,39 @@ def learner_level_label(learner_level: Optional[str]) -> str:
     return _LEARNER_LEVEL_LABELS.get(learner_level or "entry", "Entry")
 
 
+def _uk_comparison_ready(word) -> bool:
+    return bool(
+        word.content_status != "disabled"
+        and word.ipa_us
+        and word.ipa_uk
+        and word.phoneme_tags_us
+        and word.phoneme_tags_uk
+    )
+
+
+def _build_accent_compare(word, *, enabled: bool) -> Optional[dict]:
+    if not enabled or not _uk_comparison_ready(word):
+        return None
+    return {
+        "enabled": True,
+        "primary": {
+            "accent": "US",
+            "label": "American sound",
+            "ipa": word.ipa_us,
+        },
+        "comparison": {
+            "accent": "UK",
+            "label": "British note",
+            "ipa": word.ipa_uk,
+            "phoneme_tags": word.phoneme_tags_uk,
+            "review_note": (
+                "Display-only comparison. Your answer is still graded against "
+                "the American IPA."
+            ),
+        },
+    }
+
+
 def _build_response(
     *,
     session: DailySession,
@@ -748,6 +796,8 @@ def _build_response(
     action_label: Optional[str] = None,
 ) -> dict:
     """Assemble the /api/today JSON response from session + items."""
+    settings = get_settings(conn, session.user_id)
+    show_accent_compare = bool(settings and settings.show_accent_compare)
     distractor_pool = _build_distractor_pool(conn, accent)
     item_dicts: List[dict] = []
     for item in items:
@@ -774,6 +824,12 @@ def _build_response(
                 "question": question,
             }
         )
+        accent_compare = _build_accent_compare(
+            word,
+            enabled=accent == "US" and show_accent_compare,
+        )
+        if accent_compare is not None:
+            item_dicts[-1]["accent_compare"] = accent_compare
 
     response = {
         "session_id": session.id,

--- a/backend/app/services/sessions.py
+++ b/backend/app/services/sessions.py
@@ -37,6 +37,10 @@ _MINIMAL_PAIR_EMPTY_DETAIL = (
     "Sound Compare practice is not available yet. It needs at least two safe "
     "words with pair metadata."
 )
+_TARGET_PHONEME_EMPTY_DETAIL = (
+    "Sound Practice is not available for this sound yet. It needs safe words "
+    "tagged with the selected American sound."
+)
 
 
 def _today_date_str() -> str:
@@ -669,6 +673,118 @@ def build_minimal_pair_group_response(
     )
 
 
+def build_target_phoneme_group_response(
+    conn,
+    *,
+    phoneme: str,
+    user_id: str = "default",
+    accent: str = "US",
+) -> dict:
+    """Create or resume learner-directed specialty practice for one sound."""
+    session_date = _today_date_str()
+    settings = get_settings(conn, user_id)
+    if settings is None:
+        return {
+            "error": "CONTENT_NOT_READY",
+            "detail": "Settings not initialised. Run import_words.py first.",
+        }
+
+    options = _target_phoneme_options(
+        conn,
+        accent=accent,
+        learner_level=settings.learner_level,
+    )
+    approved = {option["phoneme"] for option in options}
+    if phoneme not in approved:
+        return _target_phoneme_empty_response(
+            conn,
+            user_id=user_id,
+            session_date=session_date,
+            accent=accent,
+            settings=settings,
+            phoneme=phoneme,
+            options=options,
+            origin="target_phoneme_empty",
+            detail=_TARGET_PHONEME_EMPTY_DETAIL,
+        )
+
+    existing = get_active_session_for_date(
+        conn,
+        user_id,
+        session_date,
+        accent,
+        "target_phoneme",
+        source_scope="specialty_target_phoneme",
+        focus_phonemes=[phoneme],
+        learner_level=settings.learner_level,
+    )
+    if existing is not None:
+        items = get_session_items(conn, existing.id)
+        return _build_response(
+            session=existing,
+            items=items,
+            daily_word_count=settings.daily_word_count,
+            conn=conn,
+            accent=accent,
+            origin="target_phoneme_resume",
+            source_scope="specialty_target_phoneme",
+            focus_phonemes=[phoneme],
+            selected_learner_level=settings.learner_level,
+            action_label=f"Resume Sound Practice Group {existing.group_index}",
+        )
+
+    group_index = get_next_session_group_index(conn, user_id, session_date, accent)
+    words = _select_target_phoneme_words(
+        conn,
+        accent=accent,
+        learner_level=settings.learner_level,
+        phoneme=phoneme,
+        limit=settings.daily_word_count,
+        seed=_seed_from_group(
+            session_date,
+            group_index,
+            f"target_phoneme:{phoneme}",
+        ),
+    )
+    if not words:
+        return _target_phoneme_empty_response(
+            conn,
+            user_id=user_id,
+            session_date=session_date,
+            accent=accent,
+            settings=settings,
+            phoneme=phoneme,
+            options=options,
+            origin="target_phoneme_empty",
+            detail=_TARGET_PHONEME_EMPTY_DETAIL,
+        )
+
+    session, items = _create_group_from_words(
+        conn,
+        words=words,
+        user_id=user_id,
+        session_date=session_date,
+        accent=accent,
+        group_index=group_index,
+        group_type="target_phoneme",
+        learner_level=settings.learner_level,
+        source_scope="specialty_target_phoneme",
+        focus_phonemes=[phoneme],
+    )
+    return _build_response(
+        session=session,
+        items=items,
+        daily_word_count=settings.daily_word_count,
+        conn=conn,
+        accent=accent,
+        origin="target_phoneme_start",
+        source_scope="specialty_target_phoneme",
+        focus_phonemes=[phoneme],
+        selected_learner_level=settings.learner_level,
+        action_label=f"Start Sound Practice Group {session.group_index}",
+    )
+
+
 def build_clear_focus_response(
     conn,
     *,
@@ -742,6 +858,144 @@ def _select_minimal_pair_words(
         (*level_values, *level_values, max(limit, 2)),
     ).fetchall()
     return [get_word_by_id(conn, row["id"]) for row in rows if row["id"]]
+
+
+def _level_values(learner_level: str) -> list[str]:
+    return ["entry", "beginner"] if learner_level == "entry" else [learner_level]
+
+
+def _target_phoneme_options(
+    conn,
+    *,
+    accent: str,
+    learner_level: str,
+) -> list[dict]:
+    if accent != "US":
+        return []
+    level_values = _level_values(learner_level)
+    rows = conn.execute(
+        """
+        SELECT id, symbol, example_word
+        FROM phonemes
+        WHERE accent_scope IN ('US', 'both')
+        ORDER BY priority, symbol
+        """,
+    ).fetchall()
+    options = []
+    for row in rows:
+        phoneme = row["id"]
+        count = _target_phoneme_candidate_count(
+            conn,
+            phoneme=phoneme,
+            level_values=level_values,
+        )
+        if count > 0:
+            options.append(
+                {
+                    "phoneme": phoneme,
+                    "symbol": row["symbol"],
+                    "example_word": row["example_word"],
+                    "candidate_count": count,
+                }
+            )
+    return options[:8]
+
+
+def _target_phoneme_candidate_count(
+    conn,
+    *,
+    phoneme: str,
+    level_values: list[str],
+) -> int:
+    level_placeholders = ", ".join("?" for _ in level_values)
+    row = conn.execute(
+        f"""
+        SELECT COUNT(*) AS cnt
+        FROM words
+        WHERE content_status != 'disabled'
+          AND level IN ({level_placeholders})
+          AND ipa_us IS NOT NULL
+          AND ipa_us != ''
+          AND phoneme_tags_us IS NOT NULL
+          AND phoneme_tags_us != ''
+          AND phoneme_tags_us LIKE ?
+        """,
+        (*level_values, f'%"{phoneme}"%'),
+    ).fetchone()
+    return int(row["cnt"]) if row else 0
+
+
+def _select_target_phoneme_words(
+    conn,
+    *,
+    accent: str,
+    learner_level: str,
+    phoneme: str,
+    limit: int,
+    seed: int,
+) -> list:
+    if accent != "US":
+        return []
+    level_values = _level_values(learner_level)
+    level_placeholders = ", ".join("?" for _ in level_values)
+    rows = conn.execute(
+        f"""
+        SELECT id
+        FROM words
+        WHERE content_status != 'disabled'
+          AND level IN ({level_placeholders})
+          AND ipa_us IS NOT NULL
+          AND ipa_us != ''
+          AND phoneme_tags_us IS NOT NULL
+          AND phoneme_tags_us != ''
+          AND phoneme_tags_us LIKE ?
+        ORDER BY word
+        """,
+        (*level_values, f'%"{phoneme}"%'),
+    ).fetchall()
+    candidates = [get_word_by_id(conn, row["id"]) for row in rows if row["id"]]
+    candidates = [word for word in candidates if word is not None]
+    candidates.sort(key=lambda word: (_stable_hash(f"{seed}:{word.id}"), word.word))
+    return candidates[: max(limit, 1)]
+
+
+def _target_phoneme_empty_response(
+    conn,
+    *,
+    user_id: str,
+    session_date: str,
+    accent: str,
+    settings,
+    phoneme: str,
+    options: list[dict],
+    origin: str,
+    detail: str,
+) -> dict:
+    return {
+        "group_type": "target_phoneme",
+        "learner_level": settings.learner_level,
+        "learner_level_label": learner_level_label(settings.learner_level),
+        "selected_learner_level": settings.learner_level,
+        "selected_learner_level_label": learner_level_label(settings.learner_level),
+        "date": session_date,
+        "primary_accent": accent,
+        "daily_word_count": settings.daily_word_count,
+        "recent_mistake_count": _recent_mistake_count(
+            conn,
+            user_id=user_id,
+            accent=accent,
+            daily_word_count=settings.daily_word_count,
+        ),
+        "word_count": 0,
+        "status": "empty",
+        "origin": origin,
+        "source_scope": "specialty_target_phoneme",
+        "source_session_item_ids": [],
+        "focus_phonemes": [phoneme] if phoneme else [],
+        "target_phoneme_options": options,
+        "items": [],
+        "detail": detail,
+    }
 
 
 def _create_group_from_words(
@@ -885,6 +1139,11 @@ def _normal_empty_response(
         "source_scope": "normal_none",
         "source_session_item_ids": [],
         "focus_phonemes": focus_phonemes or [],
+        "target_phoneme_options": _target_phoneme_options(
+            conn,
+            accent=accent,
+            learner_level=selected_level,
+        ),
         "action_label": f"Start {learner_level_label(selected_level)} group",
         "items": [],
     }
@@ -1026,4 +1285,9 @@ def _build_response(
         response["focus_phonemes"] = response_focus_phonemes
     if action_label is not None:
         response["action_label"] = action_label
+    response["target_phoneme_options"] = _target_phoneme_options(
+        conn,
+        accent=session.primary_accent,
+        learner_level=selected_learner_level or session.learner_level,
+    )
     return response

--- a/backend/app/services/sessions.py
+++ b/backend/app/services/sessions.py
@@ -33,6 +33,11 @@ _LEARNER_LEVEL_LABELS = {
     "mid": "Mid",
 }
 
+_MINIMAL_PAIR_EMPTY_DETAIL = (
+    "Sound Compare practice is not available yet. It needs at least two safe "
+    "words with pair metadata."
+)
+
 
 def _today_date_str() -> str:
     return date.today().isoformat()
@@ -570,6 +575,100 @@ def build_focused_group_response(
     )
 
 
+def build_minimal_pair_group_response(
+    conn,
+    *,
+    user_id: str = "default",
+    accent: str = "US",
+) -> dict:
+    """Create or resume a confusing-sound comparison specialty group."""
+    session_date = _today_date_str()
+    settings = get_settings(conn, user_id)
+    if settings is None:
+        return {
+            "error": "CONTENT_NOT_READY",
+            "detail": "Settings not initialised. Run import_words.py first.",
+        }
+
+    existing = get_active_session_for_date(
+        conn,
+        user_id,
+        session_date,
+        accent,
+        "minimal_pair",
+        source_scope="specialty_minimal_pair",
+        learner_level=settings.learner_level,
+    )
+    if existing is not None:
+        items = get_session_items(conn, existing.id)
+        return _build_response(
+            session=existing,
+            items=items,
+            daily_word_count=settings.daily_word_count,
+            conn=conn,
+            accent=accent,
+            origin="minimal_pair_resume",
+            source_scope="specialty_minimal_pair",
+            selected_learner_level=settings.learner_level,
+            action_label=f"Resume Sound Compare Group {existing.group_index}",
+        )
+
+    words = _select_minimal_pair_words(
+        conn,
+        accent=accent,
+        learner_level=settings.learner_level,
+        limit=settings.daily_word_count,
+    )
+    if len(words) < 2:
+        return {
+            "group_type": "minimal_pair",
+            "learner_level": settings.learner_level,
+            "learner_level_label": learner_level_label(settings.learner_level),
+            "selected_learner_level": settings.learner_level,
+            "selected_learner_level_label": learner_level_label(settings.learner_level),
+            "date": session_date,
+            "primary_accent": accent,
+            "daily_word_count": settings.daily_word_count,
+            "recent_mistake_count": _recent_mistake_count(
+                conn,
+                user_id=user_id,
+                accent=accent,
+                daily_word_count=settings.daily_word_count,
+            ),
+            "word_count": 0,
+            "status": "empty",
+            "origin": "minimal_pair_empty",
+            "source_scope": "specialty_minimal_pair",
+            "source_session_item_ids": [],
+            "items": [],
+            "detail": _MINIMAL_PAIR_EMPTY_DETAIL,
+        }
+
+    group_index = get_next_session_group_index(conn, user_id, session_date, accent)
+    session, items = _create_group_from_words(
+        conn,
+        words=words,
+        user_id=user_id,
+        session_date=session_date,
+        accent=accent,
+        group_index=group_index,
+        group_type="minimal_pair",
+        learner_level=settings.learner_level,
+        source_scope="specialty_minimal_pair",
+    )
+    return _build_response(
+        session=session,
+        items=items,
+        daily_word_count=settings.daily_word_count,
+        conn=conn,
+        accent=accent,
+        origin="minimal_pair_start",
+        source_scope="specialty_minimal_pair",
+        selected_learner_level=settings.learner_level,
+        action_label=f"Start Sound Compare Group {session.group_index}",
+    )
+
+
 def build_clear_focus_response(
     conn,
     *,
@@ -596,6 +695,53 @@ def build_clear_focus_response(
         response["focus_phonemes"] = []
         response["detail"] = "Focus selection cleared."
     return response
+
+
+def _select_minimal_pair_words(
+    conn,
+    *,
+    accent: str,
+    learner_level: str,
+    limit: int,
+) -> list:
+    ipa_field = "ipa_us" if accent == "US" else "ipa_uk"
+    tags_field = "phoneme_tags_us" if accent == "US" else "phoneme_tags_uk"
+    level_values = (
+        ["entry", "beginner"] if learner_level == "entry" else [learner_level]
+    )
+    level_placeholders = ", ".join("?" for _ in level_values)
+    rows = conn.execute(
+        f"""
+        SELECT *
+        FROM words
+        WHERE content_status != 'disabled'
+          AND level IN ({level_placeholders})
+          AND minimal_pair_group IS NOT NULL
+          AND minimal_pair_group != ''
+          AND {ipa_field} IS NOT NULL
+          AND {ipa_field} != ''
+          AND {tags_field} IS NOT NULL
+          AND {tags_field} != ''
+          AND minimal_pair_group IN (
+              SELECT minimal_pair_group
+              FROM words
+              WHERE content_status != 'disabled'
+                AND level IN ({level_placeholders})
+                AND minimal_pair_group IS NOT NULL
+                AND minimal_pair_group != ''
+                AND {ipa_field} IS NOT NULL
+                AND {ipa_field} != ''
+                AND {tags_field} IS NOT NULL
+                AND {tags_field} != ''
+              GROUP BY minimal_pair_group
+              HAVING COUNT(*) >= 2
+          )
+        ORDER BY minimal_pair_group, word
+        LIMIT ?
+        """,
+        (*level_values, *level_values, max(limit, 2)),
+    ).fetchall()
+    return [get_word_by_id(conn, row["id"]) for row in rows if row["id"]]
 
 
 def _create_group_from_words(

--- a/backend/scripts/report_uk_ready_content.py
+++ b/backend/scripts/report_uk_ready_content.py
@@ -1,0 +1,624 @@
+#!/usr/bin/env python3
+"""Build the M9 UK-ready content subset and accent coverage report.
+
+This script is intentionally a content/reporting tool. It does not change
+learner defaults, grading, API response shapes, or runtime specialty practice.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Iterable
+
+from validate_content import load_json, load_phoneme_inventory, load_words
+
+DEFAULT_ACCEPTED_UK_REVIEW_STATUSES = {"auto_checked", "reviewed"}
+DEFAULT_WORD_FILES = ("content/core_300_words.json", "content/core_1000_words.json")
+DEFAULT_SAMPLE_SIZE = 8
+DEFAULT_CANDIDATE_LIMIT = 30
+
+
+def _is_present(value: object) -> bool:
+    return value is not None and value != "" and value != []
+
+
+def _as_list(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value if str(item)]
+
+
+def _row_key(row: dict) -> tuple[str, str]:
+    return (str(row.get("level", "")), str(row.get("word", "")))
+
+
+def _source_label(path: Path) -> str:
+    try:
+        return path.resolve().relative_to(Path.cwd().resolve()).as_posix()
+    except ValueError:
+        pass
+    return path.as_posix()
+
+
+def load_word_sources(paths: Iterable[Path]) -> list[dict]:
+    """Load word rows and attach source-file provenance."""
+    rows: list[dict] = []
+    seen_word_ids: set[str] = set()
+    duplicates: list[str] = []
+    for path in paths:
+        for row in load_words(path):
+            copied = dict(row)
+            copied["_source_file"] = _source_label(path)
+            word_id = str(copied.get("word_id", ""))
+            if word_id in seen_word_ids:
+                duplicates.append(word_id)
+            seen_word_ids.add(word_id)
+            rows.append(copied)
+    if duplicates:
+        dupes = ", ".join(sorted(set(duplicates))[:10])
+        raise ValueError(f"Duplicate word_id values across sources: {dupes}")
+    return rows
+
+
+def load_difficult_contrasts(phonemes_path: Path) -> list[dict]:
+    """Load difficult contrast definitions from phonemes.json."""
+    data = load_json(phonemes_path)
+    contrasts = []
+    for entry in data.get("difficult_contrasts", []):
+        pair = entry.get("pair")
+        if isinstance(pair, list) and len(pair) == 2:
+            contrasts.append({
+                "pair": [str(pair[0]), str(pair[1])],
+                "description_zh": entry.get("description_zh", ""),
+            })
+    return contrasts
+
+
+def exclusion_reasons(
+    row: dict,
+    known_phonemes: set[str],
+    accepted_uk_review_statuses: set[str],
+) -> list[str]:
+    """Return M9 UK-comparison exclusion reasons for a content row."""
+    reasons: list[str] = []
+    tags_us = _as_list(row.get("phoneme_tags_us"))
+    tags_uk = _as_list(row.get("phoneme_tags_uk"))
+
+    if row.get("content_status") == "disabled":
+        reasons.append("content_status is disabled")
+    if not _is_present(row.get("ipa_us")):
+        reasons.append("missing ipa_us")
+    if not _is_present(row.get("ipa_uk")):
+        reasons.append("missing ipa_uk")
+    if not tags_us:
+        reasons.append("missing phoneme_tags_us")
+    if not tags_uk:
+        reasons.append("missing phoneme_tags_uk")
+    review_status_uk = str(row.get("review_status_uk") or "")
+    if review_status_uk not in accepted_uk_review_statuses:
+        reasons.append(f"review_status_uk '{review_status_uk or '<missing>'}' is not accepted")
+
+    unknown_us = sorted({tag for tag in tags_us if tag not in known_phonemes})
+    unknown_uk = sorted({tag for tag in tags_uk if tag not in known_phonemes})
+    if unknown_us:
+        reasons.append(f"unsupported US phoneme tag(s): {', '.join(unknown_us)}")
+    if unknown_uk:
+        reasons.append(f"unsupported UK phoneme tag(s): {', '.join(unknown_uk)}")
+
+    return reasons
+
+
+def _accent_difference_reason(row: dict) -> str:
+    reasons: list[str] = []
+    if row.get("ipa_us") != row.get("ipa_uk"):
+        reasons.append("IPA differs")
+    if _as_list(row.get("phoneme_tags_us")) != _as_list(row.get("phoneme_tags_uk")):
+        reasons.append("phoneme tags differ")
+    return "; ".join(reasons)
+
+
+def _known_caveat(row: dict) -> str:
+    caveats: list[str] = []
+    if row.get("review_status_uk") == "auto_checked":
+        caveats.append("auto_checked; Architect pronunciation acceptance pending")
+    if row.get("audio_uk") in (None, ""):
+        caveats.append("no UK audio required for M9 comparison")
+    if not _accent_difference_reason(row):
+        caveats.append("same broad IPA/tags; comparison value is low")
+    return "; ".join(caveats) or "none"
+
+
+def _sample_reason(row: dict) -> str:
+    reason = _accent_difference_reason(row)
+    if reason:
+        return f"eligible reviewed UK comparison row; {reason}"
+    return "eligible reviewed UK comparison row"
+
+
+def _coverage(rows: list[dict], field: str, known_phonemes: set[str]) -> dict[str, int]:
+    counts = Counter()
+    for row in rows:
+        counts.update(set(_as_list(row.get(field))))
+    return {phoneme: counts.get(phoneme, 0) for phoneme in sorted(known_phonemes)}
+
+
+def _candidate_row(row: dict) -> dict:
+    return {
+        "word_id": row.get("word_id"),
+        "word": row.get("word"),
+        "level": row.get("level"),
+        "ipa_us": row.get("ipa_us"),
+        "ipa_uk": row.get("ipa_uk"),
+        "phoneme_tags_us": _as_list(row.get("phoneme_tags_us")),
+        "phoneme_tags_uk": _as_list(row.get("phoneme_tags_uk")),
+        "review_status_uk": row.get("review_status_uk"),
+        "source_file": row.get("_source_file"),
+    }
+
+
+def _accent_difference_candidates(rows: list[dict]) -> list[dict]:
+    candidates = []
+    for row in sorted(rows, key=_row_key):
+        reason = _accent_difference_reason(row)
+        if not reason:
+            continue
+        candidate = _candidate_row(row)
+        candidate["reason"] = reason
+        candidate["caveat"] = _known_caveat(row)
+        candidates.append(candidate)
+    return candidates
+
+
+def _tag_sequence_minimal_pair_candidates(
+    rows: list[dict],
+    difficult_contrasts: list[dict],
+) -> list[dict]:
+    contrast_lookup = {}
+    for contrast in difficult_contrasts:
+        pair = tuple(contrast["pair"])
+        contrast_lookup[frozenset(pair)] = contrast.get("description_zh", "")
+
+    candidates = []
+    seen_word_pairs: set[tuple[str, str, tuple[str, str]]] = set()
+    sorted_rows = sorted(rows, key=_row_key)
+    for left_index, left in enumerate(sorted_rows):
+        left_tags = _as_list(left.get("phoneme_tags_us"))
+        for right in sorted_rows[left_index + 1:]:
+            right_tags = _as_list(right.get("phoneme_tags_us"))
+            if len(left_tags) != len(right_tags):
+                continue
+            diffs = [
+                (a, b)
+                for a, b in zip(left_tags, right_tags)
+                if a != b
+            ]
+            if len(diffs) != 1:
+                continue
+            contrast_key = frozenset(diffs[0])
+            if contrast_key not in contrast_lookup:
+                continue
+            words_key = tuple(sorted([str(left.get("word")), str(right.get("word"))]))
+            contrast_tuple = tuple(sorted(contrast_key))
+            candidate_key = (words_key[0], words_key[1], contrast_tuple)
+            if candidate_key in seen_word_pairs:
+                continue
+            seen_word_pairs.add(candidate_key)
+            candidates.append({
+                "left_word_id": left.get("word_id"),
+                "left_word": left.get("word"),
+                "right_word_id": right.get("word_id"),
+                "right_word": right.get("word"),
+                "contrast": sorted(contrast_key),
+                "basis": "one phoneme-tag difference in phoneme_tags_us",
+                "caveat": (
+                    "mechanical candidate only; requires Architect/content review "
+                    "before runtime specialty practice"
+                ),
+                "description_zh": contrast_lookup[contrast_key],
+            })
+    return candidates
+
+
+def _target_phoneme_coverage(
+    rows: list[dict],
+    known_phonemes: set[str],
+    phoneme_inventory: dict[str, dict],
+) -> list[dict]:
+    coverage_us = _coverage(rows, "phoneme_tags_us", known_phonemes)
+    coverage_uk = _coverage(rows, "phoneme_tags_uk", known_phonemes)
+    result = []
+    for phoneme in sorted(known_phonemes):
+        entry = phoneme_inventory.get(phoneme, {})
+        result.append({
+            "phoneme": phoneme,
+            "category": entry.get("category"),
+            "priority": entry.get("priority"),
+            "eligible_words_us": coverage_us.get(phoneme, 0),
+            "eligible_words_uk": coverage_uk.get(phoneme, 0),
+        })
+    return result
+
+
+def build_uk_ready_report(
+    rows: list[dict],
+    known_phonemes: set[str],
+    phoneme_inventory: dict[str, dict],
+    difficult_contrasts: list[dict],
+    accepted_uk_review_statuses: set[str] | None = None,
+    candidate_limit: int = DEFAULT_CANDIDATE_LIMIT,
+    sample_size: int = DEFAULT_SAMPLE_SIZE,
+) -> dict:
+    """Build an M9 UK-ready subset and accent coverage report."""
+    accepted_uk_review_statuses = (
+        accepted_uk_review_statuses or DEFAULT_ACCEPTED_UK_REVIEW_STATUSES
+    )
+
+    eligible: list[dict] = []
+    excluded: list[dict] = []
+    unsupported_uk_symbols = Counter()
+    review_status_counts = Counter()
+    content_status_counts = Counter()
+    missing_uk_ipa_count = 0
+    missing_uk_tags_count = 0
+
+    for row in rows:
+        review_status_counts[str(row.get("review_status_uk") or "<missing>")] += 1
+        content_status_counts[str(row.get("content_status") or "<missing>")] += 1
+        if not _is_present(row.get("ipa_uk")):
+            missing_uk_ipa_count += 1
+        if not _as_list(row.get("phoneme_tags_uk")):
+            missing_uk_tags_count += 1
+        for tag in _as_list(row.get("phoneme_tags_uk")):
+            if tag not in known_phonemes:
+                unsupported_uk_symbols[tag] += 1
+
+        reasons = exclusion_reasons(row, known_phonemes, accepted_uk_review_statuses)
+        if reasons:
+            excluded.append({
+                "word_id": row.get("word_id"),
+                "word": row.get("word"),
+                "review_status_uk": row.get("review_status_uk"),
+                "content_status": row.get("content_status"),
+                "reasons": reasons,
+                "source_file": row.get("_source_file"),
+            })
+        else:
+            eligible.append(row)
+
+    source_ipa_uk_summary = Counter(row.get("source_ipa_uk") or "unknown" for row in eligible)
+    source_ipa_us_summary = Counter(row.get("source_ipa_us") or "unknown" for row in eligible)
+    license_summary = Counter(row.get("license_notes") or "unspecified" for row in eligible)
+    source_file_summary = Counter(row.get("_source_file") or "unknown" for row in eligible)
+
+    all_accent_difference_candidates = _accent_difference_candidates(eligible)
+    all_minimal_pair_candidates = _tag_sequence_minimal_pair_candidates(
+        eligible,
+        difficult_contrasts,
+    )
+    accent_difference_candidates = all_accent_difference_candidates[:candidate_limit]
+    minimal_pair_candidates = all_minimal_pair_candidates[:candidate_limit]
+    target_phoneme_coverage = _target_phoneme_coverage(
+        eligible,
+        known_phonemes,
+        phoneme_inventory,
+    )
+
+    sample_rows = accent_difference_candidates[:sample_size]
+    if len(sample_rows) < sample_size:
+        existing_ids = {row["word_id"] for row in sample_rows}
+        for row in sorted(eligible, key=_row_key):
+            if row.get("word_id") in existing_ids:
+                continue
+            sample_rows.append({
+                **_candidate_row(row),
+                "reason": _sample_reason(row),
+                "caveat": _known_caveat(row),
+            })
+            if len(sample_rows) >= sample_size:
+                break
+
+    return {
+        "report_name": "M9 UK-ready content subset and accent coverage report",
+        "content_gate": {
+            "accepted_review_status_uk": sorted(accepted_uk_review_statuses),
+            "content_quality_acceptance": "Architect/content acceptance required",
+            "runtime_scope": "content/report evidence only; no UK grading or UI behavior",
+        },
+        "totals": {
+            "source_rows": len(rows),
+            "eligible_rows": len(eligible),
+            "excluded_rows": len(excluded),
+            "missing_uk_ipa_count": missing_uk_ipa_count,
+            "missing_uk_tags_count": missing_uk_tags_count,
+            "unsupported_uk_symbol_count": sum(unsupported_uk_symbols.values()),
+            "unsupported_uk_symbol_rows": sum(
+                1
+                for row in rows
+                if any(tag not in known_phonemes for tag in _as_list(row.get("phoneme_tags_uk")))
+            ),
+            "accent_difference_candidate_count": len(all_accent_difference_candidates),
+            "minimal_pair_candidate_count": len(all_minimal_pair_candidates),
+            "target_phoneme_covered_count_us": sum(
+                1 for entry in target_phoneme_coverage if entry["eligible_words_us"] > 0
+            ),
+            "target_phoneme_covered_count_uk": sum(
+                1 for entry in target_phoneme_coverage if entry["eligible_words_uk"] > 0
+            ),
+        },
+        "review_status_uk_counts": dict(sorted(review_status_counts.items())),
+        "content_status_counts": dict(sorted(content_status_counts.items())),
+        "source_metadata": {
+            "source_files": dict(sorted(source_file_summary.items())),
+            "source_ipa_us": dict(sorted(source_ipa_us_summary.items())),
+            "source_ipa_uk": dict(sorted(source_ipa_uk_summary.items())),
+            "license_notes": dict(sorted(license_summary.items())),
+        },
+        "unsupported_uk_symbols": dict(sorted(unsupported_uk_symbols.items())),
+        "eligible_word_ids": [str(row.get("word_id")) for row in sorted(eligible, key=_row_key)],
+        "sample_table": [
+            {
+                "word": row["word"],
+                "us_ipa": row["ipa_us"],
+                "uk_ipa": row["ipa_uk"],
+                "review_status_uk": row["review_status_uk"],
+                "reason_included": row["reason"],
+                "caveat": row["caveat"],
+            }
+            for row in sample_rows
+        ],
+        "accent_difference_candidates": accent_difference_candidates,
+        "minimal_pair_candidates": minimal_pair_candidates,
+        "target_phoneme_candidate_coverage": target_phoneme_coverage,
+        "known_caveats": [
+            "UK rows marked auto_checked are mechanically eligible for this report, "
+            "but still require Architect/content-quality acceptance before UI use.",
+            "UK audio is not required for M9 comparison display.",
+            "Minimal-pair candidates are mechanical tag-sequence candidates, not "
+            "accepted runtime metadata.",
+            "Target-phoneme coverage is candidate coverage only; M9 runtime selection "
+            "is intentionally out of scope for this issue.",
+        ],
+        "excluded_rows_sample": excluded[:candidate_limit],
+    }
+
+
+def _markdown_table(headers: list[str], rows: list[list[object]]) -> str:
+    lines = [
+        "| " + " | ".join(headers) + " |",
+        "| " + " | ".join("---" for _ in headers) + " |",
+    ]
+    for row in rows:
+        rendered = [str(cell).replace("\n", " ") for cell in row]
+        lines.append("| " + " | ".join(rendered) + " |")
+    return "\n".join(lines)
+
+
+def render_markdown_report(report: dict) -> str:
+    """Render a human-readable Markdown report."""
+    totals = report["totals"]
+    source_metadata = report["source_metadata"]
+    sample_rows = [
+        [
+            row["word"],
+            row["us_ipa"],
+            row["uk_ipa"],
+            row["reason_included"],
+            row["caveat"],
+        ]
+        for row in report["sample_table"]
+    ]
+    target_rows = [
+        [
+            row["phoneme"],
+            row["category"],
+            row["priority"],
+            row["eligible_words_us"],
+            row["eligible_words_uk"],
+        ]
+        for row in sorted(
+            report["target_phoneme_candidate_coverage"],
+            key=lambda item: (item["priority"] or 99, item["phoneme"]),
+        )[:20]
+    ]
+    pair_rows = [
+        [
+            f"{row['left_word']} / {row['right_word']}",
+            ", ".join(row["contrast"]),
+            row["basis"],
+            row["caveat"],
+        ]
+        for row in report["minimal_pair_candidates"][:10]
+    ]
+
+    lines = [
+        "# M9 UK-Ready Content Subset and Accent Coverage Report",
+        "",
+        "This is the checked-in evidence artifact for issue #196. It is a "
+        "content/report snapshot only; it does not enable UK grading, UK primary "
+        "accent selection, UK comparison UI/API, minimal-pair runtime, or "
+        "target-phoneme runtime behavior.",
+        "",
+        "## Gate",
+        "",
+        f"- Accepted `review_status_uk` values for this report: "
+        f"{', '.join(report['content_gate']['accepted_review_status_uk'])}",
+        "- Content-quality acceptance: Architect/content acceptance required.",
+        "- UK comparison remains display-only in later M9 work; US grading remains unchanged.",
+        "",
+        "## Summary",
+        "",
+        f"- Source rows: {totals['source_rows']}",
+        f"- Eligible UK-ready rows: {totals['eligible_rows']}",
+        f"- Excluded rows: {totals['excluded_rows']}",
+        f"- Missing UK IPA count: {totals['missing_uk_ipa_count']}",
+        f"- Missing UK phoneme tags count: {totals['missing_uk_tags_count']}",
+        f"- Unsupported UK symbol count: {totals['unsupported_uk_symbol_count']}",
+        f"- Accent-difference candidates: {totals['accent_difference_candidate_count']}",
+        f"- Minimal-pair candidates: {totals['minimal_pair_candidate_count']}",
+        f"- Target phonemes covered by US tags: {totals['target_phoneme_covered_count_us']}",
+        f"- Target phonemes covered by UK tags: {totals['target_phoneme_covered_count_uk']}",
+        "",
+        "## Sample Table",
+        "",
+        _markdown_table(
+            ["word", "US IPA", "UK IPA", "reason included", "caveat"],
+            sample_rows,
+        ),
+        "",
+        "## Source and License Metadata",
+        "",
+        "Source files:",
+        "",
+    ]
+    for source, count in source_metadata["source_files"].items():
+        lines.append(f"- `{source}`: {count}")
+    lines.extend(["", "UK IPA sources:", ""])
+    for source, count in source_metadata["source_ipa_uk"].items():
+        lines.append(f"- {source}: {count}")
+    lines.extend(["", "License notes:", ""])
+    for license_note, count in source_metadata["license_notes"].items():
+        lines.append(f"- {license_note}: {count}")
+
+    lines.extend([
+        "",
+        "## Review Status Coverage",
+        "",
+    ])
+    for status, count in report["review_status_uk_counts"].items():
+        lines.append(f"- `{status}`: {count}")
+
+    lines.extend([
+        "",
+        "## Minimal-Pair Candidate Sample",
+        "",
+    ])
+    if pair_rows:
+        lines.append(_markdown_table(
+            ["words", "contrast", "basis", "caveat"],
+            pair_rows,
+        ))
+    else:
+        lines.append("No mechanical minimal-pair candidates were found.")
+
+    lines.extend([
+        "",
+        "## Target-Phoneme Candidate Coverage Sample",
+        "",
+        _markdown_table(
+            ["phoneme", "category", "priority", "eligible words US", "eligible words UK"],
+            target_rows,
+        ),
+        "",
+        "## Caveats and Exclusions",
+        "",
+    ])
+    for caveat in report["known_caveats"]:
+        lines.append(f"- {caveat}")
+    if report["unsupported_uk_symbols"]:
+        lines.extend(["", "Unsupported UK symbols:", ""])
+        for symbol, count in report["unsupported_uk_symbols"].items():
+            lines.append(f"- `{symbol}`: {count}")
+    else:
+        lines.extend(["", "Unsupported UK symbols: none."])
+
+    excluded_rows = [
+        [
+            row["word"],
+            row["review_status_uk"],
+            row["content_status"],
+            "; ".join(row["reasons"]),
+        ]
+        for row in report["excluded_rows_sample"][:10]
+    ]
+    lines.extend([
+        "",
+        "Excluded rows sample:",
+        "",
+        _markdown_table(
+            ["word", "review_status_uk", "content_status", "reason excluded"],
+            excluded_rows,
+        ) if excluded_rows else "(none)",
+    ])
+
+    return "\n".join(lines)
+
+
+def main() -> None:
+    repo_root = Path(__file__).resolve().parent.parent.parent
+    parser = argparse.ArgumentParser(
+        description="Build the M9 UK-ready content subset/accent coverage report."
+    )
+    parser.add_argument(
+        "--words",
+        action="append",
+        default=None,
+        help=(
+            "Word JSON file. May be repeated. Defaults to core_300_words.json "
+            "and core_1000_words.json."
+        ),
+    )
+    parser.add_argument(
+        "--phonemes",
+        default=str(repo_root / "content" / "phonemes.json"),
+        help="Path to phonemes.json.",
+    )
+    parser.add_argument(
+        "--accepted-review-status-uk",
+        action="append",
+        default=None,
+        help=(
+            "Accepted UK review status for this report. May be repeated. "
+            "Defaults to auto_checked and reviewed."
+        ),
+    )
+    parser.add_argument("--json-output", default=None, help="Optional JSON report path.")
+    parser.add_argument(
+        "--markdown-output",
+        default=None,
+        help="Optional Markdown report path. Prints Markdown when no output path is set.",
+    )
+    parser.add_argument("--sample-size", type=int, default=DEFAULT_SAMPLE_SIZE)
+    parser.add_argument("--candidate-limit", type=int, default=DEFAULT_CANDIDATE_LIMIT)
+    args = parser.parse_args()
+
+    word_paths = [
+        Path(path) if Path(path).is_absolute() else repo_root / path
+        for path in (args.words or DEFAULT_WORD_FILES)
+    ]
+    phonemes_path = Path(args.phonemes)
+    if not phonemes_path.is_absolute():
+        phonemes_path = repo_root / phonemes_path
+
+    phoneme_inventory = load_phoneme_inventory(phonemes_path)
+    known_phonemes = set(phoneme_inventory)
+    report = build_uk_ready_report(
+        load_word_sources(word_paths),
+        known_phonemes,
+        phoneme_inventory,
+        load_difficult_contrasts(phonemes_path),
+        accepted_uk_review_statuses=set(
+            args.accepted_review_status_uk or DEFAULT_ACCEPTED_UK_REVIEW_STATUSES
+        ),
+        candidate_limit=args.candidate_limit,
+        sample_size=args.sample_size,
+    )
+    markdown = render_markdown_report(report)
+
+    if args.json_output:
+        output = Path(args.json_output)
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(json.dumps(report, indent=2, ensure_ascii=False) + "\n")
+
+    if args.markdown_output:
+        output = Path(args.markdown_output)
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(markdown + "\n")
+    else:
+        print(markdown)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/test_attempts.py
+++ b/backend/tests/test_attempts.py
@@ -14,14 +14,9 @@ if str(_SCRIPTS) not in sys.path:
     sys.path.insert(0, str(_SCRIPTS))
 
 from import_words import import_words  # noqa: E402
-from app.main import app  # noqa: E402
+
 from app.db import get_connection  # noqa: E402
-from app.services.db_store import (  # noqa: E402
-    create_attempt,
-    count_phonemes,
-    get_session_items,
-    get_word_by_id,
-)
+from app.main import app  # noqa: E402
 from app.services.progress import _compute_mastery, update_phoneme_stats  # noqa: E402
 
 FIXTURES = Path(__file__).resolve().parent / "fixtures"
@@ -120,6 +115,48 @@ class TestAttemptRoute:
         data = resp.json()
         assert data["is_correct"] is False
         assert data["correct_answer"] == item["display_ipa"]
+
+    def test_uk_comparison_ipa_is_not_accepted_for_us_session(self, client, seeded_db):
+        conn = get_connection(seeded_db)
+        conn.execute(
+            """
+            UPDATE words
+            SET ipa_uk = '/ʃɪp-uk/', phoneme_tags_uk = '["/ʃ/", "/ɪ/", "/p/"]'
+            WHERE id = 'ship'
+            """
+        )
+        conn.execute("UPDATE settings SET show_accent_compare = 1 WHERE user_id = 'default'")
+        conn.commit()
+        conn.close()
+
+        today = client.post("/api/practice/next-normal").json()
+        item = next(item for item in today["items"] if item["word_id"] == "ship")
+        assert item["display_ipa"] == "/ʃɪp/"
+        assert item["accent_compare"]["comparison"]["ipa"] == "/ʃɪp-uk/"
+
+        resp = client.post("/api/attempt", json={
+            "session_item_id": item["session_item_id"],
+            "selected_answer": "/ʃɪp-uk/",
+        })
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["is_correct"] is False
+        assert data["correct_answer"] == "/ʃɪp/"
+
+        conn = get_connection(seeded_db)
+        row = conn.execute(
+            """
+            SELECT selected_answer, correct_answer, is_correct, primary_accent
+            FROM attempts
+            WHERE session_item_id = ?
+            """,
+            (item["session_item_id"],),
+        ).fetchone()
+        conn.close()
+        assert row["selected_answer"] == "/ʃɪp-uk/"
+        assert row["correct_answer"] == "/ʃɪp/"
+        assert row["is_correct"] == 0
+        assert row["primary_accent"] == "US"
 
     def test_attempt_persisted(self, client, seeded_db):
         item = _get_first_item(client)
@@ -248,10 +285,11 @@ class TestAttemptRoute:
         ).fetchall()
         conn.close()
 
-        assert [(row["primary_accent"], row["attempt_count"], row["correct_count"]) for row in rows] == [
-            ("UK", 1, 0),
-            ("US", 7, 7),
+        stats_summary = [
+            (row["primary_accent"], row["attempt_count"], row["correct_count"])
+            for row in rows
         ]
+        assert stats_summary == [("UK", 1, 0), ("US", 7, 7)]
 
     def test_last_wrong_at_preserved_after_correct(self, client, seeded_db):
         """After wrong→correct, last_wrong_at should persist, not be cleared."""

--- a/backend/tests/test_attempts.py
+++ b/backend/tests/test_attempts.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
 
@@ -184,6 +185,73 @@ class TestAttemptRoute:
         assert len(rows) > 0
         for r in rows:
             assert r["primary_accent"] == "US"
+
+    def test_uk_session_attempt_updates_only_uk_phoneme_stats(self, client, seeded_db):
+        """A lower-level UK session writes UK stats without touching US stats."""
+        conn = get_connection(seeded_db)
+        session_id = "uk-session"
+        item_id = f"{session_id}_item_001"
+        conn.execute(
+            """
+            INSERT INTO daily_sessions (
+                id, user_id, session_date, primary_accent, status, created_at,
+                group_index, group_type, learner_level
+            ) VALUES (?, 'default', '2026-06-28', 'UK', 'in_progress',
+                '2026-06-28T10:00:00Z', 1, 'normal', 'entry')
+            """,
+            (session_id,),
+        )
+        conn.execute(
+            """
+            INSERT INTO session_items (
+                id, session_id, word_id, order_index, target_phonemes,
+                question_type, status
+            ) VALUES (?, ?, 'ship', 0, ?, 'choose_ipa', 'pending')
+            """,
+            (item_id, session_id, json.dumps(["/ʃ/"])),
+        )
+        conn.execute(
+            """
+            INSERT INTO phoneme_stats (
+                user_id, primary_accent, phoneme_id, attempt_count, correct_count,
+                last_attempt_at, mastery_status
+            ) VALUES ('default', 'US', '/ʃ/', 7, 7, '2026-06-27T10:00:00Z', 'mastered')
+            """
+        )
+        conn.commit()
+        conn.close()
+
+        resp = client.post("/api/attempt", json={
+            "session_item_id": item_id,
+            "selected_answer": "/wrong/",
+        })
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["is_correct"] is False
+        assert data["updated_phonemes"] == [
+            {
+                "phoneme": "/ʃ/",
+                "attempt_count": 1,
+                "correct_count": 0,
+                "mastery_status": "new",
+            }
+        ]
+
+        conn = get_connection(seeded_db)
+        rows = conn.execute(
+            """
+            SELECT primary_accent, attempt_count, correct_count
+            FROM phoneme_stats
+            WHERE user_id = 'default' AND phoneme_id = '/ʃ/'
+            ORDER BY primary_accent
+            """
+        ).fetchall()
+        conn.close()
+
+        assert [(row["primary_accent"], row["attempt_count"], row["correct_count"]) for row in rows] == [
+            ("UK", 1, 0),
+            ("US", 7, 7),
+        ]
 
     def test_last_wrong_at_preserved_after_correct(self, client, seeded_db):
         """After wrong→correct, last_wrong_at should persist, not be cleared."""

--- a/backend/tests/test_progress_api.py
+++ b/backend/tests/test_progress_api.py
@@ -242,6 +242,106 @@ class TestProgressApi:
         assert resp["level_stats"]["entry"]["weak_phonemes"][0]["phoneme"] == "/æ/"
         assert resp["level_stats"]["mid"]["strong_phonemes"][0]["phoneme"] == "/ʃ/"
 
+    def test_progress_defaults_do_not_blend_uk_stats_into_us_path(self, seeded_db):
+        conn = get_connection(seeded_db)
+        today = date.today().isoformat()
+        yesterday = (date.today() - timedelta(days=1)).isoformat()
+        sessions = [
+            ("us-normal", "US", today, "completed", "entry"),
+            ("uk-normal", "UK", today, "in_progress", "mid"),
+            ("uk-streak", "UK", yesterday, "completed", "mid"),
+        ]
+        for session_id, accent, session_date, status, level in sessions:
+            conn.execute(
+                """
+                INSERT INTO daily_sessions (
+                    id, user_id, session_date, primary_accent,
+                    status, created_at, completed_at, group_index,
+                    group_type, learner_level
+                ) VALUES (?, 'default', ?, ?, ?, ?, ?, 1, 'normal', ?)
+                """,
+                (
+                    session_id,
+                    session_date,
+                    accent,
+                    status,
+                    f"{session_date}T10:00:00Z",
+                    f"{session_date}T10:05:00Z" if status == "completed" else None,
+                    level,
+                ),
+            )
+            conn.execute(
+                """
+                INSERT INTO session_items (
+                    id, session_id, word_id, order_index, target_phonemes,
+                    question_type, status
+                ) VALUES (?, ?, 'ship', 0, ?, 'choose_ipa', 'complete')
+                """,
+                (
+                    f"{session_id}-item",
+                    session_id,
+                    json.dumps(["/ʃ/"] if accent == "US" else ["/θ/"]),
+                ),
+            )
+
+        for index in range(3):
+            conn.execute(
+                """
+                INSERT INTO attempts (
+                    id, user_id, session_item_id, word_id, primary_accent,
+                    question_type, selected_answer, correct_answer, is_correct, created_at
+                ) VALUES (?, 'default', 'us-normal-item', 'ship', 'US',
+                    'choose_ipa', '/ʃɪp/', '/ʃɪp/', 1, ?)
+                """,
+                (f"us-attempt-{index}", f"{today}T11:0{index}:00Z"),
+            )
+            conn.execute(
+                """
+                INSERT INTO attempts (
+                    id, user_id, session_item_id, word_id, primary_accent,
+                    question_type, selected_answer, correct_answer, is_correct, created_at
+                ) VALUES (?, 'default', 'uk-normal-item', 'ship', 'UK',
+                    'choose_ipa', '/wrong/', '/ʃɪp/', 0, ?)
+                """,
+                (f"uk-attempt-{index}", f"{today}T12:0{index}:00Z"),
+            )
+
+        conn.execute(
+            """
+            INSERT INTO phoneme_stats (
+                user_id, primary_accent, phoneme_id, attempt_count, correct_count,
+                last_attempt_at, mastery_status
+            ) VALUES ('default', 'US', '/ʃ/', 3, 3, ?, 'learning')
+            """,
+            (f"{today}T11:02:00Z",),
+        )
+        conn.execute(
+            """
+            INSERT INTO phoneme_stats (
+                user_id, primary_accent, phoneme_id, attempt_count, correct_count,
+                last_attempt_at, mastery_status
+            ) VALUES ('default', 'UK', '/θ/', 3, 0, ?, 'weak')
+            """,
+            (f"{today}T12:02:00Z",),
+        )
+        conn.commit()
+
+        resp = build_progress_response(conn)
+        conn.close()
+
+        assert resp["today_status"] == "completed"
+        assert resp["today_completed"] is True
+        assert resp["streak_days"] == 0
+        assert resp["total_attempts"] == 3
+        assert resp["total_sessions"] == 1
+        assert resp["total_normal_groups"] == 1
+        assert resp["level_stats"]["entry"]["normal_groups"] == 1
+        assert resp["level_stats"]["mid"]["normal_groups"] == 0
+        assert resp["level_stats"]["entry"]["attempts"] == 3
+        assert resp["level_stats"]["mid"]["attempts"] == 0
+        assert resp["weak_phonemes"] == []
+        assert resp["strong_phonemes"][0]["phoneme"] == "/ʃ/"
+
 
 # ---------------------------------------------------------------------------
 # Streak

--- a/backend/tests/test_today_persistence.py
+++ b/backend/tests/test_today_persistence.py
@@ -407,6 +407,140 @@ class TestTodayPersistence:
             ("US", len(data["updated_phonemes"]))
         ]
 
+    def test_today_exposes_guided_target_phoneme_options(self, client, seeded_db):
+        data = client.get("/api/today").json()
+
+        options = data["target_phoneme_options"]
+        option_ids = {option["phoneme"] for option in options}
+        assert "/ʃ/" in option_ids
+        assert "/æ/" in option_ids
+        assert all(option["candidate_count"] > 0 for option in options)
+
+    def test_target_phoneme_group_uses_selected_approved_us_sound(
+        self, client, seeded_db
+    ):
+        data = client.post("/api/practice/target-phoneme", json={
+            "phoneme": "/ʃ/",
+        }).json()
+
+        assert "error" not in data, data
+        assert data["group_type"] == "target_phoneme"
+        assert data["origin"] == "target_phoneme_start"
+        assert data["source_scope"] == "specialty_target_phoneme"
+        assert data["focus_phonemes"] == ["/ʃ/"]
+        assert data["primary_accent"] == "US"
+        assert data["action_label"].startswith("Start Sound Practice Group")
+        assert data["items"]
+        assert all("/ʃ/" in item["target_phonemes"] for item in data["items"])
+
+        conn = get_connection(seeded_db)
+        row = conn.execute(
+            """
+            SELECT group_type, source_scope, focus_phonemes
+            FROM daily_sessions
+            WHERE id = ?
+            """,
+            (data["session_id"],),
+        ).fetchone()
+        item_rows = conn.execute(
+            """
+            SELECT target_phonemes
+            FROM session_items
+            WHERE session_id = ?
+            ORDER BY order_index
+            """,
+            (data["session_id"],),
+        ).fetchall()
+        conn.close()
+
+        assert row["group_type"] == "target_phoneme"
+        assert row["source_scope"] == "specialty_target_phoneme"
+        assert json.loads(row["focus_phonemes"]) == ["/ʃ/"]
+        assert all("/ʃ/" in json.loads(item["target_phonemes"]) for item in item_rows)
+
+    def test_target_phoneme_group_resumes_same_selected_sound(self, client, seeded_db):
+        first = client.post("/api/practice/target-phoneme", json={
+            "phoneme": "/ʃ/",
+        }).json()
+        second = client.post("/api/practice/target-phoneme", json={
+            "phoneme": "/ʃ/",
+        }).json()
+
+        assert second["origin"] == "target_phoneme_resume"
+        assert second["session_id"] == first["session_id"]
+        assert second["focus_phonemes"] == ["/ʃ/"]
+
+    def test_target_phoneme_empty_for_unapproved_or_empty_sound(
+        self, client, seeded_db
+    ):
+        data = client.post("/api/practice/target-phoneme", json={
+            "phoneme": "/not-approved/",
+        }).json()
+
+        assert data["group_type"] == "target_phoneme"
+        assert data["status"] == "empty"
+        assert data["origin"] == "target_phoneme_empty"
+        assert data["items"] == []
+        assert "selected American sound" in data["detail"]
+
+        conn = get_connection(seeded_db)
+        count = conn.execute(
+            "SELECT COUNT(*) AS cnt FROM daily_sessions WHERE group_type = 'target_phoneme'"
+        ).fetchone()["cnt"]
+        conn.close()
+        assert count == 0
+
+    def test_target_phoneme_rejects_missing_payload(self, client):
+        resp = client.post("/api/practice/target-phoneme", json={
+            "phoneme": "",
+        })
+        assert resp.status_code == 400
+        assert resp.json()["detail"]["error"] == "INVALID_TARGET_PHONEME"
+
+    def test_target_phoneme_attempt_reuses_us_attempt_and_stats_path(
+        self, client, seeded_db
+    ):
+        group = client.post("/api/practice/target-phoneme", json={
+            "phoneme": "/ʃ/",
+        }).json()
+        item = group["items"][0]
+        resp = client.post("/api/attempt", json={
+            "session_item_id": item["session_item_id"],
+            "selected_answer": item["display_ipa"],
+        })
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["is_correct"] is True
+        assert data["correct_answer"] == item["display_ipa"]
+        assert data["updated_phonemes"]
+
+        conn = get_connection(seeded_db)
+        attempt = conn.execute(
+            """
+            SELECT primary_accent, question_type, correct_answer, is_correct
+            FROM attempts
+            WHERE session_item_id = ?
+            """,
+            (item["session_item_id"],),
+        ).fetchone()
+        stats = conn.execute(
+            """
+            SELECT primary_accent, COUNT(*) AS cnt
+            FROM phoneme_stats
+            GROUP BY primary_accent
+            """
+        ).fetchall()
+        conn.close()
+        assert dict(attempt) == {
+            "primary_accent": "US",
+            "question_type": "choose_ipa",
+            "correct_answer": item["display_ipa"],
+            "is_correct": 1,
+        }
+        assert [(row["primary_accent"], row["cnt"]) for row in stats] == [
+            ("US", len(data["updated_phonemes"]))
+        ]
+
     def test_disabled_words_not_scheduled(self, client, seeded_db):
         # Mark one word as disabled and verify it's excluded.
         conn = get_connection(seeded_db)

--- a/backend/tests/test_today_persistence.py
+++ b/backend/tests/test_today_persistence.py
@@ -305,6 +305,108 @@ class TestTodayPersistence:
         }
         assert "accent_compare" not in cat
 
+    def test_minimal_pair_group_uses_explicit_pair_metadata(self, client, seeded_db):
+        data = client.post("/api/practice/minimal-pairs").json()
+        assert "error" not in data, data
+        assert data["group_type"] == "minimal_pair"
+        assert data["origin"] == "minimal_pair_start"
+        assert data["source_scope"] == "specialty_minimal_pair"
+        assert data["primary_accent"] == "US"
+        assert data["action_label"].startswith("Start Sound Compare Group")
+        assert [item["word_id"] for item in data["items"]] == ["sheep", "ship"]
+        assert [item["display_ipa"] for item in data["items"]] == ["/ʃiːp/", "/ʃɪp/"]
+
+        conn = get_connection(seeded_db)
+        row = conn.execute(
+            "SELECT group_type FROM daily_sessions WHERE id = ?",
+            (data["session_id"],),
+        ).fetchone()
+        item_rows = conn.execute(
+            """
+            SELECT word_id, target_phonemes
+            FROM session_items
+            WHERE session_id = ?
+            ORDER BY order_index
+            """,
+            (data["session_id"],),
+        ).fetchall()
+        conn.close()
+
+        assert row["group_type"] == "minimal_pair"
+        assert [row["word_id"] for row in item_rows] == ["sheep", "ship"]
+        assert json.loads(item_rows[0]["target_phonemes"]) == ["/ʃ/", "/iː/", "/p/"]
+
+    def test_minimal_pair_group_resumes_same_day_active_group(self, client, seeded_db):
+        first = client.post("/api/practice/minimal-pairs").json()
+        second = client.post("/api/practice/minimal-pairs").json()
+        assert second["origin"] == "minimal_pair_resume"
+        assert second["session_id"] == first["session_id"]
+        assert [item["session_item_id"] for item in second["items"]] == [
+            item["session_item_id"] for item in first["items"]
+        ]
+
+    def test_minimal_pair_empty_when_metadata_insufficient(self, client, seeded_db):
+        conn = get_connection(seeded_db)
+        conn.execute("UPDATE words SET minimal_pair_group = NULL")
+        conn.commit()
+        conn.close()
+
+        data = client.post("/api/practice/minimal-pairs").json()
+        assert data["group_type"] == "minimal_pair"
+        assert data["status"] == "empty"
+        assert data["origin"] == "minimal_pair_empty"
+        assert data["items"] == []
+        assert "at least two safe words" in data["detail"]
+
+        conn = get_connection(seeded_db)
+        count = conn.execute(
+            "SELECT COUNT(*) AS cnt FROM daily_sessions WHERE group_type = 'minimal_pair'"
+        ).fetchone()["cnt"]
+        conn.close()
+        assert count == 0
+
+    def test_minimal_pair_attempt_reuses_us_attempt_and_stats_path(
+        self, client, seeded_db
+    ):
+        group = client.post("/api/practice/minimal-pairs").json()
+        item = group["items"][0]
+        resp = client.post("/api/attempt", json={
+            "session_item_id": item["session_item_id"],
+            "selected_answer": item["display_ipa"],
+        })
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["is_correct"] is True
+        assert data["correct_answer"] == item["display_ipa"]
+        assert data["updated_phonemes"]
+
+        conn = get_connection(seeded_db)
+        attempt = conn.execute(
+            """
+            SELECT primary_accent, question_type, correct_answer, is_correct
+            FROM attempts
+            WHERE session_item_id = ?
+            """,
+            (item["session_item_id"],),
+        ).fetchone()
+        stats = conn.execute(
+            """
+            SELECT primary_accent, COUNT(*) AS cnt
+            FROM phoneme_stats
+            GROUP BY primary_accent
+            """
+        ).fetchall()
+        conn.close()
+        assert dict(attempt) == {
+            "primary_accent": "US",
+            "question_type": "choose_ipa",
+            "correct_answer": item["display_ipa"],
+            "is_correct": 1,
+        }
+        assert [(row["primary_accent"], row["cnt"]) for row in stats] == [
+            ("US", len(data["updated_phonemes"]))
+        ]
+
     def test_disabled_words_not_scheduled(self, client, seeded_db):
         # Mark one word as disabled and verify it's excluded.
         conn = get_connection(seeded_db)

--- a/backend/tests/test_today_persistence.py
+++ b/backend/tests/test_today_persistence.py
@@ -246,6 +246,65 @@ class TestTodayPersistence:
             # display_ipa should match ipa_us
             assert item["display_ipa"] == w.ipa_us
 
+    def test_accent_compare_hidden_when_setting_off(self, client, seeded_db):
+        conn = get_connection(seeded_db)
+        conn.execute(
+            """
+            UPDATE words
+            SET ipa_uk = '/ʃɪp-uk/', phoneme_tags_uk = '["/ʃ/", "/ɪ/", "/p/"]'
+            WHERE id = 'ship'
+            """
+        )
+        conn.execute("UPDATE settings SET show_accent_compare = 0 WHERE user_id = 'default'")
+        conn.commit()
+        conn.close()
+
+        data = client.post("/api/practice/next-normal").json()
+        assert all("accent_compare" not in item for item in data["items"])
+        ship = next(item for item in data["items"] if item["word_id"] == "ship")
+        assert ship["display_ipa"] == "/ʃɪp/"
+        assert "/ʃɪp-uk/" not in ship["question"]["choices"]
+
+    def test_accent_compare_shown_for_eligible_rows_only(self, client, seeded_db):
+        conn = get_connection(seeded_db)
+        conn.execute(
+            """
+            UPDATE words
+            SET ipa_uk = '/ʃɪp-uk/', phoneme_tags_uk = '["/ʃ/", "/ɪ/", "/p/"]'
+            WHERE id = 'ship'
+            """
+        )
+        conn.execute("UPDATE words SET phoneme_tags_uk = NULL WHERE id = 'cat'")
+        conn.execute("UPDATE settings SET show_accent_compare = 1 WHERE user_id = 'default'")
+        conn.commit()
+        conn.close()
+
+        data = client.post("/api/practice/next-normal").json()
+        ship = next(item for item in data["items"] if item["word_id"] == "ship")
+        cat = next(item for item in data["items"] if item["word_id"] == "cat")
+
+        assert ship["display_ipa"] == "/ʃɪp/"
+        assert ship["target_phonemes"] == ["/ʃ/", "/ɪ/", "/p/"]
+        assert ship["accent_compare"] == {
+            "enabled": True,
+            "primary": {
+                "accent": "US",
+                "label": "American sound",
+                "ipa": "/ʃɪp/",
+            },
+            "comparison": {
+                "accent": "UK",
+                "label": "British note",
+                "ipa": "/ʃɪp-uk/",
+                "phoneme_tags": ["/ʃ/", "/ɪ/", "/p/"],
+                "review_note": (
+                    "Display-only comparison. Your answer is still graded against "
+                    "the American IPA."
+                ),
+            },
+        }
+        assert "accent_compare" not in cat
+
     def test_disabled_words_not_scheduled(self, client, seeded_db):
         # Mark one word as disabled and verify it's excluded.
         conn = get_connection(seeded_db)

--- a/backend/tests/test_uk_ready_content_report.py
+++ b/backend/tests/test_uk_ready_content_report.py
@@ -1,0 +1,212 @@
+"""Tests for the M9 UK-ready content report."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from report_uk_ready_content import (  # noqa: E402
+    build_uk_ready_report,
+    render_markdown_report,
+)
+from validate_content import load_phoneme_inventory  # noqa: E402
+
+PHONEMES_PATH = Path(__file__).resolve().parent.parent.parent / "content" / "phonemes.json"
+
+
+def _inventory():
+    inventory = load_phoneme_inventory(PHONEMES_PATH)
+    return inventory, set(inventory)
+
+
+def _row(
+    word_id,
+    word,
+    ipa_us,
+    ipa_uk,
+    tags_us,
+    tags_uk,
+    review_status_uk="reviewed",
+    content_status="core_selected",
+):
+    return {
+        "word_id": word_id,
+        "word": word,
+        "level": "beginner",
+        "ipa_us": ipa_us,
+        "ipa_uk": ipa_uk,
+        "phoneme_tags_us": tags_us,
+        "phoneme_tags_uk": tags_uk,
+        "meaning_zh": word,
+        "source_ipa_us": "open-dict-data/ipa-dict en_US",
+        "source_ipa_uk": "open-dict-data/ipa-dict en_UK",
+        "license_notes": "open-data",
+        "review_status_uk": review_status_uk,
+        "content_status": content_status,
+        "_source_file": "fixture.json",
+    }
+
+
+def test_uk_ready_report_filters_to_m9_eligible_rows():
+    inventory, known = _inventory()
+    rows = [
+        _row(
+            "ship",
+            "ship",
+            "/ʃɪp/",
+            "/ʃɪp/",
+            ["/ʃ/", "/ɪ/", "/p/"],
+            ["/ʃ/", "/ɪ/", "/p/"],
+        ),
+        _row(
+            "draft",
+            "draft",
+            "/dræft/",
+            "/drɑːft/",
+            ["/d/", "/r/", "/æ/", "/f/", "/t/"],
+            ["/d/", "/r/", "/ɑ/", "/f/", "/t/"],
+            review_status_uk="draft",
+        ),
+        _row(
+            "missing_uk",
+            "missing",
+            "/mɪsɪŋ/",
+            "",
+            ["/m/", "/ɪ/", "/s/", "/ŋ/"],
+            [],
+        ),
+        _row(
+            "disabled",
+            "disabled",
+            "/dɪsˈeɪbəld/",
+            "/dɪsˈeɪbəld/",
+            ["/d/", "/ɪ/", "/s/", "/eɪ/", "/b/", "/l/", "/d/"],
+            ["/d/", "/ɪ/", "/s/", "/eɪ/", "/b/", "/l/", "/d/"],
+            content_status="disabled",
+        ),
+        _row(
+            "unsupported",
+            "unsupported",
+            "/ʃɪp/",
+            "/ʃɪp/",
+            ["/ʃ/", "/ɪ/", "/p/"],
+            ["/ɸ/"],
+        ),
+    ]
+
+    report = build_uk_ready_report(
+        rows,
+        known,
+        inventory,
+        difficult_contrasts=[],
+        accepted_uk_review_statuses={"reviewed"},
+    )
+
+    assert report["totals"]["eligible_rows"] == 1
+    assert report["eligible_word_ids"] == ["ship"]
+    assert report["totals"]["missing_uk_ipa_count"] == 1
+    assert report["totals"]["missing_uk_tags_count"] == 1
+    assert report["totals"]["unsupported_uk_symbol_count"] == 1
+    assert report["unsupported_uk_symbols"] == {"/ɸ/": 1}
+    assert len(report["excluded_rows_sample"]) == 4
+
+
+def test_uk_ready_report_includes_required_sample_table_fields():
+    inventory, known = _inventory()
+    rows = [
+        _row(
+            "tomato",
+            "tomato",
+            "/təˈmeɪtoʊ/",
+            "/təmˈɑːtəʊ/",
+            ["/t/", "/ə/", "/m/", "/eɪ/", "/t/", "/oʊ/"],
+            ["/t/", "/ə/", "/m/", "/ɑ/", "/t/", "/ʊ/"],
+            review_status_uk="auto_checked",
+        ),
+    ]
+
+    report = build_uk_ready_report(
+        rows,
+        known,
+        inventory,
+        difficult_contrasts=[],
+        accepted_uk_review_statuses={"auto_checked", "reviewed"},
+    )
+    sample = report["sample_table"][0]
+    markdown = render_markdown_report(report)
+
+    assert sample["word"] == "tomato"
+    assert sample["us_ipa"] == "/təˈmeɪtoʊ/"
+    assert sample["uk_ipa"] == "/təmˈɑːtəʊ/"
+    assert "reason_included" in sample
+    assert "caveat" in sample
+    assert "| word | US IPA | UK IPA | reason included | caveat |" in markdown
+    assert "Architect pronunciation acceptance pending" in markdown
+
+
+def test_uk_ready_report_finds_mechanical_minimal_pair_candidates():
+    inventory, known = _inventory()
+    contrasts = [{"pair": ["/iː/", "/ɪ/"], "description_zh": "sheep/ship"}]
+    rows = [
+        _row(
+            "ship",
+            "ship",
+            "/ʃɪp/",
+            "/ʃɪp/",
+            ["/ʃ/", "/ɪ/", "/p/"],
+            ["/ʃ/", "/ɪ/", "/p/"],
+        ),
+        _row(
+            "sheep",
+            "sheep",
+            "/ʃiːp/",
+            "/ʃiːp/",
+            ["/ʃ/", "/iː/", "/p/"],
+            ["/ʃ/", "/iː/", "/p/"],
+        ),
+    ]
+
+    report = build_uk_ready_report(rows, known, inventory, contrasts)
+
+    assert report["totals"]["minimal_pair_candidate_count"] == 1
+    candidate = report["minimal_pair_candidates"][0]
+    assert {candidate["left_word"], candidate["right_word"]} == {"ship", "sheep"}
+    assert candidate["basis"] == "one phoneme-tag difference in phoneme_tags_us"
+
+
+def test_uk_ready_report_counts_target_phoneme_coverage_for_us_and_uk_tags():
+    inventory, known = _inventory()
+    rows = [
+        _row(
+            "ship",
+            "ship",
+            "/ʃɪp/",
+            "/ʃɪp/",
+            ["/ʃ/", "/ɪ/", "/p/"],
+            ["/ʃ/", "/ɪ/", "/p/"],
+        ),
+        _row(
+            "tomato",
+            "tomato",
+            "/təˈmeɪtoʊ/",
+            "/təmˈɑːtəʊ/",
+            ["/t/", "/ə/", "/m/", "/eɪ/", "/t/", "/oʊ/"],
+            ["/t/", "/ə/", "/m/", "/ɑ/", "/t/", "/ʊ/"],
+        ),
+    ]
+
+    report = build_uk_ready_report(rows, known, inventory, difficult_contrasts=[])
+    coverage = {
+        row["phoneme"]: row
+        for row in report["target_phoneme_candidate_coverage"]
+    }
+
+    assert coverage["/ʃ/"]["eligible_words_us"] == 1
+    assert coverage["/ʃ/"]["eligible_words_uk"] == 1
+    assert coverage["/oʊ/"]["eligible_words_us"] == 1
+    assert coverage["/oʊ/"]["eligible_words_uk"] == 0
+    assert coverage["/ʊ/"]["eligible_words_us"] == 0
+    assert coverage["/ʊ/"]["eligible_words_uk"] == 1

--- a/docs/00-design-index.md
+++ b/docs/00-design-index.md
@@ -44,6 +44,9 @@
 10. [UX Research and Practice Experience Optimization](10-ux-research-and-optimization.md)
     定义面向青少年学习者的可重复 UX 研究、视觉探索、设计审查和浏览器走查方法，用于 M10 以及未来项目复用。
 
+11. [M9 UK Accent Compare and Specialty Practice Contract](11-m9-accent-specialty-contract.md)
+    定义 M9 的 UK 对照、主口音、判题/统计、音频、specialty practice 与下游质量 gate。
+
 ## 工程随笔
 
 1. [Vibe Coding 中的老登式多 Agent 调度经历](anecdote_Reinventing_agent_scheduler.md)

--- a/docs/00-design-index.md
+++ b/docs/00-design-index.md
@@ -47,6 +47,9 @@
 11. [M9 UK Accent Compare and Specialty Practice Contract](11-m9-accent-specialty-contract.md)
     定义 M9 的 UK 对照、主口音、判题/统计、音频、specialty practice 与下游质量 gate。
 
+12. [M9 UK-Ready Content Subset and Accent Coverage Report](12-m9-uk-ready-content-report.md)
+    记录 #196 的 UK-ready 内容子集、口音差异、minimal-pair 候选、target-phoneme 覆盖与内容质量 caveat。
+
 ## 工程随笔
 
 1. [Vibe Coding 中的老登式多 Agent 调度经历](anecdote_Reinventing_agent_scheduler.md)

--- a/docs/11-m9-accent-specialty-contract.md
+++ b/docs/11-m9-accent-specialty-contract.md
@@ -355,4 +355,3 @@ follow-up gates, if any
 
 Final Epic integration to `main` remains Architect/user gated if subjective
 accent quality, learner comprehension, or visual fit remains unresolved.
-

--- a/docs/11-m9-accent-specialty-contract.md
+++ b/docs/11-m9-accent-specialty-contract.md
@@ -1,0 +1,358 @@
+# M9 UK Accent Compare and Specialty Practice Contract
+
+This document is the accepted Architect contract for Epic #28 / M9. It defines
+the product, data, API, stats, audio, and learner-facing boundaries before any
+downstream implementation issues are released.
+
+## Contract Decision
+
+M9 keeps UK pronunciation as comparison-only support data. It does not expose UK
+as a learner-selectable `primary_accent`.
+
+The learner's graded practice path remains US-first in M9:
+
+```text
+primary_accent = "US"
+question correct answer = ipa_us
+target_phonemes = phoneme_tags_us
+audio_url = audio_us
+phoneme_stats scope = ("default", "US", phoneme_id)
+```
+
+`show_accent_compare` may reveal reviewed UK IPA/tags as a labeled comparison,
+but learner-facing copy must not imply that UK answers are accepted for grading.
+The comparison is a pronunciation note, not a second answer key.
+
+Rationale:
+
+1. Tiny IPA is still a beginner, teen-facing learning app. M9 should avoid
+   making the main answer path ambiguous.
+2. Current runtime already models `primary_accent` across sessions, attempts,
+   scheduling, and stats, but UK content/audio quality is not yet accepted as a
+   production practice path.
+3. Comparison-only UK support lets the project validate reviewed UK content and
+   learner-facing presentation before expanding grading, audio, and progress UI.
+
+## Accent Field Semantics
+
+Source content continues to carry accent-specific fields:
+
+```text
+ipa_us              required for practice-ready words
+phoneme_tags_us     required for practice-ready words
+audio_us            required for stable production playback where available
+
+ipa_uk              optional in general content, required for UK comparison rows
+phoneme_tags_uk     optional in general content, required for UK comparison rows
+audio_uk            optional; not required for M9 comparison display
+review_status_uk    required by downstream content report before display
+```
+
+For M9 comparison eligibility, a word is UK-comparison-ready only when all of the
+following are true:
+
+```text
+ipa_us is present
+ipa_uk is present
+phoneme_tags_us is present
+phoneme_tags_uk is present
+review_status_uk is accepted by the M9 content gate
+content_status is not disabled
+```
+
+Missing or unreviewed UK fields must result in no comparison row for that word.
+They must not produce empty cards, placeholder IPA, or degraded grading.
+
+## Settings Contract
+
+`show_accent_compare` is the only M9 user-facing switch for UK behavior.
+
+| Setting | M9 behavior |
+| --- | --- |
+| `show_accent_compare = false` | Hide all UK comparison UI. Practice behaves as the current US-first path. |
+| `show_accent_compare = true` | Show UK comparison only for eligible reviewed words. Grading remains US. |
+| `primary_accent = "US"` | Required runtime learner path for M9. |
+| `primary_accent = "UK"` | May remain accepted by lower-level APIs for existing model completeness, but must not be exposed as an M9 learner setting. |
+
+If a backend or local fixture already allows `primary_accent = "UK"`, M9 may add
+regression tests for isolation, but UI must not turn that into a supported
+learner workflow.
+
+## Practice Response Contract
+
+The existing `GET /api/today` item shape keeps its current US-first fields:
+
+```json
+{
+  "display_ipa": "/ship-us/",
+  "audio_url": "/audio/us/ship.mp3",
+  "target_phonemes": ["/.../"],
+  "question": {
+    "correct_answer": "/ship-us/"
+  }
+}
+```
+
+Downstream UK comparison work may add a separate optional field, for example:
+
+```json
+{
+  "accent_compare": {
+    "enabled": true,
+    "primary": {
+      "accent": "US",
+      "ipa": "/.../",
+      "label": "American"
+    },
+    "comparison": {
+      "accent": "UK",
+      "ipa": "/.../",
+      "label": "British",
+      "phoneme_tags": ["/.../"],
+      "review_note": "Reviewed for M9 comparison"
+    }
+  }
+}
+```
+
+This field is optional and display-only. It must not alter:
+
+```text
+question.options
+question.correct_answer
+display_ipa
+audio_url
+target_phonemes
+attempt.correct_answer
+attempt.primary_accent
+phoneme_stats primary_accent
+```
+
+The frontend may render the comparison as a compact note near the revealed word
+or feedback summary. It should use beginner-friendly labels such as
+`American sound` and `British note`, not expert-only labels that make a child
+feel they chose the wrong system.
+
+## Question, Grading, and Stats Contract
+
+All M9 attempts continue through the existing path:
+
+```text
+session_items -> POST /api/attempt -> attempts -> phoneme_stats
+```
+
+The session's `primary_accent` remains the single source of truth for grading:
+
+```text
+correct_answer = ipa_us when session.primary_accent == "US"
+correct_answer = ipa_uk only in lower-level tests or future gated work
+```
+
+M9 implementation must not introduce:
+
+```text
+parallel attempt tables
+parallel specialty stats tables
+frontend-only grading
+blended US/UK weak or strong phoneme lists
+```
+
+Accent-specific stats separation is still a blocking Epic acceptance criterion.
+Even though UK is not exposed as an M9 learner path, regression tests must prove
+that if a UK session exists, its attempts update:
+
+```text
+phoneme_stats(user_id, "UK", phoneme_id)
+```
+
+and do not update or read:
+
+```text
+phoneme_stats(user_id, "US", phoneme_id)
+```
+
+Progress defaults to the current learner path. In M9 production UI this means US
+progress. No M9 Progress view may blend US and UK weak/strong phonemes unless a
+future contract defines an explicit comparison mode.
+
+## Audio Contract
+
+M9 UK comparison does not require UK audio playback.
+
+Audio behavior remains:
+
+```text
+practice audio_url = audio_us for US sessions
+recorded/static audio tries first
+browser speech fallback remains a confidence/fallback state
+no runtime cloud TTS
+```
+
+If `audio_uk` exists and is reviewed, a downstream UI may show it only as an
+optional comparison affordance after Architect acceptance. It must not replace
+the main practice audio, and it must have clear unavailable/fallback states.
+
+## Specialty Practice Contract
+
+Specialty practice reuses the existing group/session/attempt/stat architecture.
+It adds new group semantics, not new scoring infrastructure.
+
+Approved M9 specialty group types:
+
+```text
+minimal_pair
+target_phoneme
+```
+
+Both group types must use:
+
+```text
+daily_sessions.group_type
+session_items
+attempts
+phoneme_stats
+POST /api/attempt
+```
+
+Both must preserve `primary_accent` on the session and attempt, and must select
+words/tags from the active session accent. For M9 production UI, that active
+accent is US.
+
+### Relationship to Existing Review and Focus
+
+| Flow | Source | Learner meaning | M9 boundary |
+| --- | --- | --- | --- |
+| `normal` | Scheduler-selected level pool | Regular practice group | Unchanged |
+| `mistake_review` current group | Misses from the just-completed group | Fix this group's misses | Not specialty practice |
+| `mistake_review` recent | Recent wrong attempts across groups | Review recent mistakes | Not specialty practice |
+| `weak_focus` | Weak phonemes from `phoneme_stats` or guided focus | Remedial focus on weak sound | Existing recovery/focus flow |
+| `minimal_pair` | Reviewed minimal-pair metadata | Compare two easily confused sounds | New M9 specialty |
+| `target_phoneme` | Guided selected phoneme or approved specialty list | Practice one chosen sound intentionally | New M9 specialty |
+
+`target_phoneme` may share scheduler weighting code with `weak_focus`, but its
+product meaning is different. `weak_focus` is remedial and stat-driven;
+`target_phoneme` is learner/teacher-directed specialty practice. If downstream
+design cannot keep that distinction clear, `target_phoneme` must be delayed or
+folded back into `weak_focus` by Architect decision.
+
+### Minimal-Pair Requirements
+
+Minimal-pair practice requires reviewed metadata before runtime exposure:
+
+```text
+minimal_pair_group
+target contrast phonemes
+candidate words
+reason included
+child-safety/content caveat
+```
+
+The group may include both words from a pair or a small balanced set from the
+same contrast. Empty or insufficient candidate states must be learner-safe and
+must not create an unanswerable group.
+
+### Target-Phoneme Requirements
+
+Target-phoneme practice must be launched from a guided selection source:
+
+```text
+Progress weak sounds
+approved specialty sound list
+Architect-approved learner-facing entry point
+```
+
+It must not require children to type raw IPA. Raw/manual IPA entry remains
+advanced tooling, not the primary learner path.
+
+## UK Content Quality Gate
+
+The first downstream content issue must produce a reviewed UK-ready subset and a
+human-readable sample table. The sample must include at least:
+
+| word | US IPA | UK IPA | reason included | caveat |
+| --- | --- | --- | --- | --- |
+| ship | `/.../` | `/.../` | stable beginner word; useful contrast | example row only |
+
+The real report must also include:
+
+```text
+source and license metadata
+review_status_uk for displayed rows
+missing UK IPA/tags count
+unsupported UK symbol count
+accent-difference candidates
+minimal-pair candidates
+target-phoneme candidate coverage
+known caveats or excluded ambiguous words
+```
+
+Architect/content acceptance is required before UK comparison UI depends on the
+subset. Reviewer verification covers report mechanics; Architect acceptance
+covers pronunciation/content quality fit.
+
+## Learner-Facing Copy and UX Gates
+
+M9 UI copy must keep three ideas separate:
+
+```text
+This is the answer for this practice.
+This is a British pronunciation note.
+This is a specialty practice group.
+```
+
+Required copy constraints:
+
+1. Do not label UK IPA as another correct answer in M9.
+2. Do not show UK comparison when it is unavailable or unreviewed.
+3. Do not use raw internal group names (`minimal_pair`, `target_phoneme`) as the
+   only learner-facing labels.
+4. Do not make specialty practice look like mistake recovery.
+5. Keep mobile density readable; comparison notes should be compact and optional.
+
+Architect acceptance is required for learner-facing comparison/specialty entry
+copy. Human trial is required only if the final M9 readiness review finds that
+the comparison or specialty entry point is visually confusing or pronunciation
+quality remains subjective.
+
+## Downstream Release Plan
+
+After this contract is accepted, release only the foundational issues first:
+
+1. UK-ready content subset and accent coverage report.
+2. Accent-specific stats separation and regression checks.
+
+Those may proceed in parallel after issue contracts are created because they
+touch different risk areas. UK comparison UI, minimal-pair practice, and
+target-phoneme practice remain blocked until the relevant content and stats gates
+are accepted.
+
+| Downstream area | Depends on | Gate |
+| --- | --- | --- |
+| UK content subset | This contract | Architect/content quality acceptance |
+| Stats separation checks | This contract | Reviewer objective verification |
+| UK comparison UI/API | Content subset + stats checks | Architect copy/UX acceptance |
+| Minimal-pair practice | Content subset + stats checks | Architect specialty entry acceptance |
+| Target-phoneme practice | Content subset + shared specialty semantics | Architect overlap decision with `weak_focus` |
+| Final M9 readiness | All accepted child work | Architect/user gate if subjective trial remains |
+
+## Final M9 Readiness Evidence
+
+The final M9 readiness issue must publish a user-facing note before Epic closure
+or final `main` integration. It must include:
+
+```text
+completed capability summary
+changed learner behavior
+trial path for UK comparison off/on
+trial path for each accepted specialty practice entry
+desktop or mobile screenshots/browser evidence
+verification commands
+exclusions
+residual pronunciation/content risks
+whether human trial is required
+follow-up gates, if any
+```
+
+Final Epic integration to `main` remains Architect/user gated if subjective
+accent quality, learner comprehension, or visual fit remains unresolved.
+

--- a/docs/12-m9-uk-ready-content-report.md
+++ b/docs/12-m9-uk-ready-content-report.md
@@ -1,0 +1,120 @@
+# M9 UK-Ready Content Subset and Accent Coverage Report
+
+This is the checked-in evidence artifact for issue #196. It is a content/report snapshot only; it does not enable UK grading, UK primary accent selection, UK comparison UI/API, minimal-pair runtime, or target-phoneme runtime behavior.
+
+## Gate
+
+- Accepted `review_status_uk` values for this report: auto_checked, reviewed
+- Content-quality acceptance: Architect/content acceptance required.
+- UK comparison remains display-only in later M9 work; US grading remains unchanged.
+
+## Summary
+
+- Source rows: 1300
+- Eligible UK-ready rows: 1215
+- Excluded rows: 85
+- Missing UK IPA count: 85
+- Missing UK phoneme tags count: 85
+- Unsupported UK symbol count: 0
+- Accent-difference candidates: 1170
+- Minimal-pair candidates: 17
+- Target phonemes covered by US tags: 41
+- Target phonemes covered by UK tags: 38
+
+## Sample Table
+
+| word | US IPA | UK IPA | reason included | caveat |
+| --- | --- | --- | --- | --- |
+| about | /əˈbaʊt/ | /ɐbˈaʊt/ | IPA differs; phoneme tags differ | auto_checked; Architect pronunciation acceptance pending; no UK audio required for M9 comparison |
+| academic | /ˌækəˈdɛmɪk/ | /ˌækədˈɛmɪk/ | IPA differs | auto_checked; Architect pronunciation acceptance pending; no UK audio required for M9 comparison |
+| academy | /əˈkædəmi/ | /ɐkˈædəmi/ | IPA differs; phoneme tags differ | auto_checked; Architect pronunciation acceptance pending; no UK audio required for M9 comparison |
+| accepted | /ækˈsɛptɪd/ | /ɐksˈɛptɪd/ | IPA differs; phoneme tags differ | auto_checked; Architect pronunciation acceptance pending; no UK audio required for M9 comparison |
+| activity | /ækˈtɪvəti/ | /æktˈɪvɪti/ | IPA differs; phoneme tags differ | auto_checked; Architect pronunciation acceptance pending; no UK audio required for M9 comparison |
+| advice | /ædˈvaɪs/ | /ɐdvˈaɪs/ | IPA differs; phoneme tags differ | auto_checked; Architect pronunciation acceptance pending; no UK audio required for M9 comparison |
+| ago | /əˈɡoʊ/ | /ɐɡˈəʊ/ | IPA differs; phoneme tags differ | auto_checked; Architect pronunciation acceptance pending; no UK audio required for M9 comparison |
+| anxiety | /æŋˈzaɪəti/ | /æŋzˈaɪəti/ | IPA differs | auto_checked; Architect pronunciation acceptance pending; no UK audio required for M9 comparison |
+
+## Source and License Metadata
+
+Source files:
+
+- `content/core_1000_words.json`: 947
+- `content/core_300_words.json`: 268
+
+UK IPA sources:
+
+- open-dict-data/ipa-dict en_UK: 1215
+
+License notes:
+
+- open-data (wordfreq: MIT/Apache-2.0, ipa-dict: see repo): 1215
+
+## Review Status Coverage
+
+- `auto_checked`: 1215
+- `disabled`: 1
+- `draft`: 84
+
+## Minimal-Pair Candidate Sample
+
+| words | contrast | basis | caveat |
+| --- | --- | --- | --- |
+| bed / bad | /e/, /æ/ | one phoneme-tag difference in phoneme_tags_us | mechanical candidate only; requires Architect/content review before runtime specialty practice |
+| long / wrong | /l/, /r/ | one phoneme-tag difference in phoneme_tags_us | mechanical candidate only; requires Architect/content review before runtime specialty practice |
+| rally / rarely | /e/, /æ/ | one phoneme-tag difference in phoneme_tags_us | mechanical candidate only; requires Architect/content review before runtime specialty practice |
+| rich / reach | /iː/, /ɪ/ | one phoneme-tag difference in phoneme_tags_us | mechanical candidate only; requires Architect/content review before runtime specialty practice |
+| thing / singing | /s/, /θ/ | one phoneme-tag difference in phoneme_tags_us | mechanical candidate only; requires Architect/content review before runtime specialty practice |
+| thing / thin | /n/, /ŋ/ | one phoneme-tag difference in phoneme_tags_us | mechanical candidate only; requires Architect/content review before runtime specialty practice |
+| wing / win | /n/, /ŋ/ | one phoneme-tag difference in phoneme_tags_us | mechanical candidate only; requires Architect/content review before runtime specialty practice |
+| agree / ugly | /l/, /r/ | one phoneme-tag difference in phoneme_tags_us | mechanical candidate only; requires Architect/content review before runtime specialty practice |
+| dad / dead | /e/, /æ/ | one phoneme-tag difference in phoneme_tags_us | mechanical candidate only; requires Architect/content review before runtime specialty practice |
+| key / kick | /iː/, /ɪ/ | one phoneme-tag difference in phoneme_tags_us | mechanical candidate only; requires Architect/content review before runtime specialty practice |
+
+## Target-Phoneme Candidate Coverage Sample
+
+| phoneme | category | priority | eligible words US | eligible words UK |
+| --- | --- | --- | --- | --- |
+| /e/ | vowel | 1 | 191 | 182 |
+| /iː/ | vowel | 1 | 369 | 324 |
+| /l/ | consonant | 1 | 284 | 287 |
+| /r/ | consonant | 1 | 226 | 196 |
+| /tʃ/ | affricate | 1 | 33 | 35 |
+| /uː/ | vowel | 1 | 75 | 81 |
+| /v/ | consonant | 1 | 108 | 109 |
+| /w/ | consonant | 1 | 61 | 58 |
+| /æ/ | vowel | 1 | 161 | 146 |
+| /ð/ | consonant | 1 | 17 | 18 |
+| /ŋ/ | consonant | 1 | 74 | 74 |
+| /ɪ/ | vowel | 1 | 295 | 414 |
+| /ʃ/ | consonant | 1 | 47 | 47 |
+| /ʊ/ | vowel | 1 | 32 | 107 |
+| /ʌ/ | vowel | 1 | 13 | 86 |
+| /θ/ | consonant | 1 | 26 | 26 |
+| /aɪ/ | diphthong | 2 | 103 | 99 |
+| /aʊ/ | diphthong | 2 | 26 | 26 |
+| /b/ | consonant | 2 | 115 | 117 |
+| /d/ | consonant | 2 | 225 | 224 |
+
+## Caveats and Exclusions
+
+- UK rows marked auto_checked are mechanically eligible for this report, but still require Architect/content-quality acceptance before UI use.
+- UK audio is not required for M9 comparison display.
+- Minimal-pair candidates are mechanical tag-sequence candidates, not accepted runtime metadata.
+- Target-phoneme coverage is candidate coverage only; M9 runtime selection is intentionally out of scope for this issue.
+
+Unsupported UK symbols: none.
+
+Excluded rows sample:
+
+| word | review_status_uk | content_status | reason excluded |
+| --- | --- | --- | --- |
+| river | draft | core_selected | missing ipa_uk; missing phoneme_tags_uk; review_status_uk 'draft' is not accepted |
+| january | draft | core_selected | missing ipa_uk; missing phoneme_tags_uk; review_status_uk 'draft' is not accepted |
+| fbi | draft | core_selected | missing ipa_uk; missing phoneme_tags_uk; review_status_uk 'draft' is not accepted |
+| miami | draft | core_selected | missing ipa_uk; missing phoneme_tags_uk; review_status_uk 'draft' is not accepted |
+| nigeria | draft | core_selected | missing ipa_uk; missing phoneme_tags_uk; review_status_uk 'draft' is not accepted |
+| indiana | draft | core_selected | missing ipa_uk; missing phoneme_tags_uk; review_status_uk 'draft' is not accepted |
+| israeli | draft | core_selected | missing ipa_uk; missing phoneme_tags_uk; review_status_uk 'draft' is not accepted |
+| nba | draft | core_selected | missing ipa_uk; missing phoneme_tags_uk; review_status_uk 'draft' is not accepted |
+| dna | draft | core_selected | missing ipa_uk; missing phoneme_tags_uk; review_status_uk 'draft' is not accepted |
+| chinese | draft | core_selected | missing ipa_uk; missing phoneme_tags_uk; review_status_uk 'draft' is not accepted |

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -167,6 +167,16 @@ export async function startRecentMistakeReview(): Promise<TodayResponse> {
   return res.json();
 }
 
+export async function startMinimalPairPractice(): Promise<TodayResponse> {
+  const res = await fetch(`${API_BASE}/practice/minimal-pairs`, {
+    method: "POST",
+  });
+  if (!res.ok) {
+    throw new Error(await normalizeApiError(res));
+  }
+  return res.json();
+}
+
 export async function startFocusedPractice(
   focusPhonemes: string[],
 ): Promise<TodayResponse> {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -109,6 +109,12 @@ export interface TodayResponse {
   word_count?: number;
   status: string;
   source_session_item_ids?: string[];
+  target_phoneme_options?: {
+    phoneme: string;
+    symbol: string;
+    example_word: string | null;
+    candidate_count: number;
+  }[];
   items: TodayItem[];
   source_count?: number;
   error?: string;
@@ -170,6 +176,20 @@ export async function startRecentMistakeReview(): Promise<TodayResponse> {
 export async function startMinimalPairPractice(): Promise<TodayResponse> {
   const res = await fetch(`${API_BASE}/practice/minimal-pairs`, {
     method: "POST",
+  });
+  if (!res.ok) {
+    throw new Error(await normalizeApiError(res));
+  }
+  return res.json();
+}
+
+export async function startTargetPhonemePractice(
+  phoneme: string,
+): Promise<TodayResponse> {
+  const res = await fetch(`${API_BASE}/practice/target-phoneme`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ phoneme }),
   });
   if (!res.ok) {
     throw new Error(await normalizeApiError(res));

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -65,6 +65,21 @@ export interface TodayItem {
     prompt: string;
     choices: string[];
   };
+  accent_compare?: {
+    enabled: boolean;
+    primary: {
+      accent: "US";
+      label: string;
+      ipa: string;
+    };
+    comparison: {
+      accent: "UK";
+      label: string;
+      ipa: string;
+      phoneme_tags: string[];
+      review_note: string;
+    };
+  };
 }
 
 export interface TodayResponse {

--- a/frontend/src/components/ChoiceQuestion.tsx
+++ b/frontend/src/components/ChoiceQuestion.tsx
@@ -153,6 +153,16 @@ export function ChoiceQuestion({ item, onResult, onContinue }: Props) {
         </div>
       )}
 
+      {isAnswered && item.accent_compare && (
+        <aside className="accent-compare-note" aria-label="Accent comparison">
+          <span>{item.accent_compare.primary.label}</span>
+          <code>{item.accent_compare.primary.ipa}</code>
+          <span>{item.accent_compare.comparison.label}</span>
+          <code>{item.accent_compare.comparison.ipa}</code>
+          <p>{item.accent_compare.comparison.review_note}</p>
+        </aside>
+      )}
+
       {isError && (
         <div className="feedback feedback-error" role="alert">
           <p>⚠️ Failed to submit: {error}</p>

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,9 +1,7 @@
 /**
  * SettingsPage — display and edit user settings.
  *
- * Only exposes MVP-supported controls.  Future settings (UK accent,
- * reveal_first, accent compare) are intentionally hidden until the practice
- * flow supports them.
+ * Only exposes learner-supported controls. UK remains comparison-only in M9.
  */
 
 import { useEffect, useState } from "react";
@@ -150,6 +148,15 @@ export default function SettingsPage({
         </label>
 
         <label className="setting-row">
+          <span>
+            Accent comparison
+            <small>Show British notes after answering</small>
+          </span>
+          <input type="checkbox" checked={settings.show_accent_compare}
+            onChange={e => update({ show_accent_compare: e.target.checked })} />
+        </label>
+
+        <label className="setting-row">
           <span>Review strength</span>
           <select value={settings.review_strength}
             onChange={e => update({ review_strength: e.target.value })}>
@@ -261,10 +268,6 @@ export default function SettingsPage({
         <label className="setting-row">
           <span>Practice mode</span>
           <select value={settings.practice_mode} … />
-        </label>
-        <label className="setting-row">
-          <span>Show accent compare</span>
-          <input type="checkbox" checked={settings.show_accent_compare} … />
         </label>
         ---- */}
       </div>

--- a/frontend/src/pages/TodayPractice.tsx
+++ b/frontend/src/pages/TodayPractice.tsx
@@ -15,6 +15,7 @@ import {
   fetchToday,
   startCurrentGroupReview,
   startFocusedPractice,
+  startMinimalPairPractice,
   startNextNormalGroup,
   startRecentMistakeReview,
 } from "../api";
@@ -44,6 +45,7 @@ function canonicalFocus(phonemes: string[]): string[] {
 }
 
 function groupLabel(session: TodayResponse): string {
+  if (session.group_type === "minimal_pair") return "Sound Compare group";
   if (session.group_type === "weak_focus") return "Focused group";
   if (session.source_scope === "current_group") return "Current-group review";
   if (session.source_scope === "recent_global") return "Recent mistake review";
@@ -61,6 +63,9 @@ function selectedLevelLabel(session: TodayResponse): string {
 }
 
 function groupReason(session: TodayResponse): string {
+  if (session.group_type === "minimal_pair") {
+    return "Compare words with easily confused sounds. This is specialty practice, not mistake review or weak-sound recovery.";
+  }
   if (session.group_type === "weak_focus") {
     const focus = session.focus_phonemes?.join(" ") || "selected sounds";
     return `${learnerLevelLabel(session)} focused practice for ${focus}.`;
@@ -300,6 +305,23 @@ export default function TodayPractice({
     }
   };
 
+  const handleMinimalPairPractice = async () => {
+    setActionLoading("minimal-pair");
+    setError(null);
+    try {
+      const data = await startMinimalPairPractice();
+      if (data.status === "empty" || data.items.length === 0) {
+        setNotice(data.detail ?? "Sound Compare practice is not available yet.");
+      } else {
+        resetPractice(data);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to start Sound Compare practice");
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
   const handleFocusPractice = async (phonemes: string[]) => {
     const nextFocus = canonicalFocus(phonemes);
     if (nextFocus.length === 0) return;
@@ -414,6 +436,24 @@ export default function TodayPractice({
           {completedGroupCount(session) > 0 && (
             <p className="empty-hint">{completedGroupsCopy(session)}</p>
           )}
+
+          <div className="specialty-panel">
+            <div>
+              <span className="focus-panel-label">Specialty practice</span>
+              <strong>Sound Compare</strong>
+              <span>
+                Compare words with easily confused sounds. This is separate from mistake review and weak-sound focus.
+              </span>
+            </div>
+            <button
+              className="secondary-action-btn"
+              onClick={() => void handleMinimalPairPractice()}
+              disabled={actionLoading !== null}
+              type="button"
+            >
+              {actionLoading === "minimal-pair" ? "Loading…" : "Start Sound Compare"}
+            </button>
+          </div>
 
           {notice && <p className="empty-hint">{notice}</p>}
           {error && <p className="save-error">{error}</p>}

--- a/frontend/src/pages/TodayPractice.tsx
+++ b/frontend/src/pages/TodayPractice.tsx
@@ -18,6 +18,7 @@ import {
   startMinimalPairPractice,
   startNextNormalGroup,
   startRecentMistakeReview,
+  startTargetPhonemePractice,
 } from "../api";
 import type { ChoiceResult } from "../components/ChoiceQuestion";
 import { ChoiceQuestion } from "../components/ChoiceQuestion";
@@ -46,6 +47,7 @@ function canonicalFocus(phonemes: string[]): string[] {
 
 function groupLabel(session: TodayResponse): string {
   if (session.group_type === "minimal_pair") return "Sound Compare group";
+  if (session.group_type === "target_phoneme") return "Sound Practice group";
   if (session.group_type === "weak_focus") return "Focused group";
   if (session.source_scope === "current_group") return "Current-group review";
   if (session.source_scope === "recent_global") return "Recent mistake review";
@@ -65,6 +67,10 @@ function selectedLevelLabel(session: TodayResponse): string {
 function groupReason(session: TodayResponse): string {
   if (session.group_type === "minimal_pair") {
     return "Compare words with easily confused sounds. This is specialty practice, not mistake review or weak-sound recovery.";
+  }
+  if (session.group_type === "target_phoneme") {
+    const target = session.focus_phonemes?.[0] ?? "your chosen sound";
+    return `Intentional practice for ${target}. This is a chosen-sound specialty group, not weak-sound recovery.`;
   }
   if (session.group_type === "weak_focus") {
     const focus = session.focus_phonemes?.join(" ") || "selected sounds";
@@ -322,6 +328,23 @@ export default function TodayPractice({
     }
   };
 
+  const handleTargetPhonemePractice = async (phoneme: string) => {
+    setActionLoading(`target-${phoneme}`);
+    setError(null);
+    try {
+      const data = await startTargetPhonemePractice(phoneme);
+      if (data.status === "empty" || data.items.length === 0) {
+        setNotice(data.detail ?? "Sound Practice is not available for that sound yet.");
+      } else {
+        resetPractice(data);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to start Sound Practice");
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
   const handleFocusPractice = async (phonemes: string[]) => {
     const nextFocus = canonicalFocus(phonemes);
     if (nextFocus.length === 0) return;
@@ -453,6 +476,36 @@ export default function TodayPractice({
             >
               {actionLoading === "minimal-pair" ? "Loading…" : "Start Sound Compare"}
             </button>
+          </div>
+
+          <div className="specialty-panel target-phoneme-panel">
+            <div>
+              <span className="focus-panel-label">Specialty practice</span>
+              <strong>Sound Practice</strong>
+              <span>
+                Pick one approved American sound for intentional practice. This is separate from weak-sound recovery.
+              </span>
+            </div>
+            <div className="phoneme-chip-list">
+              {(session.target_phoneme_options ?? []).slice(0, 6).map((option) => (
+                <button
+                  className="phoneme-chip selectable"
+                  key={option.phoneme}
+                  onClick={() => void handleTargetPhonemePractice(option.phoneme)}
+                  disabled={actionLoading !== null}
+                  type="button"
+                >
+                  {actionLoading === `target-${option.phoneme}`
+                    ? "Loading..."
+                    : `Practice ${option.phoneme}`}
+                </button>
+              ))}
+              {(session.target_phoneme_options ?? []).length === 0 && (
+                <span className="empty-hint">
+                  Sound Practice will appear when approved sounds have enough words.
+                </span>
+              )}
+            </div>
           </div>
 
           {notice && <p className="empty-hint">{notice}</p>}
@@ -634,7 +687,9 @@ export default function TodayPractice({
       </div>
       {(session.focus_phonemes?.length || focusPhonemes.length > 0) && (
         <div className="active-focus-banner">
-          <span>Current focus</span>
+          <span>
+            {session.group_type === "target_phoneme" ? "Chosen sound" : "Current focus"}
+          </span>
           {(session.focus_phonemes ?? focusPhonemes).map((phoneme) => (
             <span className="phoneme-chip" key={phoneme}>{phoneme}</span>
           ))}

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -668,6 +668,7 @@ summary:focus-visible {
 }
 
 .hub-status-card,
+.specialty-panel,
 .level-progress-panel {
   background: var(--panel);
   border: 1px solid var(--line);
@@ -681,6 +682,16 @@ summary:focus-visible {
 .hub-status-card.pending {
   background: var(--warning-bg);
   border-color: #d4c3b4;
+}
+
+.specialty-panel {
+  align-items: center;
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.specialty-panel div {
+  display: grid;
+  gap: 5px;
 }
 
 .pending-copy {

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -459,6 +459,36 @@ summary:focus-visible {
   font-size: 0.85rem;
 }
 
+.accent-compare-note {
+  align-items: center;
+  background: #eef3ef;
+  border: 1px solid #cddbd0;
+  border-radius: 8px;
+  color: var(--ink);
+  display: grid;
+  font-size: 0.88rem;
+  gap: 6px 10px;
+  grid-template-columns: minmax(96px, max-content) minmax(0, 1fr);
+  margin-top: 12px;
+  padding: 12px;
+}
+
+.accent-compare-note span {
+  color: var(--muted);
+  font-weight: 750;
+}
+
+.accent-compare-note code {
+  font-family: ui-monospace, "SFMono-Regular", "Menlo", "Consolas", monospace;
+  font-weight: 750;
+}
+
+.accent-compare-note p {
+  color: var(--muted);
+  grid-column: 1 / -1;
+  margin: 2px 0 0;
+}
+
 .feedback-continue-btn {
   background: var(--accent);
   border: 1px solid var(--accent-dark);
@@ -925,6 +955,17 @@ summary:focus-visible {
   border-bottom: 1px solid rgba(217, 210, 199, 0.8);
   font-size: 0.95rem;
   cursor: pointer;
+}
+
+.setting-row span {
+  display: grid;
+  gap: 2px;
+}
+
+.setting-row small {
+  color: var(--muted);
+  font-size: 0.78rem;
+  font-weight: 600;
 }
 
 .setting-row select,

--- a/frontend/tests/e2e/m10-ux-walkthrough.spec.ts
+++ b/frontend/tests/e2e/m10-ux-walkthrough.spec.ts
@@ -1,8 +1,8 @@
 import { expect, type Page, type Route, test } from "@playwright/test";
 
 type LearnerLevel = "entry" | "mid";
-type GroupKey = "none" | "entry" | "mid" | "currentReview" | "recentReview" | "focused" | "minimalPair";
-type GroupType = "normal" | "mistake_review" | "weak_focus" | "minimal_pair";
+type GroupKey = "none" | "entry" | "mid" | "currentReview" | "recentReview" | "focused" | "minimalPair" | "targetPhoneme";
+type GroupType = "normal" | "mistake_review" | "weak_focus" | "minimal_pair" | "target_phoneme";
 
 interface MockItem {
   session_item_id: string;
@@ -148,6 +148,18 @@ const items: Record<Exclude<GroupKey, "none">, MockItem[]> = {
       audio_url: null,
     },
   ],
+  targetPhoneme: [
+    {
+      session_item_id: "target-ship",
+      word_id: "ship",
+      display_ipa: "/ʃɪp/",
+      word: "ship",
+      meaning_zh: "船",
+      target_phonemes: ["/ʃ/", "/ɪ/", "/p/"],
+      choices: ["/sɪp/", "/ʃɪp/"],
+      audio_url: null,
+    },
+  ],
 };
 
 function levelLabel(level: LearnerLevel) {
@@ -162,6 +174,7 @@ function groupType(group: GroupKey): GroupType {
   if (group === "currentReview" || group === "recentReview") return "mistake_review";
   if (group === "focused") return "weak_focus";
   if (group === "minimalPair") return "minimal_pair";
+  if (group === "targetPhoneme") return "target_phoneme";
   return "normal";
 }
 
@@ -190,6 +203,20 @@ function todayResponse(state: MockState) {
       word_count: 0,
       status: "idle",
       source_session_item_ids: [],
+      target_phoneme_options: [
+        {
+          phoneme: "/ʃ/",
+          symbol: "ʃ",
+          example_word: "ship",
+          candidate_count: 2,
+        },
+        {
+          phoneme: "/θ/",
+          symbol: "θ",
+          example_word: "thin",
+          candidate_count: 1,
+        },
+      ],
       items: [],
     };
   }
@@ -198,6 +225,7 @@ function todayResponse(state: MockState) {
   const review = state.activeGroup === "currentReview" || state.activeGroup === "recentReview";
   const focus = state.activeGroup === "focused";
   const minimalPair = state.activeGroup === "minimalPair";
+  const targetPhoneme = state.activeGroup === "targetPhoneme";
   return {
     session_id: `${state.activeGroup}-session`,
     group_id: `${state.activeGroup}-group`,
@@ -207,7 +235,7 @@ function todayResponse(state: MockState) {
     learner_level_label: levelLabel(level),
     selected_learner_level: state.selectedLevel,
     selected_learner_level_label: levelLabel(state.selectedLevel),
-    pending_level_change: !review && !focus && !minimalPair && state.selectedLevel !== level,
+    pending_level_change: !review && !focus && !minimalPair && !targetPhoneme && state.selectedLevel !== level,
     completed_normal_groups_today: {
       entry: state.completed.entry,
       mid: state.completed.mid,
@@ -215,7 +243,9 @@ function todayResponse(state: MockState) {
     },
     date: "2026-06-18",
     primary_accent: "US",
-    origin: minimalPair
+    origin: targetPhoneme
+      ? "target_phoneme_start"
+      : minimalPair
       ? "minimal_pair_start"
       : focus
         ? "focus_start"
@@ -231,16 +261,36 @@ function todayResponse(state: MockState) {
             ? "focus_selection"
             : minimalPair
               ? "specialty_minimal_pair"
+              : targetPhoneme
+                ? "specialty_target_phoneme"
               : "normal_current",
     source_group_id: review ? "entry-group" : undefined,
-    focus_phonemes: focus ? state.focusPhonemes : [],
+    focus_phonemes: focus || targetPhoneme ? state.focusPhonemes : [],
     daily_word_count: items[state.activeGroup].length,
     recent_mistake_count: state.recentMistakeCount,
     word_count: items[state.activeGroup].length,
     status: "active",
     source_session_item_ids: review ? ["entry-ship"] : [],
     source_count: review ? 1 : 0,
-    action_label: minimalPair ? "Start Sound Compare Group 1" : undefined,
+    action_label: targetPhoneme
+      ? "Start Sound Practice Group 1"
+      : minimalPair
+        ? "Start Sound Compare Group 1"
+        : undefined,
+    target_phoneme_options: [
+      {
+        phoneme: "/ʃ/",
+        symbol: "ʃ",
+        example_word: "ship",
+        candidate_count: 2,
+      },
+      {
+        phoneme: "/θ/",
+        symbol: "θ",
+        example_word: "thin",
+        candidate_count: 1,
+      },
+    ],
     items: items[state.activeGroup].map((item) => ({
       session_item_id: item.session_item_id,
       word_id: item.word_id,
@@ -396,6 +446,14 @@ async function routeMock(route: Route, state: MockState) {
     return;
   }
 
+  if (path === "/practice/target-phoneme") {
+    const body = request.postDataJSON() as { phoneme?: string };
+    state.focusPhonemes = body.phoneme ? [body.phoneme] : ["/ʃ/"];
+    state.activeGroup = "targetPhoneme";
+    await route.fulfill({ json: todayResponse(state) });
+    return;
+  }
+
   if (path === "/practice/abandon-current-and-next") {
     state.activeGroup = state.selectedLevel;
     await route.fulfill({
@@ -501,6 +559,7 @@ async function attachScreenshot(page: Page, name: string) {
 
 test.describe("M10 UX walkthrough evidence", () => {
   test("Today practice, wrong-answer recovery, reviews, and Progress focus are observable", async ({ page }) => {
+    test.setTimeout(60_000);
     await setupM10Api(page);
 
     await test.step("Today start orientation", async () => {
@@ -541,7 +600,7 @@ test.describe("M10 UX walkthrough evidence", () => {
     await test.step("Completion summary exposes current-group recovery and next choices", async () => {
       await answer(page, "/θɪn/");
       await expect(page.getByRole("heading", { name: "Practice group complete" })).toBeVisible({
-        timeout: 4_000,
+        timeout: 10_000,
       });
       await expect(page.getByText("1 / 2 correct")).toBeVisible();
       await expect(page.getByRole("heading", { name: "This group's misses" })).toBeVisible();
@@ -585,7 +644,7 @@ test.describe("M10 UX walkthrough evidence", () => {
 
     await page.goto("/");
     await expect(page.getByText("Today practice hub")).toBeVisible();
-    await expect(page.getByText("Specialty practice")).toBeVisible();
+    await expect(page.getByText("Specialty practice").first()).toBeVisible();
     await expect(page.getByText("Sound Compare", { exact: true })).toBeVisible();
     await expect(page.getByText("Compare words with easily confused sounds. This is separate from mistake review and weak-sound focus.")).toBeVisible();
     await expect(page.getByRole("button", { name: "Start Sound Compare" })).toBeVisible();
@@ -599,6 +658,28 @@ test.describe("M10 UX walkthrough evidence", () => {
     await expect(page.getByText("Focused group:")).toHaveCount(0);
     await expect(page.getByRole("button", { name: "Select /ʃɪp/" })).toBeVisible();
     await attachScreenshot(page, "m9-minimal-pair-active");
+  });
+
+  test("Sound Practice uses guided chosen-sound entry distinct from weak focus", async ({ page }) => {
+    await setupM10Api(page);
+
+    await page.goto("/");
+    await expect(page.getByText("Today practice hub")).toBeVisible();
+    await expect(page.getByText("Sound Practice", { exact: true })).toBeVisible();
+    await expect(page.getByText("Pick one approved American sound for intentional practice. This is separate from weak-sound recovery.")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Practice /ʃ/" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Practice /θ/" })).toBeVisible();
+    await attachScreenshot(page, "m9-target-phoneme-entry");
+
+    await page.getByRole("button", { name: "Practice /ʃ/" }).click();
+    await expect(page.getByText("Sound Practice group: 1 / 1")).toBeVisible();
+    await expect(page.getByText("Intentional practice for /ʃ/. This is a chosen-sound specialty group, not weak-sound recovery.")).toBeVisible();
+    await expect(page.getByText("Chosen sound")).toBeVisible();
+    await expect(page.getByText("Current focus")).toHaveCount(0);
+    await expect(page.getByText("Focused group:")).toHaveCount(0);
+    await expect(page.getByText("Current-group review:")).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "Select /ʃɪp/" })).toBeVisible();
+    await attachScreenshot(page, "m9-target-phoneme-active");
   });
 
   test("Settings level switching, empty review state, audio signal, and mobile views are observable", async ({ page }, testInfo) => {

--- a/frontend/tests/e2e/m10-ux-walkthrough.spec.ts
+++ b/frontend/tests/e2e/m10-ux-walkthrough.spec.ts
@@ -1,8 +1,8 @@
 import { expect, type Page, type Route, test } from "@playwright/test";
 
 type LearnerLevel = "entry" | "mid";
-type GroupKey = "none" | "entry" | "mid" | "currentReview" | "recentReview" | "focused";
-type GroupType = "normal" | "mistake_review" | "weak_focus";
+type GroupKey = "none" | "entry" | "mid" | "currentReview" | "recentReview" | "focused" | "minimalPair";
+type GroupType = "normal" | "mistake_review" | "weak_focus" | "minimal_pair";
 
 interface MockItem {
   session_item_id: string;
@@ -126,6 +126,28 @@ const items: Record<Exclude<GroupKey, "none">, MockItem[]> = {
       audio_url: null,
     },
   ],
+  minimalPair: [
+    {
+      session_item_id: "minimal-ship",
+      word_id: "ship",
+      display_ipa: "/ʃɪp/",
+      word: "ship",
+      meaning_zh: "船",
+      target_phonemes: ["/ʃ/", "/ɪ/", "/p/"],
+      choices: ["/ʃɪp/", "/ʃiːp/"],
+      audio_url: null,
+    },
+    {
+      session_item_id: "minimal-sheep",
+      word_id: "sheep",
+      display_ipa: "/ʃiːp/",
+      word: "sheep",
+      meaning_zh: "羊",
+      target_phonemes: ["/ʃ/", "/iː/", "/p/"],
+      choices: ["/ʃɪp/", "/ʃiːp/"],
+      audio_url: null,
+    },
+  ],
 };
 
 function levelLabel(level: LearnerLevel) {
@@ -139,6 +161,7 @@ function groupLevel(group: GroupKey): LearnerLevel {
 function groupType(group: GroupKey): GroupType {
   if (group === "currentReview" || group === "recentReview") return "mistake_review";
   if (group === "focused") return "weak_focus";
+  if (group === "minimalPair") return "minimal_pair";
   return "normal";
 }
 
@@ -174,6 +197,7 @@ function todayResponse(state: MockState) {
   const level = groupLevel(state.activeGroup);
   const review = state.activeGroup === "currentReview" || state.activeGroup === "recentReview";
   const focus = state.activeGroup === "focused";
+  const minimalPair = state.activeGroup === "minimalPair";
   return {
     session_id: `${state.activeGroup}-session`,
     group_id: `${state.activeGroup}-group`,
@@ -183,7 +207,7 @@ function todayResponse(state: MockState) {
     learner_level_label: levelLabel(level),
     selected_learner_level: state.selectedLevel,
     selected_learner_level_label: levelLabel(state.selectedLevel),
-    pending_level_change: !review && !focus && state.selectedLevel !== level,
+    pending_level_change: !review && !focus && !minimalPair && state.selectedLevel !== level,
     completed_normal_groups_today: {
       entry: state.completed.entry,
       mid: state.completed.mid,
@@ -191,7 +215,13 @@ function todayResponse(state: MockState) {
     },
     date: "2026-06-18",
     primary_accent: "US",
-    origin: focus ? "focus_start" : review ? "current_group_review_start" : "normal_start",
+    origin: minimalPair
+      ? "minimal_pair_start"
+      : focus
+        ? "focus_start"
+        : review
+          ? "current_group_review_start"
+          : "normal_start",
     source_scope:
       state.activeGroup === "currentReview"
         ? "current_group"
@@ -199,7 +229,9 @@ function todayResponse(state: MockState) {
           ? "recent_global"
           : focus
             ? "focus_selection"
-            : "normal_current",
+            : minimalPair
+              ? "specialty_minimal_pair"
+              : "normal_current",
     source_group_id: review ? "entry-group" : undefined,
     focus_phonemes: focus ? state.focusPhonemes : [],
     daily_word_count: items[state.activeGroup].length,
@@ -208,6 +240,7 @@ function todayResponse(state: MockState) {
     status: "active",
     source_session_item_ids: review ? ["entry-ship"] : [],
     source_count: review ? 1 : 0,
+    action_label: minimalPair ? "Start Sound Compare Group 1" : undefined,
     items: items[state.activeGroup].map((item) => ({
       session_item_id: item.session_item_id,
       word_id: item.word_id,
@@ -353,6 +386,12 @@ async function routeMock(route: Route, state: MockState) {
 
   if (path === "/practice/next-normal") {
     state.activeGroup = state.selectedLevel;
+    await route.fulfill({ json: todayResponse(state) });
+    return;
+  }
+
+  if (path === "/practice/minimal-pairs") {
+    state.activeGroup = "minimalPair";
     await route.fulfill({ json: todayResponse(state) });
     return;
   }
@@ -539,6 +578,27 @@ test.describe("M10 UX walkthrough evidence", () => {
       await expect(page.getByRole("button", { name: "Clear focus" })).toBeVisible();
       await attachScreenshot(page, "m10-progress-focus-entry");
     });
+  });
+
+  test("Sound Compare specialty practice is distinct from review and focus", async ({ page }) => {
+    await setupM10Api(page);
+
+    await page.goto("/");
+    await expect(page.getByText("Today practice hub")).toBeVisible();
+    await expect(page.getByText("Specialty practice")).toBeVisible();
+    await expect(page.getByText("Sound Compare", { exact: true })).toBeVisible();
+    await expect(page.getByText("Compare words with easily confused sounds. This is separate from mistake review and weak-sound focus.")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Start Sound Compare" })).toBeVisible();
+    await attachScreenshot(page, "m9-minimal-pair-entry");
+
+    await page.getByRole("button", { name: "Start Sound Compare" }).click();
+    await expect(page.getByText("Sound Compare group: 1 / 2")).toBeVisible();
+    await expect(page.getByText("Compare words with easily confused sounds. This is specialty practice, not mistake review or weak-sound recovery.")).toBeVisible();
+    await expect(page.getByText("Current-group review:")).toHaveCount(0);
+    await expect(page.getByText("Recent mistake review:")).toHaveCount(0);
+    await expect(page.getByText("Focused group:")).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "Select /ʃɪp/" })).toBeVisible();
+    await attachScreenshot(page, "m9-minimal-pair-active");
   });
 
   test("Settings level switching, empty review state, audio signal, and mobile views are observable", async ({ page }, testInfo) => {

--- a/frontend/tests/e2e/m10-ux-walkthrough.spec.ts
+++ b/frontend/tests/e2e/m10-ux-walkthrough.spec.ts
@@ -13,6 +13,21 @@ interface MockItem {
   target_phonemes: string[];
   choices: string[];
   audio_url: string | null;
+  accent_compare?: {
+    enabled: boolean;
+    primary: {
+      accent: "US";
+      label: string;
+      ipa: string;
+    };
+    comparison: {
+      accent: "UK";
+      label: string;
+      ipa: string;
+      phoneme_tags: string[];
+      review_note: string;
+    };
+  };
 }
 
 interface MockState {
@@ -22,6 +37,7 @@ interface MockState {
   focusPhonemes: string[];
   recentMistakeCount: number;
   recentReviewEmpty: boolean;
+  showAccentCompare: boolean;
 }
 
 const items: Record<Exclude<GroupKey, "none">, MockItem[]> = {
@@ -35,6 +51,21 @@ const items: Record<Exclude<GroupKey, "none">, MockItem[]> = {
       target_phonemes: ["/ʃ/"],
       choices: ["/sɪp/", "/ʃɪp/"],
       audio_url: null,
+      accent_compare: {
+        enabled: true,
+        primary: {
+          accent: "US",
+          label: "American sound",
+          ipa: "/ʃɪp/",
+        },
+        comparison: {
+          accent: "UK",
+          label: "British note",
+          ipa: "/ʃɪp-uk/",
+          phoneme_tags: ["/ʃ/", "/ɪ/", "/p/"],
+          review_note: "Display-only comparison. Your answer is still graded against the American IPA.",
+        },
+      },
     },
     {
       session_item_id: "entry-thin",
@@ -185,6 +216,7 @@ function todayResponse(state: MockState) {
       meaning_zh: item.meaning_zh,
       audio_url: item.audio_url,
       target_phonemes: item.target_phonemes,
+      accent_compare: state.showAccentCompare ? item.accent_compare : undefined,
       question: {
         type: "ipa_choice",
         prompt: "Which IPA matches this word?",
@@ -199,7 +231,7 @@ function settingsResponse(state: MockState) {
     primary_accent: "US",
     daily_word_count: 2,
     show_translation: true,
-    show_accent_compare: false,
+    show_accent_compare: state.showAccentCompare,
     practice_mode: "ipa_first",
     review_strength: "normal",
     learner_level: state.selectedLevel,
@@ -271,6 +303,7 @@ async function setupM10Api(page: Page, options: Partial<MockState> = {}) {
     focusPhonemes: options.focusPhonemes ?? [],
     recentMistakeCount: options.recentMistakeCount ?? 0,
     recentReviewEmpty: options.recentReviewEmpty ?? false,
+    showAccentCompare: options.showAccentCompare ?? false,
   };
 
   await page.route("**/api/**", async (route) => {
@@ -301,9 +334,13 @@ async function routeMock(route: Route, state: MockState) {
         learner_level?: LearnerLevel;
         focus_phonemes?: string[];
         daily_word_count?: number;
+        show_accent_compare?: boolean;
       };
       if (body.learner_level) state.selectedLevel = body.learner_level;
       if (body.focus_phonemes) state.focusPhonemes = body.focus_phonemes;
+      if (typeof body.show_accent_compare === "boolean") {
+        state.showAccentCompare = body.show_accent_compare;
+      }
     }
     await route.fulfill({ json: settingsResponse(state) });
     return;
@@ -578,5 +615,31 @@ test.describe("M10 UX walkthrough evidence", () => {
     await page.getByRole("button", { name: "Play pronunciation with browser voice" }).click();
     await expect(page.getByText("Audio unavailable")).toBeVisible();
     await attachScreenshot(page, "m10-audio-unavailable-state");
+  });
+
+  test("UK comparison is settings-gated and display-only", async ({ page }) => {
+    const state = await setupM10Api(page);
+
+    await page.goto("/");
+    await page.getByRole("button", { name: "Start Entry group" }).click();
+    await answer(page, "/sɪp/");
+    await expect(page.getByLabel("Accent comparison")).toHaveCount(0);
+
+    state.activeGroup = "none";
+    await page.getByRole("button", { name: "Settings" }).click();
+    await page.getByLabel("Accent comparison").click();
+    await expect(page.getByText("Saved")).toBeVisible();
+    await expect(page.getByText("Primary accent")).toHaveCount(0);
+
+    await page.getByRole("button", { name: "Today", exact: true }).click();
+    await page.getByRole("button", { name: "Start Entry group" }).click();
+    await answer(page, "/sɪp/");
+
+    await expect(page.getByLabel("Accent comparison")).toBeVisible();
+    await expect(page.getByText("American sound")).toBeVisible();
+    await expect(page.getByText("British note")).toBeVisible();
+    await expect(page.getByText("/ʃɪp-uk/")).toBeVisible();
+    await expect(page.getByText("Your answer is still graded against the American IPA")).toBeVisible();
+    await attachScreenshot(page, "m9-uk-comparison-note");
   });
 });


### PR DESCRIPTION
## Summary

Integrates M9 UK Accent Compare and Specialty Practice from `epic/28-uk-accent-specialty-practice` into `main`.

Completed M9 gates:
- #193 / PR #195: M9 accent and specialty practice contract.
- #196 / PR #200: UK-ready content subset and accent coverage report.
- #197 / PR #199: accent-specific stats separation regression checks.
- #201 / PR #202: settings-gated, display-only UK comparison UI/API.
- #203 / PR #204: minimal-pair specialty practice.
- #205 / PR #206: target-phoneme specialty practice.
- #207: final M9 readiness review and integration gate accepted.

## M9 Contract Boundaries

- UK pronunciation remains comparison-only support data in M9.
- Learners cannot select UK as `primary_accent`.
- `show_accent_compare` gates the learner-facing UK comparison note.
- UK comparison is display-only and does not imply UK IPA is accepted for grading.
- Production answer generation, grading, audio, attempts, progress, and stats remain US-first.
- Minimal-pair and target-phoneme specialty practice reuse existing session/item/attempt/stat paths.

## Readiness Evidence

Final readiness review: https://github.com/farmerhunter/tiny-ipa/issues/207#issuecomment-4827042699
Architect acceptance: https://github.com/farmerhunter/tiny-ipa/issues/207#issuecomment-4827048819
Epic checkpoint: https://github.com/farmerhunter/tiny-ipa/issues/28#issuecomment-4827049124

Reviewer verification from #207:
- `UV_CACHE_DIR=.uv-cache uv run --project backend pytest` -> 209 passed.
- `pnpm lint` in `frontend` -> passed.
- `pnpm build` in `frontend` -> passed.
- `pnpm test:e2e:m7` in `frontend` -> 7 passed.
- `pnpm test:e2e:m10` in `frontend` -> 12 passed, including UK comparison and both M9 specialty flows on desktop/mobile.
- `git diff --check` -> passed.
- `tools/agents/agent-audit` -> clean.

## Trial Path

- UK comparison off: Today -> Entry group -> answer item; no accent comparison note appears.
- UK comparison on: Settings -> enable Accent comparison -> Today -> Entry group -> answer eligible item; feedback shows American sound / British note and American-grading copy.
- Minimal-pair specialty: Today -> Specialty practice -> Sound Compare -> Start Sound Compare.
- Target-phoneme specialty: Today -> Specialty practice -> Sound Practice -> choose an approved sound chip.

## Residual Risks

- Content/pronunciation fit remains subjective; human learner/content trial is optional during final PR review, not required before PR preparation.
- Specialty candidate coverage is intentionally content-gated and may be sparse; safe empty states are expected.
- UK comparison copy is explicit, but final review may still choose to validate learner comprehension before merge.

## Boundaries

- No Project mutation requested.
- Do not close Epic #28 until this final integration PR is accepted/merged and closeout is posted.
