### PR TITLE
Add M11 UI language contract inventory

### DIFF
--- a/backend/tests/test_ui_language_inventory.py
+++ b/backend/tests/test_ui_language_inventory.py
@@ -1,0 +1,68 @@
+"""Validate the M11 UI language copy inventory fixture."""
+
+import json
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+INVENTORY_PATH = (
+    REPO_ROOT / "frontend" / "tests" / "fixtures" / "ui-language-copy-inventory.json"
+)
+REQUIRED_SURFACES = {
+    "app_shell",
+    "today",
+    "today_hub",
+    "practice",
+    "practice_summary",
+    "review_focus",
+    "audio",
+    "progress",
+    "settings",
+    "loading_error",
+    "domain_tokens",
+    "content_data",
+    "developer_only",
+}
+REQUIRED_CLASSIFICATIONS = {
+    "translatable",
+    "domain_token",
+    "content_data",
+    "developer_only",
+}
+
+
+def test_ui_language_inventory_schema_and_coverage():
+    inventory = json.loads(INVENTORY_PATH.read_text(encoding="utf-8"))
+
+    assert inventory["default_locale"] == "zh-CN"
+    assert inventory["selectable_locales"] == ["zh-CN", "en-US"]
+    assert set(inventory["classifications"]) == REQUIRED_CLASSIFICATIONS
+
+    entries = inventory["entries"]
+    assert entries
+
+    keys = [entry["key"] for entry in entries]
+    assert len(keys) == len(set(keys))
+    assert all(key == key.lower() for key in keys)
+    assert all(" " not in key for key in keys)
+
+    surfaces = {entry["surface"] for entry in entries}
+    assert REQUIRED_SURFACES <= surfaces
+
+    for entry in entries:
+        assert entry["classification"] in REQUIRED_CLASSIFICATIONS
+        assert entry["surface"] in REQUIRED_SURFACES
+        assert entry["source"]
+        assert entry["current"]
+
+
+def test_ui_language_inventory_preserves_domain_and_content_boundaries():
+    inventory = json.loads(INVENTORY_PATH.read_text(encoding="utf-8"))
+    by_key = {entry["key"]: entry for entry in inventory["entries"]}
+
+    assert by_key["token.ipa_symbols"]["classification"] == "domain_token"
+    assert by_key["token.accent_identifiers"]["classification"] == "domain_token"
+    assert by_key["token.api_enums"]["classification"] == "domain_token"
+    assert by_key["token.error_codes"]["classification"] == "domain_token"
+    assert by_key["content.word_values"]["classification"] == "content_data"
+    assert by_key["content.word_values"]["current"].find("meaning_zh") != -1

--- a/docs/00-design-index.md
+++ b/docs/00-design-index.md
@@ -50,6 +50,9 @@
 12. [M9 UK-Ready Content Subset and Accent Coverage Report](12-m9-uk-ready-content-report.md)
     记录 #196 的 UK-ready 内容子集、口音差异、minimal-pair 候选、target-phoneme 覆盖与内容质量 caveat。
 
+13. [M11 UI Language Contract and Copy Inventory](13-m11-ui-language-contract.md)
+    定义 M11 的 UI 语言边界、copy inventory、locale key 约定、缺失 key 行为，以及不应进入 localization resource 的 IPA/domain/content 数据。
+
 ## 工程随笔
 
 1. [Vibe Coding 中的老登式多 Agent 调度经历](anecdote_Reinventing_agent_scheduler.md)

--- a/docs/13-m11-ui-language-contract.md
+++ b/docs/13-m11-ui-language-contract.md
@@ -1,0 +1,215 @@
+# M11 UI Language Contract and Copy Inventory
+
+This contract defines the first M11 localization boundary for learner-facing UI
+language. It is an implementation guide for #214 through #217, not a locale
+runtime implementation.
+
+## Locale Contract
+
+Initial supported UI locales:
+
+```text
+default locale: zh-CN
+selectable locale: en-US
+```
+
+`zh-CN` is the default for new/local users unless a later Architect/User
+acceptance decision changes it. `en-US` must be selectable without a code
+change once #214/#215 implement settings and locale resources.
+
+Locale keys use lower-case dotted paths:
+
+```text
+<surface>.<flow>.<element>[.<state>]
+```
+
+Examples:
+
+```text
+app.nav.today
+today.hub.heading.start
+practice.feedback.correct
+review.recent.empty
+settings.review_strength
+audio.status.fallback
+error.practice.invalid_request
+```
+
+Dynamic data remains explicit placeholders inside localized strings:
+
+```text
+{level}
+{selectedLevel}
+{currentLevel}
+{groupIndex}
+{count}
+{phonemes}
+{error}
+{status}
+```
+
+Do not concatenate localized fragments around variable grammar unless the
+locale helper supports ordered placeholders. Full phrases should own their
+grammar, such as `today.confirm.abandon_pending`.
+
+## Classification Boundary
+
+The structured inventory lives at:
+
+```text
+frontend/tests/fixtures/ui-language-copy-inventory.json
+```
+
+Every entry is classified as one of:
+
+```text
+translatable
+domain_token
+content_data
+developer_only
+```
+
+### Translatable Learner-Facing Copy
+
+Move learner-visible prose, headings, buttons, helper text, notices, loading
+states, empty states, and recoverable error details into locale resources.
+
+Covered surfaces include:
+
+```text
+app shell
+Today hub
+normal practice
+completion summary
+current-group review
+recent/global review
+focus practice
+specialty Sound Compare / Sound Practice
+audio controls and fallback status
+Progress
+Settings
+API error details that are shown to the learner
+```
+
+Backend fields such as `action_label`, `detail`, `question.prompt`, level
+labels, and accent comparison labels are learner-visible when the frontend
+renders them. Follow-up implementation may either localize them server-side or
+return stable codes/parameters for frontend localization, but it must not leave
+new learner-facing English copy hidden behind backend response fields.
+
+### Stable Domain Tokens
+
+These values are not ordinary prose and must not be translated as locale copy:
+
+```text
+IPA symbols and IPA choices
+phoneme tags
+US / UK accent identifiers
+API enum values and source_scope/origin codes
+group_type values
+learner_level values: entry, mid
+mastery_status values: new, weak, learning, mastered
+error codes such as CONTENT_NOT_READY and INVALID_FOCUS
+route paths and HTTP method names
+```
+
+User-facing labels for those tokens may be localized, but the token values
+themselves remain stable data or machine contracts.
+
+### Content Data
+
+Do not move source content into locale resources:
+
+```text
+item.word
+item.meaning_zh
+IPA strings
+correct_answer / selected_answer
+phoneme inventory symbols
+accent comparison IPA values
+word/source metadata
+content/core_*.json values
+```
+
+`meaning_zh` is content curation data, not UI locale text. M11 must not
+translate source word content or reinterpret content import behavior.
+
+### Developer-Only Copy
+
+Test names, CSS class names, internal comments, CLI commands, fixture labels,
+and non-rendered implementation notes do not need locale keys. If a command or
+diagnostic is rendered to learners, classify the rendered prose as
+`translatable` and keep the command/token itself as a stable token.
+
+## Missing-Key Behavior
+
+Implementation must fail visibly for missing learner-facing keys:
+
+```text
+dev/test: throw or render a deterministic missing-key marker
+production: fall back to en-US text only with a visible telemetry/test signal
+never: silently hide buttons, labels, or recovery actions
+```
+
+Recommended marker shape:
+
+```text
+⟦missing:<locale>:<key>⟧
+```
+
+Interactive controls must remain visible even when a key is missing. A missing
+translation may degrade text quality, but must not remove actions such as start,
+resume, review, focus, clear focus, audio replay, or retry.
+
+## Accepted Initial Inventory
+
+The inventory fixture currently covers these key families:
+
+```text
+app.*
+today.*
+practice.*
+review.*
+focus.*
+specialty.*
+audio.*
+progress.*
+settings.*
+error.*
+token.*
+content.*
+dev.*
+```
+
+The inventory is intentionally compact. It groups repeated variants when they
+share one localization decision, for example `practice.feedback.explanation_labels`
+and `progress.stats`.
+
+## Follow-Up Implementation Guidance
+
+#214 should add UI-language persistence and a Settings selector using this
+contract without changing auth/account/deployment behavior.
+
+#215 should add locale resources for `zh-CN` and `en-US`, enforce the missing-key
+behavior, and decide whether backend-provided learner copy is localized
+server-side or represented as codes and parameters.
+
+#216 should extract frontend copy across the inventoried learner workflows.
+
+#217 should verify mobile text fit and bilingual walkthrough evidence.
+
+#218 remains the Architect/User readiness checkpoint for subjective wording,
+trial notes, and final M11 acceptance.
+
+## Subjective Product-Copy Decisions Deferred
+
+These decisions are not blockers for #213 but need Architect/User acceptance
+before M11 closure:
+
+```text
+English product display name for 小音标
+whether developer setup hints such as import_words.py should be learner-visible
+final Chinese wording for review/focus/specialty practice distinctions
+whether Entry/Mid should be displayed as English tokens, Chinese labels, or both
+tone for auth placeholder copy before real account work
+```

--- a/frontend/tests/fixtures/ui-language-copy-inventory.json
+++ b/frontend/tests/fixtures/ui-language-copy-inventory.json
@@ -1,0 +1,634 @@
+{
+  "inventory_version": "m11-p0-2026-06-29",
+  "default_locale": "zh-CN",
+  "selectable_locales": ["zh-CN", "en-US"],
+  "classifications": [
+    "translatable",
+    "domain_token",
+    "content_data",
+    "developer_only"
+  ],
+  "entries": [
+    {
+      "key": "app.brand.name",
+      "surface": "app_shell",
+      "classification": "translatable",
+      "source": "frontend/src/App.tsx",
+      "current": "小音标",
+      "notes": "Product name copy; English display name needs Architect/User acceptance."
+    },
+    {
+      "key": "app.brand.tagline",
+      "surface": "app_shell",
+      "classification": "translatable",
+      "source": "frontend/src/App.tsx",
+      "current": "每天几分钟，把声音和 IPA 对上号。"
+    },
+    {
+      "key": "app.nav.today",
+      "surface": "app_shell",
+      "classification": "translatable",
+      "source": "frontend/src/App.tsx",
+      "current": "Today"
+    },
+    {
+      "key": "app.nav.progress",
+      "surface": "app_shell",
+      "classification": "translatable",
+      "source": "frontend/src/App.tsx",
+      "current": "Progress"
+    },
+    {
+      "key": "app.nav.settings",
+      "surface": "app_shell",
+      "classification": "translatable",
+      "source": "frontend/src/App.tsx",
+      "current": "Settings"
+    },
+    {
+      "key": "app.login.disabled",
+      "surface": "app_shell",
+      "classification": "translatable",
+      "source": "frontend/src/App.tsx frontend/src/pages/SettingsPage.tsx",
+      "current": "登录 / 登录后同步练习 / 账号入口暂未启用；后续可用于同步进度和错题。",
+      "notes": "Visible auth placeholder; no auth behavior changes in M11."
+    },
+    {
+      "key": "app.backend.connecting",
+      "surface": "loading_error",
+      "classification": "translatable",
+      "source": "frontend/src/App.tsx",
+      "current": "Connecting to backend…"
+    },
+    {
+      "key": "app.backend.unreachable",
+      "surface": "loading_error",
+      "classification": "translatable",
+      "source": "frontend/src/App.tsx",
+      "current": "Cannot reach backend. Make sure it is running on port 8010."
+    },
+    {
+      "key": "today.loading",
+      "surface": "today",
+      "classification": "translatable",
+      "source": "frontend/src/pages/TodayPractice.tsx",
+      "current": "Loading today's practice…"
+    },
+    {
+      "key": "today.error.title",
+      "surface": "today",
+      "classification": "translatable",
+      "source": "frontend/src/pages/TodayPractice.tsx",
+      "current": "Practice unavailable"
+    },
+    {
+      "key": "today.error.import_hint",
+      "surface": "today",
+      "classification": "translatable",
+      "source": "frontend/src/pages/TodayPractice.tsx",
+      "current": "Make sure you've run import_words.py and the backend is running.",
+      "notes": "Developer-oriented wording shown to learners; follow-up copy decision needed before final M11 readiness."
+    },
+    {
+      "key": "today.hub.kicker",
+      "surface": "today_hub",
+      "classification": "translatable",
+      "source": "frontend/src/pages/TodayPractice.tsx",
+      "current": "Today practice hub"
+    },
+    {
+      "key": "today.hub.heading.start",
+      "surface": "today_hub",
+      "classification": "translatable",
+      "source": "frontend/src/pages/TodayPractice.tsx",
+      "current": "Start {selectedLevel} practice"
+    },
+    {
+      "key": "today.hub.heading.active",
+      "surface": "today_hub",
+      "classification": "translatable",
+      "source": "frontend/src/pages/TodayPractice.tsx",
+      "current": "{level} practice in progress"
+    },
+    {
+      "key": "today.hub.copy.empty",
+      "surface": "today_hub",
+      "classification": "translatable",
+      "source": "frontend/src/pages/TodayPractice.tsx",
+      "current": "A short listening group is ready. Listen first, then choose the IPA that matches."
+    },
+    {
+      "key": "today.hub.copy.active",
+      "surface": "today_hub",
+      "classification": "translatable",
+      "source": "frontend/src/pages/TodayPractice.tsx",
+      "current": "Pick up where you left off, or switch intentionally when you are ready."
+    },
+    {
+      "key": "today.hub.status.ready",
+      "surface": "today_hub",
+      "classification": "translatable",
+      "source": "frontend/src/pages/TodayPractice.tsx",
+      "current": "Ready when you are / {selectedLevel} listening group / {count} words per normal group"
+    },
+    {
+      "key": "today.hub.status.active",
+      "surface": "today_hub",
+      "classification": "translatable",
+      "source": "frontend/src/pages/TodayPractice.tsx",
+      "current": "Active group / {level} group in progress / {wordCount} words assigned"
+    },
+    {
+      "key": "today.hub.pending_level_change",
+      "surface": "today_hub",
+      "classification": "translatable",
+      "source": "frontend/src/pages/TodayPractice.tsx",
+      "current": "{selectedLevel} is selected for your next new group. Your current {currentLevel} group stays active until you finish it or switch now."
+    },
+    {
+      "key": "today.hub.completed_today",
+      "surface": "today_hub",
+      "classification": "translatable",
+      "source": "frontend/src/pages/TodayPractice.tsx",
+      "current": "Completed today: Entry {entryCount}, Mid {midCount}."
+    },
+    {
+      "key": "today.action.start_group",
+      "surface": "today_hub",
+      "classification": "translatable",
+      "source": "frontend/src/pages/TodayPractice.tsx backend/app/services/sessions.py",
+      "current": "Start {level} group / Start {level} Group {groupIndex}"
+    },
+    {
+      "key": "today.action.resume_group",
+      "surface": "today_hub",
+      "classification": "translatable",
+      "source": "frontend/src/pages/TodayPractice.tsx backend/app/services/sessions.py",
+      "current": "Resume {level} group / Resume {level} Group {groupIndex}"
+    },
+    {
+      "key": "today.action.switch_now",
+      "surface": "today_hub",
+      "classification": "translatable",
+      "source": "frontend/src/pages/TodayPractice.tsx",
+      "current": "Switch to {selectedLevel} now"
+    },
+    {
+      "key": "today.confirm.abandon_pending",
+      "surface": "today_hub",
+      "classification": "translatable",
+      "source": "frontend/src/pages/TodayPractice.tsx",
+      "current": "End this {currentLevel} group and switch to {selectedLevel} now?"
+    },
+    {
+      "key": "today.confirm.abandon_same_level",
+      "surface": "today_hub",
+      "classification": "translatable",
+      "source": "frontend/src/pages/TodayPractice.tsx",
+      "current": "End this {currentLevel} group and start another {selectedLevel} group?"
+    },
+    {
+      "key": "today.group.reason.normal_next",
+      "surface": "practice",
+      "classification": "translatable",
+      "source": "frontend/src/pages/TodayPractice.tsx",
+      "current": "A new {level} practice group."
+    },
+    {
+      "key": "today.group.reason.normal_resume",
+      "surface": "practice",
+      "classification": "translatable",
+      "source": "frontend/src/pages/TodayPractice.tsx",
+      "current": "Resuming your current {level} group."
+    },
+    {
+      "key": "practice.question.prompt.choose_ipa",
+      "surface": "practice",
+      "classification": "translatable",
+      "source": "backend/app/services/questions.py",
+      "current": "Which IPA matches this word?"
+    },
+    {
+      "key": "practice.feedback.submitting",
+      "surface": "practice",
+      "classification": "translatable",
+      "source": "frontend/src/components/ChoiceQuestion.tsx",
+      "current": "Submitting…"
+    },
+    {
+      "key": "practice.feedback.correct",
+      "surface": "practice",
+      "classification": "translatable",
+      "source": "frontend/src/components/ChoiceQuestion.tsx",
+      "current": "Correct!"
+    },
+    {
+      "key": "practice.feedback.incorrect",
+      "surface": "practice",
+      "classification": "translatable",
+      "source": "frontend/src/components/ChoiceQuestion.tsx",
+      "current": "Not quite."
+    },
+    {
+      "key": "practice.feedback.explanation_labels",
+      "surface": "practice",
+      "classification": "translatable",
+      "source": "frontend/src/components/ChoiceQuestion.tsx frontend/src/pages/TodayPractice.tsx",
+      "current": "You picked / Correct IPA / Target sound / picked {selected}, correct {correct}"
+    },
+    {
+      "key": "practice.feedback.focus_hint.default",
+      "surface": "practice",
+      "classification": "translatable",
+      "source": "frontend/src/components/ChoiceQuestion.tsx frontend/src/pages/TodayPractice.tsx",
+      "current": "Focus on the IPA difference, then listen again."
+    },
+    {
+      "key": "practice.feedback.focus_hint.phonemes",
+      "surface": "practice",
+      "classification": "translatable",
+      "source": "frontend/src/components/ChoiceQuestion.tsx frontend/src/pages/TodayPractice.tsx",
+      "current": "Focus on {phonemes} before choosing."
+    },
+    {
+      "key": "practice.action.continue",
+      "surface": "practice",
+      "classification": "translatable",
+      "source": "frontend/src/components/ChoiceQuestion.tsx",
+      "current": "Continue"
+    },
+    {
+      "key": "practice.feedback.submit_failed",
+      "surface": "practice",
+      "classification": "translatable",
+      "source": "frontend/src/components/ChoiceQuestion.tsx",
+      "current": "Failed to submit: {error}"
+    },
+    {
+      "key": "practice.summary.complete_title",
+      "surface": "practice_summary",
+      "classification": "translatable",
+      "source": "frontend/src/pages/TodayPractice.tsx",
+      "current": "{groupLabel} complete"
+    },
+    {
+      "key": "practice.summary.score",
+      "surface": "practice_summary",
+      "classification": "translatable",
+      "source": "frontend/src/pages/TodayPractice.tsx",
+      "current": "{correctCount} / {totalCount} correct"
+    },
+    {
+      "key": "practice.summary.current_misses",
+      "surface": "practice_summary",
+      "classification": "translatable",
+      "source": "frontend/src/pages/TodayPractice.tsx",
+      "current": "This group's misses"
+    },
+    {
+      "key": "practice.summary.no_misses",
+      "surface": "practice_summary",
+      "classification": "translatable",
+      "source": "frontend/src/pages/TodayPractice.tsx",
+      "current": "No misses in this group."
+    },
+    {
+      "key": "practice.summary.focus_next",
+      "surface": "practice_summary",
+      "classification": "translatable",
+      "source": "frontend/src/pages/TodayPractice.tsx",
+      "current": "Focus a weak sound next / Start a focused group weighted toward one of the sounds missed in this group."
+    },
+    {
+      "key": "review.current.action",
+      "surface": "review_focus",
+      "classification": "translatable",
+      "source": "frontend/src/pages/TodayPractice.tsx backend/app/services/sessions.py",
+      "current": "Review this group's misses / Review Group {groupIndex} misses"
+    },
+    {
+      "key": "review.current.empty",
+      "surface": "review_focus",
+      "classification": "translatable",
+      "source": "frontend/src/pages/TodayPractice.tsx backend/app/services/sessions.py",
+      "current": "No misses in this group are ready for review. / No incorrect answers are available for this group."
+    },
+    {
+      "key": "review.recent.action",
+      "surface": "review_focus",
+      "classification": "translatable",
+      "source": "frontend/src/pages/TodayPractice.tsx backend/app/services/sessions.py",
+      "current": "Review {count} older mistakes / Start Recent Review Group {groupIndex}"
+    },
+    {
+      "key": "review.recent.empty",
+      "surface": "review_focus",
+      "classification": "translatable",
+      "source": "frontend/src/pages/TodayPractice.tsx backend/app/services/sessions.py",
+      "current": "No recent mistakes are ready for review. / No recent incorrect attempts are available for review."
+    },
+    {
+      "key": "focus.current.panel",
+      "surface": "review_focus",
+      "classification": "translatable",
+      "source": "frontend/src/pages/ProgressPage.tsx frontend/src/pages/SettingsPage.tsx",
+      "current": "Current focus / Next group focus / Focus changes the next focused practice group. Clear it to return to normal practice."
+    },
+    {
+      "key": "focus.action.start",
+      "surface": "review_focus",
+      "classification": "translatable",
+      "source": "frontend/src/pages/ProgressPage.tsx frontend/src/pages/SettingsPage.tsx backend/app/services/sessions.py",
+      "current": "Focus {phoneme} / Start {level} Focus Group {groupIndex}"
+    },
+    {
+      "key": "focus.action.resume",
+      "surface": "review_focus",
+      "classification": "translatable",
+      "source": "frontend/src/pages/ProgressPage.tsx backend/app/services/sessions.py",
+      "current": "Resume focus / Resume {level} Focus Group {groupIndex}"
+    },
+    {
+      "key": "focus.action.clear",
+      "surface": "review_focus",
+      "classification": "translatable",
+      "source": "frontend/src/pages/TodayPractice.tsx frontend/src/pages/ProgressPage.tsx frontend/src/pages/SettingsPage.tsx backend/app/services/sessions.py",
+      "current": "Clear focus / Focus cleared. Back to normal practice. / Focus selection cleared."
+    },
+    {
+      "key": "specialty.sound_compare",
+      "surface": "review_focus",
+      "classification": "translatable",
+      "source": "frontend/src/pages/TodayPractice.tsx backend/app/services/sessions.py",
+      "current": "Sound Compare / Compare words with easily confused sounds. This is separate from mistake review and weak-sound focus."
+    },
+    {
+      "key": "specialty.sound_compare.empty",
+      "surface": "review_focus",
+      "classification": "translatable",
+      "source": "frontend/src/pages/TodayPractice.tsx backend/app/services/sessions.py",
+      "current": "Sound Compare practice is not available yet. It needs at least two safe words with pair metadata."
+    },
+    {
+      "key": "specialty.sound_practice",
+      "surface": "review_focus",
+      "classification": "translatable",
+      "source": "frontend/src/pages/TodayPractice.tsx backend/app/services/sessions.py",
+      "current": "Sound Practice / Pick one approved American sound for intentional practice."
+    },
+    {
+      "key": "specialty.sound_practice.empty",
+      "surface": "review_focus",
+      "classification": "translatable",
+      "source": "frontend/src/pages/TodayPractice.tsx backend/app/services/sessions.py",
+      "current": "Sound Practice is not available for this sound yet. It needs safe words tagged with the selected American sound."
+    },
+    {
+      "key": "audio.action.play_recorded",
+      "surface": "audio",
+      "classification": "translatable",
+      "source": "frontend/src/components/AudioButton.tsx",
+      "current": "Play recorded pronunciation"
+    },
+    {
+      "key": "audio.action.play_browser_voice",
+      "surface": "audio",
+      "classification": "translatable",
+      "source": "frontend/src/components/AudioButton.tsx",
+      "current": "Play pronunciation with browser voice"
+    },
+    {
+      "key": "audio.status.recorded",
+      "surface": "audio",
+      "classification": "translatable",
+      "source": "frontend/src/components/AudioButton.tsx",
+      "current": "Recorded audio / Playing recorded audio"
+    },
+    {
+      "key": "audio.status.browser_voice",
+      "surface": "audio",
+      "classification": "translatable",
+      "source": "frontend/src/components/AudioButton.tsx",
+      "current": "Browser voice / Playing browser voice"
+    },
+    {
+      "key": "audio.status.fallback",
+      "surface": "audio",
+      "classification": "translatable",
+      "source": "frontend/src/components/AudioButton.tsx",
+      "current": "Recorded audio unavailable; using browser voice"
+    },
+    {
+      "key": "audio.status.unavailable",
+      "surface": "audio",
+      "classification": "translatable",
+      "source": "frontend/src/components/AudioButton.tsx",
+      "current": "Audio unavailable"
+    },
+    {
+      "key": "progress.loading",
+      "surface": "progress",
+      "classification": "translatable",
+      "source": "frontend/src/pages/ProgressPage.tsx",
+      "current": "Loading progress…"
+    },
+    {
+      "key": "progress.today_status",
+      "surface": "progress",
+      "classification": "translatable",
+      "source": "frontend/src/pages/ProgressPage.tsx",
+      "current": "Done / Started / Ready / practice completed today / practice underway today / start today's practice"
+    },
+    {
+      "key": "progress.stats",
+      "surface": "progress",
+      "classification": "translatable",
+      "source": "frontend/src/pages/ProgressPage.tsx",
+      "current": "answered items / completed groups / active / {accuracy}% accuracy / Accuracy appears after answers"
+    },
+    {
+      "key": "progress.level.hints",
+      "surface": "progress",
+      "classification": "translatable",
+      "source": "frontend/src/pages/ProgressPage.tsx",
+      "current": "{level} has an active group. Answer a few items to unlock accuracy and sound signals. / {level} has no answered items yet. / {level} has sounds ready for focused practice."
+    },
+    {
+      "key": "progress.weak.level",
+      "surface": "progress",
+      "classification": "translatable",
+      "source": "frontend/src/pages/ProgressPage.tsx",
+      "current": "Sounds to revisit in {level} / No weak sound signal yet for {level}; it appears after answered items."
+    },
+    {
+      "key": "progress.weak.global",
+      "surface": "progress",
+      "classification": "translatable",
+      "source": "frontend/src/pages/ProgressPage.tsx",
+      "current": "Sounds to revisit overall / Sounds that need more reps across your complete history."
+    },
+    {
+      "key": "progress.strong.global",
+      "surface": "progress",
+      "classification": "translatable",
+      "source": "frontend/src/pages/ProgressPage.tsx",
+      "current": "Sounds going well overall"
+    },
+    {
+      "key": "progress.empty",
+      "surface": "progress",
+      "classification": "translatable",
+      "source": "frontend/src/pages/ProgressPage.tsx",
+      "current": "Answer a few items to see sound-level progress."
+    },
+    {
+      "key": "settings.loading",
+      "surface": "settings",
+      "classification": "translatable",
+      "source": "frontend/src/pages/SettingsPage.tsx",
+      "current": "Loading…"
+    },
+    {
+      "key": "settings.saved",
+      "surface": "settings",
+      "classification": "translatable",
+      "source": "frontend/src/pages/SettingsPage.tsx",
+      "current": "Saved"
+    },
+    {
+      "key": "settings.words_per_group",
+      "surface": "settings",
+      "classification": "translatable",
+      "source": "frontend/src/pages/SettingsPage.tsx",
+      "current": "Words per group"
+    },
+    {
+      "key": "settings.show_translation",
+      "surface": "settings",
+      "classification": "translatable",
+      "source": "frontend/src/pages/SettingsPage.tsx",
+      "current": "Show translation"
+    },
+    {
+      "key": "settings.accent_compare",
+      "surface": "settings",
+      "classification": "translatable",
+      "source": "frontend/src/pages/SettingsPage.tsx",
+      "current": "Accent comparison / Show British notes after answering"
+    },
+    {
+      "key": "settings.review_strength",
+      "surface": "settings",
+      "classification": "translatable",
+      "source": "frontend/src/pages/SettingsPage.tsx",
+      "current": "Review strength / Quick / Normal / Extra review"
+    },
+    {
+      "key": "settings.practice_level",
+      "surface": "settings",
+      "classification": "translatable",
+      "source": "frontend/src/pages/SettingsPage.tsx",
+      "current": "Practice level / Choose the level for the next new normal group."
+    },
+    {
+      "key": "settings.level.entry",
+      "surface": "settings",
+      "classification": "translatable",
+      "source": "frontend/src/pages/SettingsPage.tsx backend/app/services/sessions.py backend/app/services/progress.py",
+      "current": "Entry / Starter word pool for the next new normal group."
+    },
+    {
+      "key": "settings.level.mid",
+      "surface": "settings",
+      "classification": "translatable",
+      "source": "frontend/src/pages/SettingsPage.tsx backend/app/services/sessions.py backend/app/services/progress.py",
+      "current": "Mid / Broader word pool for the next new normal group."
+    },
+    {
+      "key": "settings.focus_practice",
+      "surface": "settings",
+      "classification": "translatable",
+      "source": "frontend/src/pages/SettingsPage.tsx",
+      "current": "Focus practice / Pick a sound to start a focused group. The scheduler will weight words toward that sound until you clear focus."
+    },
+    {
+      "key": "settings.focus.manual",
+      "surface": "settings",
+      "classification": "translatable",
+      "source": "frontend/src/pages/SettingsPage.tsx",
+      "current": "Manual IPA focus entry / Comma-separated IPA symbols"
+    },
+    {
+      "key": "error.api.normalized",
+      "surface": "loading_error",
+      "classification": "translatable",
+      "source": "frontend/src/api.ts",
+      "current": "Request failed (HTTP {status}) / {errorCode}: {detail}"
+    },
+    {
+      "key": "error.settings.invalid",
+      "surface": "loading_error",
+      "classification": "translatable",
+      "source": "backend/app/routes/settings.py",
+      "current": "primary_accent must be one of ... / daily_word_count must be an integer between 1 and 50 / focus_phonemes must be a list of non-empty strings"
+    },
+    {
+      "key": "error.practice.invalid_request",
+      "surface": "loading_error",
+      "classification": "translatable",
+      "source": "backend/app/routes/practice.py backend/app/routes/attempts.py",
+      "current": "phoneme must be one approved sound string. / group_id is required for current-group review. / Missing session_item_id"
+    },
+    {
+      "key": "token.ipa_symbols",
+      "surface": "domain_tokens",
+      "classification": "domain_token",
+      "source": "frontend/src/components/ChoiceQuestion.tsx frontend/src/pages/TodayPractice.tsx content/phonemes.json",
+      "current": "/ʃ/ /θ/ /æ/ /ɪ/ /tʃ/ /ʌ/ and all IPA choices",
+      "notes": "Never translate, normalize, or wrap as prose."
+    },
+    {
+      "key": "token.accent_identifiers",
+      "surface": "domain_tokens",
+      "classification": "domain_token",
+      "source": "frontend/src/api.ts backend/app/routes/settings.py",
+      "current": "US / UK / primary_accent / show_accent_compare"
+    },
+    {
+      "key": "token.api_enums",
+      "surface": "domain_tokens",
+      "classification": "domain_token",
+      "source": "frontend/src/api.ts backend/app/services/sessions.py backend/app/services/progress.py",
+      "current": "entry / mid / normal / weak_focus / mistake_review / minimal_pair / target_phoneme / normal_next / recent_global / current_group / new / weak / learning / mastered"
+    },
+    {
+      "key": "token.error_codes",
+      "surface": "domain_tokens",
+      "classification": "domain_token",
+      "source": "backend/app/routes/practice.py backend/app/routes/settings.py backend/app/routes/attempts.py",
+      "current": "CONTENT_NOT_READY / INVALID_FOCUS / SETTINGS_INVALID / INVALID_ATTEMPT / ITEM_NOT_FOUND / SESSION_NOT_FOUND"
+    },
+    {
+      "key": "content.word_values",
+      "surface": "content_data",
+      "classification": "content_data",
+      "source": "frontend/src/components/ChoiceQuestion.tsx content/*.json",
+      "current": "item.word, item.meaning_zh, IPA choices, correct_answer, source word metadata",
+      "notes": "Do not move source word content or meaning_zh into locale resources."
+    },
+    {
+      "key": "content.accent_compare_values",
+      "surface": "content_data",
+      "classification": "content_data",
+      "source": "frontend/src/components/ChoiceQuestion.tsx backend/app/services/sessions.py",
+      "current": "accent_compare.primary.ipa, accent_compare.comparison.ipa, comparison.review_note"
+    },
+    {
+      "key": "dev.test_selectors_and_classnames",
+      "surface": "developer_only",
+      "classification": "developer_only",
+      "source": "frontend/src/**/*.tsx frontend/tests/e2e/*.spec.ts",
+      "current": "CSS classes, test names, route-mock labels, command names, import_words.py references in docs/tests"
+    }
+  ]
+}


### PR DESCRIPTION
## Scope completed
- Added the M11 UI language contract for locale shape, key conventions, fallback/missing-key behavior, persistence/API boundary, and follow-up issue responsibilities.
- Added a structured UI language copy inventory fixture covering app shell, Today hub/practice/summary, review/focus, audio, Progress, Settings, API errors, domain/content boundaries, and developer-only copy.
- Added backend pytest validation for inventory schema, required surface coverage, unique lowercase keys, and preservation of domain/content boundaries.
- Updated `docs/00-design-index.md` so the M11 contract is discoverable.

## Files changed
- `docs/13-m11-ui-language-contract.md`
- `docs/00-design-index.md`
- `frontend/tests/fixtures/ui-language-copy-inventory.json`
- `backend/tests/test_ui_language_inventory.py`

## Verification
- `uv run --project backend pytest backend/tests/test_ui_language_inventory.py` -> passed
- `git diff --check` -> passed
- `tools/agents/agent-audit` -> passed clean
- `uv run --project backend pytest` -> 211 passed, 1 existing Starlette/httpx deprecation warning

## Scope boundaries
- No locale runtime implementation.
- No Settings API implementation.
- No frontend extraction implementation.
- No auth/account/deployment behavior.
- No scheduler, grading, content import, progress, database, runtime config, deployment config, or security config changes.
- No #214-#218 work started.

## Residual risks
- The inventory is an initial contract surface and may need small additions when #214-#216 touch exact runtime strings.
- English translations remain intentionally absent until locale resource work.
- Product naming and learner-facing English wording still need later acceptance in the relevant child issues/readiness review.

Linked: #209, #213
