### PR TITLE
docs: insert localization and auth roadmap epics

### DIFF
--- a/docs/02-system-architecture.md
+++ b/docs/02-system-architecture.md
@@ -22,6 +22,7 @@ Runtime Assets
         |
         v
 FastAPI Backend
+  auth/session/current user
   practice
   grading
   progress
@@ -92,6 +93,8 @@ FastAPI 只面向运行时用户体验。它不在请求路径中做大规模内
 后端拥有：
 
 ```text
+current-user resolution
+minimal auth/session boundary
 session generation
 question generation
 server-side grading
@@ -105,6 +108,48 @@ settings validation
 React PWA 消费领域摘要，不自行计算掌握度或决定调度逻辑。
 
 前端可以有本地 UI 状态，例如当前卡片是否 reveal，但不拥有学习记录事实。
+
+### Localization
+
+UI language is a product/runtime preference, not content-source data.
+
+Learner-facing UI copy should live behind a locale boundary so the app can
+support:
+
+```text
+zh-CN default learner-facing copy
+en-US selectable UI copy
+stable IPA, phoneme, accent, and content semantics
+```
+
+Localization should not translate source word records or `meaning_zh`. IPA
+symbols, phoneme tags, accent identifiers, and grading semantics remain domain
+data. Locale resources own button labels, state descriptions, error copy, and
+help text.
+
+### Auth and User Data Boundary
+
+Tiny IPA starts as a local single-user app, but runtime learning data is already
+modeled around `user_id`. Before deployment, the system needs an explicit
+current-user boundary:
+
+```text
+users / owner bootstrap
+login / logout / current user
+settings scoped by user
+daily_sessions scoped by user
+attempts scoped by user
+phoneme_stats scoped by user
+review/focus state scoped by user
+```
+
+Content tables remain global and source-driven. User runtime tables are private
+learning state and must be backed up and restored with the authenticated user
+boundary intact.
+
+Minimal auth should avoid broad SaaS features. OAuth, social login, family
+dashboards, complex role matrices, and account administration are separate
+future product decisions.
 
 ### Audio Assets
 
@@ -183,6 +228,9 @@ tiny-ipa/
 
 ```text
 content_source_unavailable
+auth_required
+current_user_missing
+user_data_scope_violation
 ipa_missing_us
 ipa_missing_uk
 ipa_parse_failed

--- a/docs/05-data-api-contracts.md
+++ b/docs/05-data-api-contracts.md
@@ -14,6 +14,42 @@ Runtime Data
 
 源内容是事实来源。SQLite 可以删除重建，但用户学习记录需要备份。
 
+## Localization and Current-user Roadmap Boundary
+
+M11 and M12 insert two prerequisites before deployment:
+
+```text
+M11 Localization and Configurable UI Language (#209)
+M12 Minimal Auth and Multi-user Data Isolation (#210)
+```
+
+Localization is a UI/runtime contract. It should make learner-facing copy
+configurable without changing IPA/content/grading semantics. Auth is a runtime
+identity contract. It should make existing `user_id` fields meaningful before
+the app is exposed through VPS deployment.
+
+These Epics must preserve the existing content boundary:
+
+```text
+global source/runtime content:
+  words
+  phonemes
+  static audio assets
+  source reports
+
+per-user runtime learning data:
+  settings
+  daily_sessions
+  session ownership
+  attempts
+  phoneme_stats
+  review/focus state
+```
+
+The old `default` user is a migration concern. Any real migration of existing
+SQLite data requires backup guidance, dry-run evidence, and explicit Human
+approval before mutating real/private data.
+
 ## 源词条字段
 
 推荐源内容字段：
@@ -85,6 +121,7 @@ settings(
   practice_mode TEXT NOT NULL,
   review_strength TEXT NOT NULL,
   learner_level TEXT NOT NULL DEFAULT 'entry',
+  ui_language TEXT NOT NULL DEFAULT 'zh-CN',
   focus_phonemes TEXT NOT NULL DEFAULT '[]',
   updated_at TEXT NOT NULL
 )
@@ -143,6 +180,47 @@ phoneme_stats(
 `primary_accent` 必须进入 session、attempt 和 stats，否则未来 UK 对照会污染 US 统计。
 
 ## API 合同
+
+### Current user and auth boundary
+
+Pre-auth local development may continue to use a documented dev/default user.
+M12 must make the current-user source explicit before VPS deployment:
+
+```text
+anonymous local dev user     allowed only in documented dev mode
+authenticated runtime user   required for deployed learner data
+owner/admin bootstrap        minimal personal deployment setup
+```
+
+Runtime endpoints that read or mutate learner data must resolve the current
+user before touching user-scoped tables:
+
+```text
+GET /api/today
+POST /api/practice/next-normal
+POST /api/practice/abandon-current-and-next
+POST /api/practice/focus
+POST /api/practice/clear-focus
+POST /api/review/current-group
+POST /api/review/recent-mistakes
+POST /api/attempt
+GET /api/progress
+GET/PUT /api/settings
+```
+
+Shared content reads may remain global, but must not leak another user's
+runtime attempts, settings, sessions, or stats.
+
+M12 should define the concrete auth endpoints. Expected minimum shape:
+
+```http
+POST /api/auth/login
+POST /api/auth/logout
+GET /api/auth/me
+```
+
+The final contract must specify cookie/session behavior, secret configuration,
+local dev bootstrap, and failure states before M13 deployment releases.
 
 ### Health
 
@@ -551,6 +629,7 @@ MVP 默认：
   "show_accent_compare": false,
   "practice_mode": "ipa_first",
   "review_strength": "normal",
+  "ui_language": "zh-CN",
   "learner_level": "entry"
 }
 ```
@@ -631,6 +710,7 @@ Settings API contract:
   "practice_mode": "ipa_first",
   "review_strength": "normal",
   "focus_phonemes": [],
+  "ui_language": "zh-CN",
   "learner_level": "entry"
 }
 ```
@@ -641,6 +721,18 @@ Settings API contract:
 entry | mid      accepted values
 other values     400 SETTINGS_INVALID
 ```
+
+M11 adds `ui_language` as a learner-facing UI preference. Initial accepted
+values should be:
+
+```text
+zh-CN | en-US     accepted values
+other values      400 SETTINGS_INVALID
+```
+
+`ui_language` controls interface copy only. It must not translate IPA strings,
+phoneme symbols, accent identifiers, source word content, `meaning_zh`, grading
+logic, or scheduler behavior.
 
 If the UI exposes `mid` before the Mid content set is ready, the action must fail
 with a clear disabled/hold state or a structured backend error. Final M8
@@ -729,6 +821,9 @@ cd frontend && pnpm test:e2e:m8
 ```text
 CONTENT_NOT_READY
 AUDIO_MISSING
+AUTH_REQUIRED
+CURRENT_USER_MISSING
+USER_DATA_SCOPE_VIOLATION
 SESSION_NOT_FOUND
 SESSION_ALREADY_COMPLETED
 ITEM_NOT_FOUND

--- a/docs/06-epic-roadmap.md
+++ b/docs/06-epic-roadmap.md
@@ -20,6 +20,7 @@ Tiny IPA uses Epic issues as the primary planning and multi-agent coordination u
 | M11 Localization and Configurable UI Language | #209 | Planning |
 | M12 Minimal Auth and Multi-user Data Isolation | #210 | Planning |
 | M13 VPS Deployment and Backup | #27 | Blocked |
+| M14 Account Management and Admin UX | #212 | Backlog / Deferred |
 
 ## M0：Feasibility and Architecture Skeleton
 
@@ -529,6 +530,53 @@ deployment is an adapter/contract layer, not a place to add business logic
 do not implement auth, localization, account management, or data migration here
 do not mutate real SQLite data, secrets, DNS, VPS runtime, or deployment config
 without explicit Human approval
+```
+
+## M14：Account Management and Admin UX
+
+Goal: preserve broader account and admin UX ideas as a deferred post-deploy
+roadmap placeholder, without mixing them into minimal auth or deployment.
+
+Roadmap status:
+
+```text
+Backlog / deferred. Epic #212 exists as a placeholder only. It should not be
+decomposed or released until post-deploy usage produces a concrete product need
+and Architect/Human accepts the scope.
+```
+
+Potential future scope:
+
+```text
+user profile/account settings polish
+password change/reset/recovery strategy
+owner/admin management entry points
+multi-learner management UX if later product decision requires it
+user data export/delete policy review
+```
+
+Explicit non-scope until separately approved:
+
+```text
+SaaS billing
+OAuth or social login
+family/teacher dashboard
+complex role matrix
+production account recovery service
+account/admin implementation code in M11, M12, or M13
+```
+
+Execution contract:
+
+```text
+Branch strategy: not released; future decomposition required
+Owner role: architect for future product/UX scoping
+Review role: reviewer only after future child issues exist
+Acceptance role: architect / user for future account/admin product decision
+Depends on: #209, #210, and #27
+Completion handoff: hold
+Merge rule: no implementation PRs until this Epic is explicitly reactivated
+Verification required: future scope-specific verification to be defined during decomposition
 ```
 
 ## Scope Control

--- a/docs/06-epic-roadmap.md
+++ b/docs/06-epic-roadmap.md
@@ -17,7 +17,9 @@ Tiny IPA uses Epic issues as the primary planning and multi-agent coordination u
 | M8 Level-based Content Expansion and Core 1000 Rebalance | #108 | Done |
 | M9 UK Accent Compare and Specialty Practice | #28 | Done |
 | M10 UX Research and Practice Experience Optimization | #102 | Done |
-| M11 VPS Deployment and Backup | #27 | Ready |
+| M11 Localization and Configurable UI Language | #209 | Planning |
+| M12 Minimal Auth and Multi-user Data Isolation | #210 | Planning |
+| M13 VPS Deployment and Backup | #27 | Blocked |
 
 ## M0：Feasibility and Architecture Skeleton
 
@@ -361,15 +363,140 @@ practice experience changes preserve existing scheduling and progress boundaries
 final closeout is recorded on #102
 ```
 
-## M11：VPS Deployment and Backup
+## M11：Localization and Configurable UI Language
+
+Goal: make Tiny IPA configurable for learner-facing UI language before auth and
+deployment harden the user boundary.
+
+Roadmap status:
+
+```text
+Planning. Epic #209 has been created as the next roadmap stage, but child
+issues are not planned or released yet.
+```
+
+Expected child issue areas:
+
+```text
+UI language contract and learner-facing copy inventory
+zh-CN and en-US locale resource structure
+settings/API support for configurable UI language
+frontend copy extraction across Today, Practice, Progress, Settings, audio,
+review/focus, and error states
+mobile text-fit and walkthrough evidence for both languages
+final localization readiness review and user-facing trial note
+```
+
+Acceptance:
+
+```text
+zh-CN is the default learner-facing UI language unless product decision changes it
+en-US is selectable without code changes
+learner-facing copy is not hard-coded across production components
+IPA strings, phoneme symbols, accent labels, source word content, and grading
+semantics remain domain data rather than translated UI prose
+missing translation keys fail visibly in dev/test or have a documented fallback
+mobile walkthrough evidence covers major flows and long text fit in both languages
+local dev remains runnable without auth or deployment prerequisites
+```
+
+Boundaries:
+
+```text
+do not translate source word content or meaning_zh in this Epic
+do not add real auth, account management, family dashboard, OAuth, social login,
+analytics, or deployment changes
+do not rewrite scheduler, grading, content import, or progress semantics
+```
+
+Execution contract:
+
+```text
+Branch strategy: epic integration branch
+Integration branch: epic/m11-localization-ui-language
+Base branch: epic/m11-localization-ui-language
+Target PR base: epic/m11-localization-ui-language
+Final PR target: main
+Owner role: architect for planning/decomposition; implementer per child issue
+Review role: reviewer for UI/API changes; architect for cross-issue contract acceptance
+Acceptance role: architect / user for language and copy acceptance
+Completion handoff: batch checkpoint
+```
+
+## M12：Minimal Auth and Multi-user Data Isolation
+
+Goal: add the minimum authentication and per-user data isolation needed before
+personal VPS deployment exposes Tiny IPA beyond a single local default user.
+
+Roadmap status:
+
+```text
+Planning. Epic #210 has been created after #209 and before #27. Child issues are
+not planned or released yet.
+```
+
+Expected child issue areas:
+
+```text
+auth/domain contract and personal-VPS threat boundary
+user model and owner/admin bootstrap strategy
+login, logout, and current-user API/session behavior
+per-user scoping for settings, sessions, attempts, progress, phoneme stats,
+review/focus state, and backup/restore expectations
+old default-user data migration or owner-claim strategy
+minimal frontend login/logout/current-user UX using localized copy from M11
+security/session tests, user-isolation regression tests, and local dev bootstrap
+final auth/data-boundary readiness review before deployment release
+```
+
+Acceptance:
+
+```text
+runtime learner data resolves an authenticated/current user instead of one global user
+settings, normal/review/focus sessions, attempts, progress, and phoneme stats are user-scoped
+shared content tables remain global/source-driven
+existing default data has an explicit migration or owner-claim strategy with backup guidance
+owner/admin bootstrap exists for personal deployment while broad admin UI stays deferred
+login/logout/current-user states are visible and tested or walkthrough-covered
+local development remains easy without external OAuth
+session/cookie/secret behavior needed by VPS deployment is documented and testable
+```
+
+Boundaries:
+
+```text
+do not add OAuth, social login, family dashboard, multi-role permission matrix,
+billing, analytics, email verification, password reset, or broad SaaS account management
+do not perform real data migration or mutate real SQLite data without explicit Human approval
+do not bind business logic to a VPS provider, domain, or reverse proxy
+```
+
+Execution contract:
+
+```text
+Branch strategy: epic integration branch
+Integration branch: epic/m12-minimal-auth-data-isolation
+Base branch: epic/m12-minimal-auth-data-isolation
+Target PR base: epic/m12-minimal-auth-data-isolation
+Final PR target: main
+Owner role: architect for planning/decomposition; implementer per child issue
+Review role: reviewer for implementation PRs; architect for security/data-boundary acceptance
+Acceptance role: architect / user for auth boundary and migration acceptance
+Depends on: #209 for localization/copy boundary before learner-facing auth UI work
+Completion handoff: batch checkpoint
+```
+
+## M13：VPS Deployment and Backup
 
 Goal: make the app reachable on a real phone and maintainable on a personal VPS.
 
 Roadmap status:
 
 ```text
-Ready. M11 is the next Epic candidate after M9 completion. Child issues are not
-planned yet and should be decomposed by Architect before implementation release.
+Blocked. Epic #27 has moved after #209 Localization and #210 Minimal Auth /
+Multi-user Data Isolation. It should not be decomposed or released to
+Implementer until those prerequisites define the language, current-user,
+auth-secret, session-cookie, and user-data backup boundaries.
 ```
 
 Expected child issue areas:
@@ -391,6 +518,17 @@ domain works over HTTPS
 /audio/ works
 service survives restart
 backup can restore learning data
+auth/session secrets and secure cookie behavior are verified for the deployment target
+local dev remains runnable without VPS-only assumptions
+```
+
+Boundaries:
+
+```text
+deployment is an adapter/contract layer, not a place to add business logic
+do not implement auth, localization, account management, or data migration here
+do not mutate real SQLite data, secrets, DNS, VPS runtime, or deployment config
+without explicit Human approval
 ```
 
 ## Scope Control


### PR DESCRIPTION
## Summary

- Insert M11 Localization / configurable UI language before auth and deployment.
- Insert M12 Minimal Auth and Multi-user Data Isolation before VPS deployment.
- Shift existing VPS Deployment and Backup #27 to M13 and document it as blocked on #209/#210.
- Add M14 Account Management and Admin UX as a deferred post-deploy placeholder #212.
- Add planning-level architecture/API boundaries for UI language, current-user resolution, auth/session boundary, default-user migration, and deployment prerequisites.

## Durable planning links

- M11 Epic: #209
- M12 Epic: #210
- Shifted VPS Epic: #27
- Deferred M14 Epic: #212
- Coordinator dispatch: https://github.com/farmerhunter/tiny-ipa/issues/27#issuecomment-4828209306
- Human authorization update: https://github.com/farmerhunter/tiny-ipa/issues/27#issuecomment-4828228985
- Coordinator addendum: https://github.com/farmerhunter/tiny-ipa/issues/27#issuecomment-4828533518

## Verification

- `git diff --check`
- `tools/agents/agent-audit`
- `tools/agents/agent-inbox all`

## Scope boundaries

Planning/docs only. No auth, i18n, account/admin, deployment, runtime config, database, migration, or implementation code changes. No Implementer work released.