### PR TITLE
[#214] Add Settings UI language selector

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -64,6 +64,7 @@ class Settings:
     practice_mode: str = "ipa_first"
     review_strength: str = "normal"
     learner_level: str = "entry"
+    ui_language: str = "zh-CN"
     focus_phonemes: List[str] = field(default_factory=list)
     updated_at: str = ""
 

--- a/backend/app/routes/settings.py
+++ b/backend/app/routes/settings.py
@@ -16,6 +16,7 @@ _VALID_ACCENTS = {"US", "UK"}
 _VALID_MODES = {"ipa_first", "reveal_first"}
 _VALID_STRENGTHS = {"normal", "extra_review", "quick"}
 _VALID_LEARNER_LEVELS = {"entry", "mid"}
+_VALID_UI_LANGUAGES = {"zh-CN", "en-US"}
 
 
 @router.get("/settings")
@@ -33,6 +34,7 @@ def settings_get():
                 "practice_mode": "ipa_first",
                 "review_strength": "normal",
                 "learner_level": "entry",
+                "ui_language": "zh-CN",
                 "focus_phonemes": [],
             }
         return {
@@ -43,6 +45,7 @@ def settings_get():
             "practice_mode": s.practice_mode,
             "review_strength": s.review_strength,
             "learner_level": s.learner_level,
+            "ui_language": s.ui_language,
             "focus_phonemes": s.focus_phonemes,
         }
 
@@ -112,6 +115,13 @@ async def settings_put(request: Request):
             else:
                 existing.learner_level = v
 
+        if "ui_language" in body:
+            v = body["ui_language"]
+            if v not in _VALID_UI_LANGUAGES:
+                errors.append(f"ui_language must be one of {_VALID_UI_LANGUAGES}")
+            else:
+                existing.ui_language = v
+
         if "focus_phonemes" in body:
             v = body["focus_phonemes"]
             if not isinstance(v, list) or any(
@@ -138,5 +148,6 @@ async def settings_put(request: Request):
             "practice_mode": existing.practice_mode,
             "review_strength": existing.review_strength,
             "learner_level": existing.learner_level,
+            "ui_language": existing.ui_language,
             "focus_phonemes": existing.focus_phonemes,
         }

--- a/backend/app/services/db_schema.py
+++ b/backend/app/services/db_schema.py
@@ -57,6 +57,7 @@ TABLES_DDL: List[str] = [
         practice_mode        TEXT    NOT NULL,
         review_strength      TEXT    NOT NULL,
         learner_level        TEXT    NOT NULL DEFAULT 'entry',
+        ui_language          TEXT    NOT NULL DEFAULT 'zh-CN',
         focus_phonemes       TEXT    NOT NULL DEFAULT '[]', -- JSON array
         updated_at           TEXT    NOT NULL
     )
@@ -167,6 +168,10 @@ def ensure_settings_schema(conn: sqlite3.Connection) -> None:
     if "learner_level" not in columns:
         conn.execute(
             "ALTER TABLE settings ADD COLUMN learner_level TEXT NOT NULL DEFAULT 'entry'"
+        )
+    if "ui_language" not in columns:
+        conn.execute(
+            "ALTER TABLE settings ADD COLUMN ui_language TEXT NOT NULL DEFAULT 'zh-CN'"
         )
 
 

--- a/backend/app/services/db_store.py
+++ b/backend/app/services/db_store.py
@@ -90,6 +90,7 @@ def _settings_from_row(row: sqlite3.Row) -> Settings:
         practice_mode=row["practice_mode"],
         review_strength=row["review_strength"],
         learner_level=row["learner_level"],
+        ui_language=row["ui_language"],
         focus_phonemes=_parse_list(row["focus_phonemes"]) or [],
         updated_at=row["updated_at"],
     )
@@ -210,11 +211,13 @@ def upsert_settings(conn: sqlite3.Connection, settings: Settings) -> None:
         INSERT OR REPLACE INTO settings (
             user_id, primary_accent, daily_word_count,
             show_translation, show_accent_compare,
-            practice_mode, review_strength, learner_level, focus_phonemes, updated_at
+            practice_mode, review_strength, learner_level, ui_language,
+            focus_phonemes, updated_at
         ) VALUES (
             :user_id, :primary_accent, :daily_word_count,
             :show_translation, :show_accent_compare,
-            :practice_mode, :review_strength, :learner_level, :focus_phonemes, :updated_at
+            :practice_mode, :review_strength, :learner_level, :ui_language,
+            :focus_phonemes, :updated_at
         )
         """,
         {
@@ -226,6 +229,7 @@ def upsert_settings(conn: sqlite3.Connection, settings: Settings) -> None:
             "practice_mode": settings.practice_mode,
             "review_strength": settings.review_strength,
             "learner_level": settings.learner_level,
+            "ui_language": settings.ui_language,
             "focus_phonemes": _to_json(settings.focus_phonemes),
             "updated_at": settings.updated_at,
         },

--- a/backend/tests/test_import_words.py
+++ b/backend/tests/test_import_words.py
@@ -81,7 +81,7 @@ class TestSchemaInitialisation:
         conn.close()
         assert before == after
 
-    def test_init_adds_focus_phonemes_to_existing_settings_table(self, temp_db):
+    def test_init_adds_new_settings_columns_to_existing_settings_table(self, temp_db):
         conn = get_connection(temp_db)
         conn.execute(
             """
@@ -115,7 +115,11 @@ class TestSchemaInitialisation:
         conn.close()
 
         assert "focus_phonemes" in columns
+        assert "learner_level" in columns
+        assert "ui_language" in columns
         assert settings is not None
+        assert settings.learner_level == "entry"
+        assert settings.ui_language == "zh-CN"
         assert settings.focus_phonemes == []
 
 
@@ -240,6 +244,7 @@ class TestSettingsStore:
             show_accent_compare=False,
             practice_mode="ipa_first",
             review_strength="normal",
+            ui_language="en-US",
             focus_phonemes=["/ʃ/", "/ɪ/"],
             updated_at="2026-06-06T00:00:00Z",
         )
@@ -252,6 +257,7 @@ class TestSettingsStore:
         assert got.show_accent_compare is False
         assert got.practice_mode == "ipa_first"
         assert got.review_strength == "normal"
+        assert got.ui_language == "en-US"
         assert got.focus_phonemes == ["/ʃ/", "/ɪ/"]
 
     def test_get_missing_settings(self):
@@ -297,6 +303,7 @@ class TestImportWords:
         assert settings.user_id == "default"
         assert settings.primary_accent == "US"
         assert settings.daily_word_count == 10
+        assert settings.ui_language == "zh-CN"
         assert settings.focus_phonemes == []
 
     def test_import_preserves_accent_fields(self, temp_db):

--- a/backend/tests/test_settings_api.py
+++ b/backend/tests/test_settings_api.py
@@ -52,6 +52,7 @@ class TestSettingsApi:
         assert data["daily_word_count"] == 10
         assert data["show_translation"] is True
         assert data["learner_level"] == "entry"
+        assert data["ui_language"] == "zh-CN"
         assert data["focus_phonemes"] == []
 
     def test_put_updates_and_persists(self, client, seeded_db):
@@ -59,6 +60,7 @@ class TestSettingsApi:
             "daily_word_count": 5,
             "show_translation": False,
             "learner_level": "mid",
+            "ui_language": "en-US",
             "focus_phonemes": ["/ʃ/", " /ɪ/ "],
         })
         assert resp.status_code == 200
@@ -66,6 +68,7 @@ class TestSettingsApi:
         assert data["daily_word_count"] == 5
         assert data["show_translation"] is False
         assert data["learner_level"] == "mid"
+        assert data["ui_language"] == "en-US"
         assert data["focus_phonemes"] == ["/ʃ/", "/ɪ/"]
         # Other fields unchanged
         assert data["primary_accent"] == "US"
@@ -78,7 +81,14 @@ class TestSettingsApi:
         assert s.daily_word_count == 5
         assert s.show_translation is False
         assert s.learner_level == "mid"
+        assert s.ui_language == "en-US"
         assert s.focus_phonemes == ["/ʃ/", "/ɪ/"]
+
+    @pytest.mark.parametrize("ui_language", ["zh-CN", "en-US"])
+    def test_put_accepts_supported_ui_languages(self, client, ui_language):
+        resp = client.put("/api/settings", json={"ui_language": ui_language})
+        assert resp.status_code == 200
+        assert resp.json()["ui_language"] == ui_language
 
     def test_put_invalid_daily_word_count(self, client):
         resp = client.put("/api/settings", json={"daily_word_count": 100})
@@ -98,6 +108,11 @@ class TestSettingsApi:
 
     def test_put_invalid_learner_level(self, client):
         resp = client.put("/api/settings", json={"learner_level": "advanced"})
+        assert resp.status_code == 400
+        assert resp.json()["detail"]["error"] == "SETTINGS_INVALID"
+
+    def test_put_invalid_ui_language(self, client):
+        resp = client.put("/api/settings", json={"ui_language": "fr-FR"})
         assert resp.status_code == 400
         assert resp.json()["detail"]["error"] == "SETTINGS_INVALID"
 
@@ -137,6 +152,7 @@ class TestSettingsApi:
             assert resp.status_code == 200
             assert resp.json()["daily_word_count"] == 10
             assert resp.json()["learner_level"] == "entry"
+            assert resp.json()["ui_language"] == "zh-CN"
             assert resp.json()["focus_phonemes"] == []
         finally:
             db_mod.DEFAULT_DB_PATH = orig

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -319,6 +319,7 @@ export interface SettingsData {
   practice_mode: string;
   review_strength: string;
   learner_level: "entry" | "mid";
+  ui_language: "zh-CN" | "en-US";
   focus_phonemes: string[];
 }
 

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -39,6 +39,14 @@ const LEVEL_OPTIONS: Array<{
   },
 ];
 
+const UI_LANGUAGE_OPTIONS: Array<{
+  value: SettingsData["ui_language"];
+  label: string;
+}> = [
+  { value: "zh-CN", label: "中文 (zh-CN)" },
+  { value: "en-US", label: "English (en-US)" },
+];
+
 function canonicalFocus(phonemes: string[]): string[] {
   return Array.from(new Set(phonemes.map((item) => item.trim()).filter(Boolean))).sort();
 }
@@ -163,6 +171,16 @@ export default function SettingsPage({
             <option value="quick">Quick</option>
             <option value="normal">Normal</option>
             <option value="extra_review">Extra review</option>
+          </select>
+        </label>
+
+        <label className="setting-row">
+          <span>UI language</span>
+          <select value={settings.ui_language}
+            onChange={e => update({ ui_language: e.target.value as SettingsData["ui_language"] })}>
+            {UI_LANGUAGE_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>{option.label}</option>
+            ))}
           </select>
         </label>
 

--- a/frontend/tests/e2e/m10-ux-walkthrough.spec.ts
+++ b/frontend/tests/e2e/m10-ux-walkthrough.spec.ts
@@ -318,6 +318,7 @@ function settingsResponse(state: MockState) {
     practice_mode: "ipa_first",
     review_strength: "normal",
     learner_level: state.selectedLevel,
+    ui_language: "zh-CN",
     focus_phonemes: state.focusPhonemes,
   };
 }

--- a/frontend/tests/e2e/m7-walkthrough.spec.ts
+++ b/frontend/tests/e2e/m7-walkthrough.spec.ts
@@ -234,6 +234,7 @@ function settingsResponse(state: MockState) {
     practice_mode: "adaptive",
     review_strength: "normal",
     learner_level: "entry",
+    ui_language: "zh-CN",
     focus_phonemes: state.focusPhonemes,
   };
 }

--- a/frontend/tests/e2e/m8-level-selection.spec.ts
+++ b/frontend/tests/e2e/m8-level-selection.spec.ts
@@ -111,6 +111,7 @@ function settingsResponse(state: MockState) {
     practice_mode: "ipa_first",
     review_strength: "normal",
     learner_level: state.selectedLevel,
+    ui_language: "zh-CN",
     focus_phonemes: [],
   };
 }


### PR DESCRIPTION
## Summary
- Adds persisted `ui_language` to settings with default `zh-CN` and accepted values `zh-CN` / `en-US`.
- Exposes `ui_language` in `GET /api/settings` and validates `PUT /api/settings` with `SETTINGS_INVALID` on unsupported values.
- Adds a Settings page UI language selector and keeps frontend settings mocks aligned.

## Verification
- `uv run --project backend pytest backend/tests/test_settings_api.py backend/tests/test_import_words.py`
- `uv run --project backend pytest`
- `cd frontend && pnpm run lint`
- `cd frontend && pnpm exec tsc --noEmit`
- `cd frontend && pnpm run build`
- `git diff --check`
- `tools/agents/agent-audit`

## Scope notes
- No auth/session/account/admin/deployment behavior added.
- No locale resource tables/files or UI string extraction implemented.
- No learning-domain semantics, scheduler, grading, content import, or progress behavior changed.

Closes/Refs #214