### PR TITLE
[#233] Fix next normal group after completion

### DIFF
--- a/backend/app/services/sessions.py
+++ b/backend/app/services/sessions.py
@@ -24,6 +24,7 @@ from app.services.db_store import (
     get_settings,
     get_word_by_id,
     mark_session_abandoned,
+    mark_session_completed,
     upsert_settings,
 )
 from app.services.questions import generate_question
@@ -61,6 +62,10 @@ def _seed_from_group(session_date: str, group_index: int, group_type: str) -> in
     return _stable_hash(f"{session_date}:{group_index}:{group_type}")
 
 
+def _all_session_items_complete(items: List[SessionItem]) -> bool:
+    return bool(items) and all(item.status == "complete" for item in items)
+
+
 def build_today_response(
     conn,
     *,
@@ -89,6 +94,17 @@ def build_today_response(
     existing = get_active_session_for_date(conn, user_id, session_date, accent, "normal")
     if existing is not None:
         items = get_session_items(conn, existing.id)
+        if _all_session_items_complete(items):
+            mark_session_completed(conn, existing.id, _now_iso())
+            return _normal_empty_response(
+                conn,
+                user_id=user_id,
+                session_date=session_date,
+                accent=accent,
+                daily_word_count=daily_word_count,
+                selected_level=selected_level,
+                focus_phonemes=settings.focus_phonemes,
+            )
         return _build_response(
             session=existing,
             items=items,
@@ -134,6 +150,17 @@ def build_next_normal_group_response(
     existing = get_active_session_for_date(conn, user_id, session_date, accent, "normal")
     if existing is not None:
         items = get_session_items(conn, existing.id)
+        if _all_session_items_complete(items):
+            mark_session_completed(conn, existing.id, _now_iso())
+            return _create_normal_group_response(
+                conn,
+                user_id=user_id,
+                session_date=session_date,
+                accent=accent,
+                settings=settings,
+                origin="normal_next",
+                source_scope="normal_next",
+            )
         return _build_response(
             session=existing,
             items=items,

--- a/backend/tests/test_today_persistence.py
+++ b/backend/tests/test_today_persistence.py
@@ -215,6 +215,104 @@ class TestTodayPersistence:
         }
         assert "last_attempt" not in resumed["items"][2]
 
+    def test_today_reconciles_fully_answered_active_group_without_next_group(
+        self, client, seeded_db
+    ):
+        client.put("/api/settings", json={"daily_word_count": 2})
+        first = client.post("/api/practice/next-normal").json()
+        for item in first["items"]:
+            client.post("/api/attempt", json={
+                "session_item_id": item["session_item_id"],
+                "selected_answer": item["display_ipa"],
+            })
+
+        conn = get_connection(seeded_db)
+        conn.execute(
+            """
+            UPDATE daily_sessions
+            SET status = 'in_progress', completed_at = NULL
+            WHERE id = ?
+            """,
+            (first["session_id"],),
+        )
+        conn.commit()
+        conn.close()
+
+        today = client.get("/api/today").json()
+        assert today["origin"] == "normal_empty"
+        assert today["status"] == "idle"
+        assert today["word_count"] == 0
+        assert today["completed_normal_groups_today"] == {
+            "entry": 1,
+            "mid": 0,
+            "total": 1,
+        }
+
+        conn = get_connection(seeded_db)
+        rows = conn.execute(
+            """
+            SELECT id, status, completed_at
+            FROM daily_sessions
+            WHERE session_date = ?
+            """,
+            (date.today().isoformat(),),
+        ).fetchall()
+        conn.close()
+
+        assert len(rows) == 1
+        assert rows[0]["id"] == first["session_id"]
+        assert rows[0]["status"] == "completed"
+        assert rows[0]["completed_at"] is not None
+
+    def test_next_normal_reconciles_fully_answered_active_group_and_is_idempotent(
+        self, client, seeded_db
+    ):
+        client.put("/api/settings", json={"daily_word_count": 2})
+        first = client.post("/api/practice/next-normal").json()
+        for item in first["items"]:
+            client.post("/api/attempt", json={
+                "session_item_id": item["session_item_id"],
+                "selected_answer": item["display_ipa"],
+            })
+
+        conn = get_connection(seeded_db)
+        conn.execute(
+            """
+            UPDATE daily_sessions
+            SET status = 'in_progress', completed_at = NULL
+            WHERE id = ?
+            """,
+            (first["session_id"],),
+        )
+        conn.commit()
+        conn.close()
+
+        second = client.post("/api/practice/next-normal").json()
+        assert second["origin"] == "normal_next"
+        assert second["session_id"] != first["session_id"]
+        assert second["group_index"] == first["group_index"] + 1
+        assert second["resume_index"] == 0
+        assert second["completed_item_count"] == 0
+        assert {item["status"] for item in second["items"]} == {"pending"}
+
+        repeated = client.post("/api/practice/next-normal").json()
+        assert repeated["origin"] == "normal_resume"
+        assert repeated["session_id"] == second["session_id"]
+        assert repeated["group_index"] == second["group_index"]
+        assert repeated["resume_index"] == 0
+
+        conn = get_connection(seeded_db)
+        count = conn.execute(
+            """
+            SELECT COUNT(*) AS cnt
+            FROM daily_sessions
+            WHERE session_date = ?
+            """,
+            (date.today().isoformat(),),
+        ).fetchone()
+        conn.close()
+        assert count["cnt"] == 2
+
     def test_second_today_creates_no_duplicate(self, client, seeded_db):
         client.post("/api/practice/next-normal")
         client.get("/api/today")

--- a/frontend/tests/e2e/m11-real-backend-state.spec.ts
+++ b/frontend/tests/e2e/m11-real-backend-state.spec.ts
@@ -22,6 +22,7 @@ async function selectCorrectAnswer(page: Page) {
 test.describe("M11 real backend Today/Progress/Settings consistency", () => {
   test("unfinished regular practice is resumable and clears after completion", async ({ page }) => {
     test.setTimeout(90_000);
+    let firstNormalGroupId = "";
 
     await test.step("Settings review strength persists and affects the next regular group", async () => {
       await page.goto("/");
@@ -54,6 +55,9 @@ test.describe("M11 real backend Today/Progress/Settings consistency", () => {
       const progress = await progressResponse.json();
       expect(progress.resumable_normal_groups).toBe(1);
       expect(progress.level_stats.entry.resumable_normal_groups).toBe(1);
+      const todayResponse = await page.request.get(`${apiBase}/today`);
+      const today = await todayResponse.json();
+      firstNormalGroupId = today.group_id;
 
       await attachScreenshot(page, "m11-real-extra-review-group");
     });
@@ -73,23 +77,41 @@ test.describe("M11 real backend Today/Progress/Settings consistency", () => {
       await attachScreenshot(page, "m11-real-today-resume");
     });
 
-    await test.step("Completing the group clears unfinished Progress state", async () => {
+    await test.step("Completion summary starts a new next group instead of resuming the completed one", async () => {
       await page.getByRole("button", { name: "Resume Entry group" }).click();
       await selectCorrectAnswer(page);
       await expect(page.getByRole("heading", { name: "Practice group complete" })).toBeVisible({
         timeout: 10_000,
       });
+      const idleTodayResponse = await page.request.get(`${apiBase}/today`);
+      const idleToday = await idleTodayResponse.json();
+      expect(idleToday.origin).toBe("normal_empty");
+      expect(idleToday.word_count).toBe(0);
 
+      await page.getByRole("button", { name: "Start next Entry group" }).click();
+      await expect(page.getByText("Practice group: 1 / 1")).toBeVisible();
+      const nextTodayResponse = await page.request.get(`${apiBase}/today`);
+      const nextToday = await nextTodayResponse.json();
+      expect(nextToday.group_id).not.toBe(firstNormalGroupId);
+      expect(nextToday.group_index).toBeGreaterThan(1);
+      expect(nextToday.resume_index).toBe(0);
+      expect(nextToday.completed_item_count).toBe(0);
+      await attachScreenshot(page, "m11-real-next-group-after-completion");
+
+      await selectCorrectAnswer(page);
+      await expect(page.getByRole("heading", { name: "Practice group complete" })).toBeVisible({
+        timeout: 10_000,
+      });
       await page.getByRole("button", { name: "Progress", exact: true }).click();
       await expect(page.getByRole("heading", { name: "Progress", exact: true })).toBeVisible();
       await expect(page.getByText("Unfinished regular practice", { exact: true })).toHaveCount(0);
-      await expect(page.getByText("1 completed today")).toBeVisible();
+      await expect(page.getByText("2 completed today")).toBeVisible();
 
       const progressResponse = await page.request.get(`${apiBase}/progress`);
       const progress = await progressResponse.json();
       expect(progress.resumable_normal_groups).toBe(0);
       expect(progress.today_status).toBe("completed");
-      expect(progress.level_stats.entry.completed_normal_groups_today).toBe(1);
+      expect(progress.level_stats.entry.completed_normal_groups_today).toBe(2);
 
       await attachScreenshot(page, "m11-real-progress-completed");
     });
@@ -123,7 +145,7 @@ test.describe("M11 real backend Today/Progress/Settings consistency", () => {
 
       await page.getByRole("button", { name: "Progress", exact: true }).click();
       await expect(page.getByText("Unfinished regular practice", { exact: true })).toHaveCount(0);
-      await expect(page.getByText("2 completed today")).toBeVisible();
+      await expect(page.getByText("3 completed today")).toBeVisible();
       await attachScreenshot(page, "m11-real-resume-breakpoint-completed");
     });
 


### PR DESCRIPTION
## Scope completed
- Reconciled fully answered active normal groups before Today/next-normal responses.
- `GET /api/today` now marks stale fully answered active normal groups completed and returns the no-active hub instead of `origin=normal_resume`; it does not auto-create a new group.
- `POST /api/practice/next-normal` now reconciles a stale fully answered active group and creates the next normal group with a new identity, later group index, `resume_index == 0`, and `completed_item_count == 0`.
- Preserved #231 partial resume behavior.
- Extended M11 real-backend E2E to cover completion summary -> Start next Entry group -> new group -> Progress remains clear.

Linked issues: #209, #218, #233

## Verification
- `tools/agents/agent-permission-smoke` -> passed.
- `tools/agents/agent-ready-queue --role implementer` -> #233 startable.
- `tools/agents/agent-audit` -> clean.
- `uv run --project backend pytest backend/tests/test_today_persistence.py::TestTodayPersistence::test_today_reconciles_fully_answered_active_group_without_next_group backend/tests/test_today_persistence.py::TestTodayPersistence::test_next_normal_reconciles_fully_answered_active_group_and_is_idempotent backend/tests/test_today_persistence.py::TestTodayPersistence::test_partial_normal_group_resume_metadata_keeps_completed_items -q` -> 3 passed.
- `uv run --project backend ruff check backend/app/services/sessions.py backend/tests/test_today_persistence.py` -> passed.
- `uv run --project backend pytest backend/tests/test_today_persistence.py backend/tests/test_progress_api.py` -> 69 passed, 1 StarletteDeprecationWarning.
- `uv run --project backend pytest` -> 226 passed, 1 StarletteDeprecationWarning.
- `cd frontend && pnpm exec tsc --noEmit` -> passed.
- `cd frontend && pnpm run lint` -> passed.
- `cd frontend && pnpm run build` -> passed.
- `env M11_REAL_FRONTEND_PORT=5203 M11_REAL_BACKEND_PORT=8033 pnpm test:e2e:m11-real` -> 1 passed after execution-layer sandbox permission for local bind.
- `env M11_WALKTHROUGH_PORT=5204 pnpm test:e2e:m11` -> 4 passed after execution-layer sandbox permission for local bind.
- `git diff --check` -> passed.

## Residual risks
- Reconciliation is intentionally scoped to active normal groups; review/focus/specialty groups keep their existing lifecycle.
- Completion timestamps for stale fully answered active groups are set at reconciliation time; this preserves completed counts and avoids duplicate next groups, but exact original final-answer time remains in the attempts table.
- #218 still needs Reviewer/Architect acceptance and human-facing trial rerun after this PR lands in the M11 integration branch.

## Out of scope honored
- No final `main` merge.
- No #209/#218 closure.
- No M12/#210 release.
- No source content, `meaning_zh`, content taxonomy, auth/account/admin/deployment, data migration, runtime/security config, force push, reset, delete, or DB backup changes.
