### PR TITLE
Add M12 auth persistence foundation

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -49,6 +49,32 @@ class Phoneme:
 
 
 # ---------------------------------------------------------------------------
+# Users and auth sessions
+# ---------------------------------------------------------------------------
+
+@dataclass
+class User:
+    id: str
+    username: str
+    password_hash: str
+    is_owner: bool
+    is_active: bool
+    created_at: str
+    updated_at: str
+
+
+@dataclass
+class AuthSession:
+    id: str
+    user_id: str
+    token_hash: str
+    created_at: str
+    last_seen_at: str
+    expires_at: str
+    revoked_at: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
 # Settings
 # ---------------------------------------------------------------------------
 

--- a/backend/app/services/auth.py
+++ b/backend/app/services/auth.py
@@ -1,0 +1,288 @@
+"""Auth persistence foundation for M12.
+
+This module intentionally stops short of FastAPI route behavior. It owns the
+user/session storage primitives that later auth endpoints can call.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import secrets
+import sqlite3
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from argon2 import PasswordHasher
+from argon2.exceptions import VerificationError, VerifyMismatchError
+
+from app.models import AuthSession, Settings, User
+from app.services.db_schema import init_db
+from app.services.db_store import (
+    count_owner_users,
+    create_auth_session,
+    create_user,
+    get_auth_session_by_token_hash,
+    get_user_by_id,
+    get_user_by_username,
+    revoke_auth_session_by_token_hash,
+    touch_auth_session,
+    upsert_settings,
+)
+
+SESSION_TOKEN_BYTES = 32
+DEFAULT_SESSION_TTL_HOURS = 24 * 14
+LOCAL_DEV_ENVIRONMENTS = {"", "local", "development", "dev", "test"}
+DEPLOYED_ENVIRONMENTS = {"production", "prod", "deployed", "deploy"}
+DEFAULT_LOCAL_DEV_USERNAME = "local-dev"
+
+_PASSWORD_HASHER = PasswordHasher()
+
+
+class AuthBootstrapError(ValueError):
+    pass
+
+
+class OwnerAlreadyExistsError(AuthBootstrapError):
+    pass
+
+
+class ProductionBootstrapDisabledError(AuthBootstrapError):
+    pass
+
+
+class AuthSecretRequiredError(AuthBootstrapError):
+    pass
+
+
+@dataclass(frozen=True)
+class BootstrapResult:
+    user: User
+    created: bool
+
+
+@dataclass(frozen=True)
+class IssuedSession:
+    token: str
+    session: AuthSession
+
+
+@dataclass(frozen=True)
+class ResolvedSession:
+    session: AuthSession
+    user: User
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _iso(value: datetime) -> str:
+    return value.astimezone(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def _parse_iso(value: str) -> datetime:
+    return datetime.fromisoformat(value)
+
+
+def hash_password(password: str) -> str:
+    """Hash a password with Argon2 through argon2-cffi's high-level API."""
+    _validate_password(password)
+    return _PASSWORD_HASHER.hash(password)
+
+
+def verify_password(password: str, password_hash: str) -> bool:
+    if not password or not password_hash:
+        return False
+    try:
+        return _PASSWORD_HASHER.verify(password_hash, password)
+    except (VerifyMismatchError, VerificationError):
+        return False
+
+
+def password_hash_needs_rehash(password_hash: str) -> bool:
+    return _PASSWORD_HASHER.check_needs_rehash(password_hash)
+
+
+def bootstrap_owner(
+    conn: sqlite3.Connection,
+    *,
+    username: str,
+    password: str,
+    now: Optional[datetime] = None,
+) -> BootstrapResult:
+    """Create the first owner account, failing closed if any owner exists."""
+    init_db(conn)
+    username = _normalize_username(username)
+    if username == "default":
+        raise AuthBootstrapError("default is reserved for explicit owner-claim work")
+    if count_owner_users(conn) > 0:
+        raise OwnerAlreadyExistsError("owner account already exists")
+    if get_user_by_username(conn, username) is not None:
+        raise AuthBootstrapError("username already exists")
+
+    timestamp = _iso(now or _now())
+    user = User(
+        id=f"user_{uuid.uuid4().hex}",
+        username=username,
+        password_hash=hash_password(password),
+        is_owner=True,
+        is_active=True,
+        created_at=timestamp,
+        updated_at=timestamp,
+    )
+    create_user(conn, user)
+    upsert_settings(conn, _default_settings(user.id, timestamp))
+    return BootstrapResult(user=user, created=True)
+
+
+def bootstrap_local_dev_user(
+    conn: sqlite3.Connection,
+    *,
+    password: str,
+    username: str = DEFAULT_LOCAL_DEV_USERNAME,
+    enabled: bool,
+    environment: Optional[str] = None,
+    now: Optional[datetime] = None,
+) -> BootstrapResult:
+    """Create or return a local dev user only when explicitly enabled."""
+    env = _normalize_environment(environment)
+    if env in DEPLOYED_ENVIRONMENTS:
+        raise ProductionBootstrapDisabledError("local dev bootstrap is disabled in deployed mode")
+    if not enabled:
+        raise AuthBootstrapError("local dev bootstrap requires an explicit enable flag")
+
+    init_db(conn)
+    username = _normalize_username(username)
+    existing = get_user_by_username(conn, username)
+    if existing is not None:
+        return BootstrapResult(user=existing, created=False)
+
+    timestamp = _iso(now or _now())
+    user = User(
+        id=f"user_{uuid.uuid4().hex}",
+        username=username,
+        password_hash=hash_password(password),
+        is_owner=False,
+        is_active=True,
+        created_at=timestamp,
+        updated_at=timestamp,
+    )
+    create_user(conn, user)
+    upsert_settings(conn, _default_settings(user.id, timestamp))
+    return BootstrapResult(user=user, created=True)
+
+
+def require_session_secret(
+    *,
+    environment: Optional[str] = None,
+    session_secret: Optional[str] = None,
+) -> Optional[str]:
+    """Fail closed for deployed auth when the session secret is missing."""
+    env = _normalize_environment(environment)
+    secret = session_secret if session_secret is not None else os.getenv("TINY_IPA_SESSION_SECRET")
+    if env in DEPLOYED_ENVIRONMENTS and not secret:
+        raise AuthSecretRequiredError("TINY_IPA_SESSION_SECRET is required in deployed mode")
+    return secret
+
+
+def issue_auth_session(
+    conn: sqlite3.Connection,
+    *,
+    user_id: str,
+    now: Optional[datetime] = None,
+    ttl: Optional[timedelta] = None,
+) -> IssuedSession:
+    init_db(conn)
+    user = get_user_by_id(conn, user_id)
+    if user is None or not user.is_active:
+        raise AuthBootstrapError("active user is required for session issuance")
+
+    issued_at = now or _now()
+    expires_at = issued_at + (ttl or timedelta(hours=DEFAULT_SESSION_TTL_HOURS))
+    token = secrets.token_urlsafe(SESSION_TOKEN_BYTES)
+    session = AuthSession(
+        id=f"sess_{uuid.uuid4().hex}",
+        user_id=user.id,
+        token_hash=hash_session_token(token),
+        created_at=_iso(issued_at),
+        last_seen_at=_iso(issued_at),
+        expires_at=_iso(expires_at),
+        revoked_at=None,
+    )
+    create_auth_session(conn, session)
+    return IssuedSession(token=token, session=session)
+
+
+def resolve_auth_session(
+    conn: sqlite3.Connection,
+    *,
+    token: str,
+    now: Optional[datetime] = None,
+    touch: bool = True,
+) -> Optional[ResolvedSession]:
+    if not token:
+        return None
+    session = get_auth_session_by_token_hash(conn, hash_session_token(token))
+    if session is None or session.revoked_at is not None:
+        return None
+    if _parse_iso(session.expires_at) <= (now or _now()):
+        return None
+    user = get_user_by_id(conn, session.user_id)
+    if user is None or not user.is_active:
+        return None
+    if touch:
+        last_seen_at = _iso(now or _now())
+        touch_auth_session(conn, session.id, last_seen_at)
+        session = AuthSession(
+            id=session.id,
+            user_id=session.user_id,
+            token_hash=session.token_hash,
+            created_at=session.created_at,
+            last_seen_at=last_seen_at,
+            expires_at=session.expires_at,
+            revoked_at=session.revoked_at,
+        )
+    return ResolvedSession(session=session, user=user)
+
+
+def revoke_session(conn: sqlite3.Connection, *, token: str, now: Optional[datetime] = None) -> None:
+    if not token:
+        return
+    revoke_auth_session_by_token_hash(conn, hash_session_token(token), _iso(now or _now()))
+
+
+def hash_session_token(token: str) -> str:
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+def _normalize_username(username: str) -> str:
+    normalized = username.strip()
+    if not normalized:
+        raise AuthBootstrapError("username is required")
+    return normalized
+
+
+def _normalize_environment(environment: Optional[str]) -> str:
+    raw = environment if environment is not None else os.getenv("TINY_IPA_ENV", "local")
+    return raw.strip().lower()
+
+
+def _validate_password(password: str) -> None:
+    if len(password) < 8:
+        raise AuthBootstrapError("password must be at least 8 characters")
+
+
+def _default_settings(user_id: str, timestamp: str) -> Settings:
+    return Settings(
+        user_id=user_id,
+        primary_accent="US",
+        daily_word_count=10,
+        show_translation=True,
+        show_accent_compare=False,
+        practice_mode="ipa_first",
+        review_strength="normal",
+        updated_at=timestamp,
+    )

--- a/backend/app/services/db_schema.py
+++ b/backend/app/services/db_schema.py
@@ -11,6 +11,35 @@ from typing import List
 
 TABLES_DDL: List[str] = [
     # ------------------------------------------------------------------
+    # users
+    # ------------------------------------------------------------------
+    """
+    CREATE TABLE IF NOT EXISTS users (
+        id             TEXT PRIMARY KEY,
+        username       TEXT    NOT NULL UNIQUE,
+        password_hash  TEXT    NOT NULL,
+        is_owner       INTEGER NOT NULL DEFAULT 0,
+        is_active      INTEGER NOT NULL DEFAULT 1,
+        created_at     TEXT    NOT NULL,
+        updated_at     TEXT    NOT NULL
+    )
+    """,
+    # ------------------------------------------------------------------
+    # auth_sessions
+    # ------------------------------------------------------------------
+    """
+    CREATE TABLE IF NOT EXISTS auth_sessions (
+        id            TEXT PRIMARY KEY,
+        user_id       TEXT    NOT NULL,
+        token_hash    TEXT    NOT NULL UNIQUE,
+        created_at    TEXT    NOT NULL,
+        last_seen_at  TEXT    NOT NULL,
+        expires_at    TEXT    NOT NULL,
+        revoked_at    TEXT,
+        FOREIGN KEY (user_id) REFERENCES users(id)
+    )
+    """,
+    # ------------------------------------------------------------------
     # words
     # ------------------------------------------------------------------
     """
@@ -145,8 +174,54 @@ def init_db(conn: sqlite3.Connection) -> None:
     """
     for ddl in TABLES_DDL:
         conn.execute(ddl)
+    ensure_users_schema(conn)
+    ensure_auth_sessions_schema(conn)
     ensure_settings_schema(conn)
     ensure_daily_sessions_schema(conn)
+
+
+def ensure_users_schema(conn: sqlite3.Connection) -> None:
+    """Apply compatibility patches for existing users tables."""
+    table = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='users'"
+    ).fetchone()
+    if table is None:
+        return
+
+    columns = {
+        row["name"]
+        for row in conn.execute("PRAGMA table_info(users)").fetchall()
+    }
+    if "is_owner" not in columns:
+        conn.execute("ALTER TABLE users ADD COLUMN is_owner INTEGER NOT NULL DEFAULT 0")
+    if "is_active" not in columns:
+        conn.execute("ALTER TABLE users ADD COLUMN is_active INTEGER NOT NULL DEFAULT 1")
+    if "created_at" not in columns:
+        conn.execute("ALTER TABLE users ADD COLUMN created_at TEXT NOT NULL DEFAULT ''")
+    if "updated_at" not in columns:
+        conn.execute("ALTER TABLE users ADD COLUMN updated_at TEXT NOT NULL DEFAULT ''")
+
+
+def ensure_auth_sessions_schema(conn: sqlite3.Connection) -> None:
+    """Apply compatibility patches for existing auth_sessions tables."""
+    table = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='auth_sessions'"
+    ).fetchone()
+    if table is None:
+        return
+
+    columns = {
+        row["name"]
+        for row in conn.execute("PRAGMA table_info(auth_sessions)").fetchall()
+    }
+    if "last_seen_at" not in columns:
+        conn.execute(
+            "ALTER TABLE auth_sessions ADD COLUMN last_seen_at TEXT NOT NULL DEFAULT ''"
+        )
+    if "expires_at" not in columns:
+        conn.execute("ALTER TABLE auth_sessions ADD COLUMN expires_at TEXT NOT NULL DEFAULT ''")
+    if "revoked_at" not in columns:
+        conn.execute("ALTER TABLE auth_sessions ADD COLUMN revoked_at TEXT")
 
 
 def ensure_settings_schema(conn: sqlite3.Connection) -> None:

--- a/backend/app/services/db_store.py
+++ b/backend/app/services/db_store.py
@@ -10,8 +10,22 @@ import json
 import sqlite3
 from typing import List, Optional
 
-from app.models import Attempt, DailySession, Phoneme, SessionItem, Settings, Word
-from app.services.db_schema import ensure_daily_sessions_schema, ensure_settings_schema
+from app.models import (
+    Attempt,
+    AuthSession,
+    DailySession,
+    Phoneme,
+    SessionItem,
+    Settings,
+    User,
+    Word,
+)
+from app.services.db_schema import (
+    ensure_auth_sessions_schema,
+    ensure_daily_sessions_schema,
+    ensure_settings_schema,
+    ensure_users_schema,
+)
 
 # ============================================================================
 # Serialisation helpers
@@ -80,6 +94,30 @@ def _phoneme_from_row(row: sqlite3.Row) -> Phoneme:
     )
 
 
+def _user_from_row(row: sqlite3.Row) -> User:
+    return User(
+        id=row["id"],
+        username=row["username"],
+        password_hash=row["password_hash"],
+        is_owner=bool(row["is_owner"]),
+        is_active=bool(row["is_active"]),
+        created_at=row["created_at"],
+        updated_at=row["updated_at"],
+    )
+
+
+def _auth_session_from_row(row: sqlite3.Row) -> AuthSession:
+    return AuthSession(
+        id=row["id"],
+        user_id=row["user_id"],
+        token_hash=row["token_hash"],
+        created_at=row["created_at"],
+        last_seen_at=row["last_seen_at"],
+        expires_at=row["expires_at"],
+        revoked_at=row["revoked_at"],
+    )
+
+
 def _settings_from_row(row: sqlite3.Row) -> Settings:
     return Settings(
         user_id=row["user_id"],
@@ -93,6 +131,126 @@ def _settings_from_row(row: sqlite3.Row) -> Settings:
         ui_language=row["ui_language"],
         focus_phonemes=_parse_list(row["focus_phonemes"]) or [],
         updated_at=row["updated_at"],
+    )
+
+
+# ============================================================================
+# Users
+# ============================================================================
+
+
+def create_user(conn: sqlite3.Connection, user: User) -> str:
+    """Insert a user row. Returns the user id."""
+    ensure_users_schema(conn)
+    conn.execute(
+        """
+        INSERT INTO users (
+            id, username, password_hash, is_owner, is_active, created_at, updated_at
+        ) VALUES (
+            :id, :username, :password_hash, :is_owner, :is_active, :created_at, :updated_at
+        )
+        """,
+        {
+            "id": user.id,
+            "username": user.username,
+            "password_hash": user.password_hash,
+            "is_owner": int(user.is_owner),
+            "is_active": int(user.is_active),
+            "created_at": user.created_at,
+            "updated_at": user.updated_at,
+        },
+    )
+    return user.id
+
+
+def get_user_by_id(conn: sqlite3.Connection, user_id: str) -> Optional[User]:
+    ensure_users_schema(conn)
+    row = conn.execute("SELECT * FROM users WHERE id = ?", (user_id,)).fetchone()
+    if row is None:
+        return None
+    return _user_from_row(row)
+
+
+def get_user_by_username(conn: sqlite3.Connection, username: str) -> Optional[User]:
+    ensure_users_schema(conn)
+    row = conn.execute(
+        "SELECT * FROM users WHERE username = ?", (username,)
+    ).fetchone()
+    if row is None:
+        return None
+    return _user_from_row(row)
+
+
+def count_owner_users(conn: sqlite3.Connection) -> int:
+    ensure_users_schema(conn)
+    row = conn.execute(
+        "SELECT COUNT(*) AS cnt FROM users WHERE is_owner = 1"
+    ).fetchone()
+    return int(row["cnt"] if row else 0)
+
+
+# ============================================================================
+# Auth sessions
+# ============================================================================
+
+
+def create_auth_session(conn: sqlite3.Connection, session: AuthSession) -> str:
+    """Insert a server-side auth session row. Returns the session id."""
+    ensure_auth_sessions_schema(conn)
+    conn.execute(
+        """
+        INSERT INTO auth_sessions (
+            id, user_id, token_hash, created_at, last_seen_at, expires_at, revoked_at
+        ) VALUES (
+            :id, :user_id, :token_hash, :created_at, :last_seen_at, :expires_at, :revoked_at
+        )
+        """,
+        {
+            "id": session.id,
+            "user_id": session.user_id,
+            "token_hash": session.token_hash,
+            "created_at": session.created_at,
+            "last_seen_at": session.last_seen_at,
+            "expires_at": session.expires_at,
+            "revoked_at": session.revoked_at,
+        },
+    )
+    return session.id
+
+
+def get_auth_session_by_token_hash(
+    conn: sqlite3.Connection, token_hash: str
+) -> Optional[AuthSession]:
+    ensure_auth_sessions_schema(conn)
+    row = conn.execute(
+        "SELECT * FROM auth_sessions WHERE token_hash = ?", (token_hash,)
+    ).fetchone()
+    if row is None:
+        return None
+    return _auth_session_from_row(row)
+
+
+def touch_auth_session(
+    conn: sqlite3.Connection, session_id: str, last_seen_at: str
+) -> None:
+    ensure_auth_sessions_schema(conn)
+    conn.execute(
+        "UPDATE auth_sessions SET last_seen_at = ? WHERE id = ?",
+        (last_seen_at, session_id),
+    )
+
+
+def revoke_auth_session_by_token_hash(
+    conn: sqlite3.Connection, token_hash: str, revoked_at: str
+) -> None:
+    ensure_auth_sessions_schema(conn)
+    conn.execute(
+        """
+        UPDATE auth_sessions
+        SET revoked_at = ?
+        WHERE token_hash = ? AND revoked_at IS NULL
+        """,
+        (revoked_at, token_hash),
     )
 
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 description = "Tiny IPA backend service"
 requires-python = ">=3.9"
 dependencies = [
+    "argon2-cffi>=23.1.0",
     "fastapi>=0.115.0",
     "uvicorn[standard]>=0.30.0",
 ]

--- a/backend/scripts/bootstrap_auth.py
+++ b/backend/scripts/bootstrap_auth.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Bootstrap Tiny IPA auth users for owner setup or local development."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+_HERE = Path(__file__).resolve().parent
+_BACKEND = _HERE.parent
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+from app.db import DEFAULT_DB_PATH, get_db  # noqa: E402
+from app.services.auth import (  # noqa: E402
+    DEFAULT_LOCAL_DEV_USERNAME,
+    AuthBootstrapError,
+    bootstrap_local_dev_user,
+    bootstrap_owner,
+)
+
+
+def _db_path(raw: str) -> str:
+    if raw.startswith("sqlite:///"):
+        return raw[len("sqlite:///"):]
+    return raw
+
+
+def bootstrap_auth(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="Bootstrap Tiny IPA auth users.")
+    parser.add_argument(
+        "--db-url",
+        default=DEFAULT_DB_PATH,
+        help="SQLite database path or sqlite:/// URI.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    owner = subparsers.add_parser("owner", help="Create the first owner user.")
+    owner.add_argument("--username", required=True)
+    owner.add_argument("--password", required=True)
+
+    dev = subparsers.add_parser("dev-user", help="Create an explicit local dev user.")
+    dev.add_argument("--username", default=DEFAULT_LOCAL_DEV_USERNAME)
+    dev.add_argument("--password", required=True)
+    dev.add_argument(
+        "--enable-local-dev",
+        action="store_true",
+        help="Required guard: local dev bootstrap is never implicit.",
+    )
+    dev.add_argument(
+        "--environment",
+        default=None,
+        help="Runtime environment guard; production/prod/deployed refuse dev bootstrap.",
+    )
+
+    args = parser.parse_args(argv)
+
+    try:
+        with get_db(_db_path(args.db_url)) as conn:
+            if args.command == "owner":
+                result = bootstrap_owner(
+                    conn,
+                    username=args.username,
+                    password=args.password,
+                )
+            else:
+                result = bootstrap_local_dev_user(
+                    conn,
+                    username=args.username,
+                    password=args.password,
+                    enabled=args.enable_local_dev,
+                    environment=args.environment,
+                )
+        print(json.dumps({
+            "created": result.created,
+            "user_id": result.user.id,
+            "username": result.user.username,
+            "is_owner": result.user.is_owner,
+        }))
+        return 0
+    except AuthBootstrapError as exc:
+        print(json.dumps({"error": type(exc).__name__, "detail": str(exc)}), file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(bootstrap_auth())

--- a/backend/tests/test_auth_foundation.py
+++ b/backend/tests/test_auth_foundation.py
@@ -1,0 +1,269 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from app.db import get_connection
+from app.services.auth import (
+    AuthBootstrapError,
+    AuthSecretRequiredError,
+    OwnerAlreadyExistsError,
+    ProductionBootstrapDisabledError,
+    bootstrap_local_dev_user,
+    bootstrap_owner,
+    hash_session_token,
+    issue_auth_session,
+    require_session_secret,
+    resolve_auth_session,
+    revoke_session,
+    verify_password,
+)
+from app.services.db_schema import init_db, table_names
+from app.services.db_store import count_owner_users, get_settings
+
+
+@pytest.fixture(name="conn")
+def conn_fixture(tmp_path: Path):
+    db_path = str(tmp_path / "auth.sqlite")
+    connection = get_connection(db_path)
+    init_db(connection)
+    yield connection
+    connection.close()
+
+
+class TestAuthSchema:
+    def test_init_creates_user_and_session_tables(self, conn):
+        names = table_names(conn)
+
+        assert "users" in names
+        assert "auth_sessions" in names
+
+        user_columns = {row["name"] for row in conn.execute("PRAGMA table_info(users)")}
+        session_columns = {
+            row["name"] for row in conn.execute("PRAGMA table_info(auth_sessions)")
+        }
+
+        assert {
+            "id",
+            "username",
+            "password_hash",
+            "is_owner",
+            "is_active",
+            "created_at",
+            "updated_at",
+        }.issubset(user_columns)
+        assert {
+            "id",
+            "user_id",
+            "token_hash",
+            "created_at",
+            "last_seen_at",
+            "expires_at",
+            "revoked_at",
+        }.issubset(session_columns)
+
+    def test_schema_init_is_idempotent(self, conn):
+        before = table_names(conn)
+        init_db(conn)
+        after = table_names(conn)
+
+        assert before == after
+
+
+class TestOwnerBootstrap:
+    def test_owner_bootstrap_creates_one_owner_and_settings(self, conn):
+        result = bootstrap_owner(
+            conn,
+            username="owner",
+            password="correct horse battery staple",
+            now=datetime(2026, 7, 2, tzinfo=timezone.utc),
+        )
+
+        assert result.created is True
+        assert result.user.username == "owner"
+        assert result.user.is_owner is True
+        assert result.user.is_active is True
+        assert result.user.password_hash != "correct horse battery staple"
+        assert result.user.password_hash.startswith("$argon2")
+        assert verify_password("correct horse battery staple", result.user.password_hash)
+        assert not verify_password("wrong password", result.user.password_hash)
+        assert count_owner_users(conn) == 1
+
+        settings = get_settings(conn, result.user.id)
+        assert settings is not None
+        assert settings.primary_accent == "US"
+
+    def test_owner_bootstrap_fails_closed_when_owner_exists(self, conn):
+        bootstrap_owner(conn, username="owner", password="correct horse battery staple")
+
+        with pytest.raises(OwnerAlreadyExistsError):
+            bootstrap_owner(conn, username="second", password="another safe password")
+
+    def test_owner_bootstrap_does_not_claim_default_user(self, conn):
+        with pytest.raises(AuthBootstrapError):
+            bootstrap_owner(conn, username="default", password="correct horse battery staple")
+
+
+class TestLocalDevBootstrap:
+    def test_local_dev_bootstrap_requires_explicit_enable(self, conn):
+        with pytest.raises(AuthBootstrapError):
+            bootstrap_local_dev_user(
+                conn,
+                username="local-dev",
+                password="local dev password",
+                enabled=False,
+                environment="local",
+            )
+
+    def test_local_dev_bootstrap_refuses_deployed_mode(self, conn):
+        with pytest.raises(ProductionBootstrapDisabledError):
+            bootstrap_local_dev_user(
+                conn,
+                username="local-dev",
+                password="local dev password",
+                enabled=True,
+                environment="production",
+            )
+
+    def test_local_dev_bootstrap_is_explicit_and_idempotent(self, conn):
+        first = bootstrap_local_dev_user(
+            conn,
+            username="local-dev",
+            password="local dev password",
+            enabled=True,
+            environment="development",
+        )
+        second = bootstrap_local_dev_user(
+            conn,
+            username="local-dev",
+            password="local dev password",
+            enabled=True,
+            environment="development",
+        )
+
+        assert first.created is True
+        assert second.created is False
+        assert second.user.id == first.user.id
+        assert first.user.is_owner is False
+        assert verify_password("local dev password", first.user.password_hash)
+
+    def test_deployed_secret_fails_closed_when_missing(self, monkeypatch):
+        monkeypatch.delenv("TINY_IPA_SESSION_SECRET", raising=False)
+
+        with pytest.raises(AuthSecretRequiredError):
+            require_session_secret(environment="production")
+
+    def test_local_secret_can_be_missing_without_enabling_prod_bypass(self, monkeypatch):
+        monkeypatch.delenv("TINY_IPA_SESSION_SECRET", raising=False)
+
+        assert require_session_secret(environment="local") is None
+
+
+class TestSessionStorage:
+    def test_session_storage_hashes_token_and_resolves_active_user(self, conn):
+        owner = bootstrap_owner(conn, username="owner", password="correct horse battery staple")
+        now = datetime(2026, 7, 2, 12, 0, tzinfo=timezone.utc)
+
+        issued = issue_auth_session(
+            conn,
+            user_id=owner.user.id,
+            now=now,
+            ttl=timedelta(hours=1),
+        )
+        stored = conn.execute(
+            "SELECT * FROM auth_sessions WHERE id = ?",
+            (issued.session.id,),
+        ).fetchone()
+
+        assert stored["token_hash"] == hash_session_token(issued.token)
+        assert stored["token_hash"] != issued.token
+        assert len(stored["token_hash"]) == 64
+
+        resolved = resolve_auth_session(
+            conn,
+            token=issued.token,
+            now=now + timedelta(minutes=5),
+        )
+
+        assert resolved is not None
+        assert resolved.user.id == owner.user.id
+        assert resolved.session.last_seen_at == "2026-07-02T12:05:00+00:00"
+
+    def test_session_resolution_rejects_expired_or_revoked_tokens(self, conn):
+        owner = bootstrap_owner(conn, username="owner", password="correct horse battery staple")
+        now = datetime(2026, 7, 2, 12, 0, tzinfo=timezone.utc)
+        issued = issue_auth_session(
+            conn,
+            user_id=owner.user.id,
+            now=now,
+            ttl=timedelta(minutes=10),
+        )
+
+        assert (
+            resolve_auth_session(conn, token=issued.token, now=now + timedelta(minutes=11))
+            is None
+        )
+
+        active = issue_auth_session(
+            conn,
+            user_id=owner.user.id,
+            now=now,
+            ttl=timedelta(hours=1),
+        )
+        revoke_session(conn, token=active.token, now=now + timedelta(minutes=1))
+
+        assert (
+            resolve_auth_session(conn, token=active.token, now=now + timedelta(minutes=2))
+            is None
+        )
+
+    def test_session_issuance_requires_active_existing_user(self, conn):
+        with pytest.raises(AuthBootstrapError):
+            issue_auth_session(conn, user_id="missing-user")
+
+
+class TestBootstrapCli:
+    def test_local_dev_bootstrap_cli_smoke(self, tmp_path: Path):
+        db_path = tmp_path / "cli.sqlite"
+        script = Path(__file__).resolve().parents[1] / "scripts" / "bootstrap_auth.py"
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(script),
+                "--db-url",
+                str(db_path),
+                "dev-user",
+                "--enable-local-dev",
+                "--environment",
+                "development",
+                "--username",
+                "local-dev",
+                "--password",
+                "local dev password",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+        payload = json.loads(result.stdout)
+        assert payload["created"] is True
+        assert payload["username"] == "local-dev"
+        assert payload["is_owner"] is False
+
+        conn = get_connection(str(db_path))
+        try:
+            row = conn.execute(
+                "SELECT username, password_hash FROM users WHERE username = 'local-dev'"
+            ).fetchone()
+        finally:
+            conn.close()
+
+        assert row is not None
+        assert row["password_hash"] != "local dev password"

--- a/backend/tests/test_import_words.py
+++ b/backend/tests/test_import_words.py
@@ -62,12 +62,14 @@ class TestSchemaInitialisation:
         names = table_names(conn)
         conn.close()
         for expected in [
+            "auth_sessions",
             "attempts",
             "daily_sessions",
             "phoneme_stats",
             "phonemes",
             "session_items",
             "settings",
+            "users",
             "words",
         ]:
             assert expected in names, f"Table '{expected}' missing from {names}"

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -2,7 +2,8 @@ version = 1
 revision = 3
 requires-python = ">=3.9"
 resolution-markers = [
-    "python_full_version >= '3.10'",
+    "python_full_version >= '3.14'",
+    "python_full_version >= '3.10' and python_full_version < '3.14'",
     "python_full_version < '3.10'",
 ]
 
@@ -46,7 +47,8 @@ name = "anyio"
 version = "4.13.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.10'",
+    "python_full_version >= '3.14'",
+    "python_full_version >= '3.10' and python_full_version < '3.14'",
 ]
 dependencies = [
     { name = "exceptiongroup", marker = "python_full_version == '3.10.*'" },
@@ -59,12 +61,155 @@ wheels = [
 ]
 
 [[package]]
+name = "argon2-cffi"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "argon2-cffi-bindings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/89/ce5af8a7d472a67cc819d5d998aa8c82c5d860608c4db9f46f1162d7dab9/argon2_cffi-25.1.0.tar.gz", hash = "sha256:694ae5cc8a42f4c4e2bf2ca0e64e51e23a040c6a517a85074683d3959e1346c1", size = 45706, upload-time = "2025-06-03T06:55:32.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/d3/a8b22fa575b297cd6e3e3b0155c7e25db170edf1c74783d6a31a2490b8d9/argon2_cffi-25.1.0-py3-none-any.whl", hash = "sha256:fdc8b074db390fccb6eb4a3604ae7231f219aa669a2652e0f20e16ba513d5741", size = 14657, upload-time = "2025-06-03T06:55:30.804Z" },
+]
+
+[[package]]
+name = "argon2-cffi-bindings"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/2d/db8af0df73c1cf454f71b2bbe5e356b8c1f8041c979f505b3d3186e520a9/argon2_cffi_bindings-25.1.0.tar.gz", hash = "sha256:b957f3e6ea4d55d820e40ff76f450952807013d361a65d7f28acc0acbf29229d", size = 1783441, upload-time = "2025-07-30T10:02:05.147Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/97/3c0a35f46e52108d4707c44b95cfe2afcafc50800b5450c197454569b776/argon2_cffi_bindings-25.1.0-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:3d3f05610594151994ca9ccb3c771115bdb4daef161976a266f0dd8aa9996b8f", size = 54393, upload-time = "2025-07-30T10:01:40.97Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/f4/98bbd6ee89febd4f212696f13c03ca302b8552e7dbf9c8efa11ea4a388c3/argon2_cffi_bindings-25.1.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:8b8efee945193e667a396cbc7b4fb7d357297d6234d30a489905d96caabde56b", size = 29328, upload-time = "2025-07-30T10:01:41.916Z" },
+    { url = "https://files.pythonhosted.org/packages/43/24/90a01c0ef12ac91a6be05969f29944643bc1e5e461155ae6559befa8f00b/argon2_cffi_bindings-25.1.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:3c6702abc36bf3ccba3f802b799505def420a1b7039862014a65db3205967f5a", size = 31269, upload-time = "2025-07-30T10:01:42.716Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/d3/942aa10782b2697eee7af5e12eeff5ebb325ccfb86dd8abda54174e377e4/argon2_cffi_bindings-25.1.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a1c70058c6ab1e352304ac7e3b52554daadacd8d453c1752e547c76e9c99ac44", size = 86558, upload-time = "2025-07-30T10:01:43.943Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/82/b484f702fec5536e71836fc2dbc8c5267b3f6e78d2d539b4eaa6f0db8bf8/argon2_cffi_bindings-25.1.0-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e2fd3bfbff3c5d74fef31a722f729bf93500910db650c925c2d6ef879a7e51cb", size = 92364, upload-time = "2025-07-30T10:01:44.887Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/c1/a606ff83b3f1735f3759ad0f2cd9e038a0ad11a3de3b6c673aa41c24bb7b/argon2_cffi_bindings-25.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c4f9665de60b1b0e99bcd6be4f17d90339698ce954cfd8d9cf4f91c995165a92", size = 85637, upload-time = "2025-07-30T10:01:46.225Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b4/678503f12aceb0262f84fa201f6027ed77d71c5019ae03b399b97caa2f19/argon2_cffi_bindings-25.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ba92837e4a9aa6a508c8d2d7883ed5a8f6c308c89a4790e1e447a220deb79a85", size = 91934, upload-time = "2025-07-30T10:01:47.203Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/c7/f36bd08ef9bd9f0a9cff9428406651f5937ce27b6c5b07b92d41f91ae541/argon2_cffi_bindings-25.1.0-cp314-cp314t-win32.whl", hash = "sha256:84a461d4d84ae1295871329b346a97f68eade8c53b6ed9a7ca2d7467f3c8ff6f", size = 28158, upload-time = "2025-07-30T10:01:48.341Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/80/0106a7448abb24a2c467bf7d527fe5413b7fdfa4ad6d6a96a43a62ef3988/argon2_cffi_bindings-25.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b55aec3565b65f56455eebc9b9f34130440404f27fe21c3b375bf1ea4d8fbae6", size = 32597, upload-time = "2025-07-30T10:01:49.112Z" },
+    { url = "https://files.pythonhosted.org/packages/05/b8/d663c9caea07e9180b2cb662772865230715cbd573ba3b5e81793d580316/argon2_cffi_bindings-25.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:87c33a52407e4c41f3b70a9c2d3f6056d88b10dad7695be708c5021673f55623", size = 28231, upload-time = "2025-07-30T10:01:49.92Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/57/96b8b9f93166147826da5f90376e784a10582dd39a393c99bb62cfcf52f0/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:aecba1723ae35330a008418a91ea6cfcedf6d31e5fbaa056a166462ff066d500", size = 54121, upload-time = "2025-07-30T10:01:50.815Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/08/a9bebdb2e0e602dde230bdde8021b29f71f7841bd54801bcfd514acb5dcf/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:2630b6240b495dfab90aebe159ff784d08ea999aa4b0d17efa734055a07d2f44", size = 29177, upload-time = "2025-07-30T10:01:51.681Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/02/d297943bcacf05e4f2a94ab6f462831dc20158614e5d067c35d4e63b9acb/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:7aef0c91e2c0fbca6fc68e7555aa60ef7008a739cbe045541e438373bc54d2b0", size = 31090, upload-time = "2025-07-30T10:01:53.184Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/93/44365f3d75053e53893ec6d733e4a5e3147502663554b4d864587c7828a7/argon2_cffi_bindings-25.1.0-cp39-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1e021e87faa76ae0d413b619fe2b65ab9a037f24c60a1e6cc43457ae20de6dc6", size = 81246, upload-time = "2025-07-30T10:01:54.145Z" },
+    { url = "https://files.pythonhosted.org/packages/09/52/94108adfdd6e2ddf58be64f959a0b9c7d4ef2fa71086c38356d22dc501ea/argon2_cffi_bindings-25.1.0-cp39-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d3e924cfc503018a714f94a49a149fdc0b644eaead5d1f089330399134fa028a", size = 87126, upload-time = "2025-07-30T10:01:55.074Z" },
+    { url = "https://files.pythonhosted.org/packages/72/70/7a2993a12b0ffa2a9271259b79cc616e2389ed1a4d93842fac5a1f923ffd/argon2_cffi_bindings-25.1.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c87b72589133f0346a1cb8d5ecca4b933e3c9b64656c9d175270a000e73b288d", size = 80343, upload-time = "2025-07-30T10:01:56.007Z" },
+    { url = "https://files.pythonhosted.org/packages/78/9a/4e5157d893ffc712b74dbd868c7f62365618266982b64accab26bab01edc/argon2_cffi_bindings-25.1.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1db89609c06afa1a214a69a462ea741cf735b29a57530478c06eb81dd403de99", size = 86777, upload-time = "2025-07-30T10:01:56.943Z" },
+    { url = "https://files.pythonhosted.org/packages/74/cd/15777dfde1c29d96de7f18edf4cc94c385646852e7c7b0320aa91ccca583/argon2_cffi_bindings-25.1.0-cp39-abi3-win32.whl", hash = "sha256:473bcb5f82924b1becbb637b63303ec8d10e84c8d241119419897a26116515d2", size = 27180, upload-time = "2025-07-30T10:01:57.759Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/c6/a759ece8f1829d1f162261226fbfd2c6832b3ff7657384045286d2afa384/argon2_cffi_bindings-25.1.0-cp39-abi3-win_amd64.whl", hash = "sha256:a98cd7d17e9f7ce244c0803cad3c23a7d379c301ba618a5fa76a67d116618b98", size = 31715, upload-time = "2025-07-30T10:01:58.56Z" },
+    { url = "https://files.pythonhosted.org/packages/42/b9/f8d6fa329ab25128b7e98fd83a3cb34d9db5b059a9847eddb840a0af45dd/argon2_cffi_bindings-25.1.0-cp39-abi3-win_arm64.whl", hash = "sha256:b0fdbcf513833809c882823f98dc2f931cf659d9a1429616ac3adebb49f5db94", size = 27149, upload-time = "2025-07-30T10:01:59.329Z" },
+    { url = "https://files.pythonhosted.org/packages/11/2d/ba4e4ca8d149f8dcc0d952ac0967089e1d759c7e5fcf0865a317eb680fbb/argon2_cffi_bindings-25.1.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:6dca33a9859abf613e22733131fc9194091c1fa7cb3e131c143056b4856aa47e", size = 24549, upload-time = "2025-07-30T10:02:00.101Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/82/9b2386cc75ac0bd3210e12a44bfc7fd1632065ed8b80d573036eecb10442/argon2_cffi_bindings-25.1.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:21378b40e1b8d1655dd5310c84a40fc19a9aa5e6366e835ceb8576bf0fea716d", size = 25539, upload-time = "2025-07-30T10:02:00.929Z" },
+    { url = "https://files.pythonhosted.org/packages/31/db/740de99a37aa727623730c90d92c22c9e12585b3c98c54b7960f7810289f/argon2_cffi_bindings-25.1.0-pp310-pypy310_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5d588dec224e2a83edbdc785a5e6f3c6cd736f46bfd4b441bbb5aa1f5085e584", size = 28467, upload-time = "2025-07-30T10:02:02.08Z" },
+    { url = "https://files.pythonhosted.org/packages/71/7a/47c4509ea18d755f44e2b92b7178914f0c113946d11e16e626df8eaa2b0b/argon2_cffi_bindings-25.1.0-pp310-pypy310_pp73-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5acb4e41090d53f17ca1110c3427f0a130f944b896fc8c83973219c97f57b690", size = 27355, upload-time = "2025-07-30T10:02:02.867Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/82/82745642d3c46e7cea25e1885b014b033f4693346ce46b7f47483cf5d448/argon2_cffi_bindings-25.1.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:da0c79c23a63723aa5d782250fbf51b768abca630285262fb5144ba5ae01e520", size = 29187, upload-time = "2025-07-30T10:02:03.674Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.5.20"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/ce/ee2ecad540810a79593028e88299baeae54d346cc7a0d94b6199988b89b1/certifi-2026.5.20.tar.gz", hash = "sha256:69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d", size = 135422, upload-time = "2026-05-20T11:46:50.073Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/59/8c/57e832b7af6d7c5abe66eb3fbe3a3a32f4d11ea23a1aa7131371035be991/certifi-2026.5.20-py3-none-any.whl", hash = "sha256:3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897", size = 134134, upload-time = "2026-05-20T11:46:48.578Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", version = "2.23", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' and implementation_name != 'PyPy'" },
+    { name = "pycparser", version = "3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' and implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/d7/516d984057745a6cd96575eea814fe1edd6646ee6efd552fb7b0921dec83/cffi-2.0.0-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:0cf2d91ecc3fcc0625c2c530fe004f82c110405f101548512cce44322fa8ac44", size = 184283, upload-time = "2025-09-08T23:22:08.01Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/84/ad6a0b408daa859246f57c03efd28e5dd1b33c21737c2db84cae8c237aa5/cffi-2.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f73b96c41e3b2adedc34a7356e64c8eb96e03a3782b535e043a986276ce12a49", size = 180504, upload-time = "2025-09-08T23:22:10.637Z" },
+    { url = "https://files.pythonhosted.org/packages/50/bd/b1a6362b80628111e6653c961f987faa55262b4002fcec42308cad1db680/cffi-2.0.0-cp310-cp310-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:53f77cbe57044e88bbd5ed26ac1d0514d2acf0591dd6bb02a3ae37f76811b80c", size = 208811, upload-time = "2025-09-08T23:22:12.267Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/27/6933a8b2562d7bd1fb595074cf99cc81fc3789f6a6c05cdabb46284a3188/cffi-2.0.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3e837e369566884707ddaf85fc1744b47575005c0a229de3327f8f9a20f4efeb", size = 216402, upload-time = "2025-09-08T23:22:13.455Z" },
+    { url = "https://files.pythonhosted.org/packages/05/eb/b86f2a2645b62adcfff53b0dd97e8dfafb5c8aa864bd0d9a2c2049a0d551/cffi-2.0.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:5eda85d6d1879e692d546a078b44251cdd08dd1cfb98dfb77b670c97cee49ea0", size = 203217, upload-time = "2025-09-08T23:22:14.596Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/e0/6cbe77a53acf5acc7c08cc186c9928864bd7c005f9efd0d126884858a5fe/cffi-2.0.0-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9332088d75dc3241c702d852d4671613136d90fa6881da7d770a483fd05248b4", size = 203079, upload-time = "2025-09-08T23:22:15.769Z" },
+    { url = "https://files.pythonhosted.org/packages/98/29/9b366e70e243eb3d14a5cb488dfd3a0b6b2f1fb001a203f653b93ccfac88/cffi-2.0.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fc7de24befaeae77ba923797c7c87834c73648a05a4bde34b3b7e5588973a453", size = 216475, upload-time = "2025-09-08T23:22:17.427Z" },
+    { url = "https://files.pythonhosted.org/packages/21/7a/13b24e70d2f90a322f2900c5d8e1f14fa7e2a6b3332b7309ba7b2ba51a5a/cffi-2.0.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:cf364028c016c03078a23b503f02058f1814320a56ad535686f90565636a9495", size = 218829, upload-time = "2025-09-08T23:22:19.069Z" },
+    { url = "https://files.pythonhosted.org/packages/60/99/c9dc110974c59cc981b1f5b66e1d8af8af764e00f0293266824d9c4254bc/cffi-2.0.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:e11e82b744887154b182fd3e7e8512418446501191994dbf9c9fc1f32cc8efd5", size = 211211, upload-time = "2025-09-08T23:22:20.588Z" },
+    { url = "https://files.pythonhosted.org/packages/49/72/ff2d12dbf21aca1b32a40ed792ee6b40f6dc3a9cf1644bd7ef6e95e0ac5e/cffi-2.0.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8ea985900c5c95ce9db1745f7933eeef5d314f0565b27625d9a10ec9881e1bfb", size = 218036, upload-time = "2025-09-08T23:22:22.143Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/cc/027d7fb82e58c48ea717149b03bcadcbdc293553edb283af792bd4bcbb3f/cffi-2.0.0-cp310-cp310-win32.whl", hash = "sha256:1f72fb8906754ac8a2cc3f9f5aaa298070652a0ffae577e0ea9bd480dc3c931a", size = 172184, upload-time = "2025-09-08T23:22:23.328Z" },
+    { url = "https://files.pythonhosted.org/packages/33/fa/072dd15ae27fbb4e06b437eb6e944e75b068deb09e2a2826039e49ee2045/cffi-2.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:b18a3ed7d5b3bd8d9ef7a8cb226502c6bf8308df1525e1cc676c3680e7176739", size = 182790, upload-time = "2025-09-08T23:22:24.752Z" },
+    { url = "https://files.pythonhosted.org/packages/12/4a/3dfd5f7850cbf0d06dc84ba9aa00db766b52ca38d8b86e3a38314d52498c/cffi-2.0.0-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:b4c854ef3adc177950a8dfc81a86f5115d2abd545751a304c5bcf2c2c7283cfe", size = 184344, upload-time = "2025-09-08T23:22:26.456Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/8b/f0e4c441227ba756aafbe78f117485b25bb26b1c059d01f137fa6d14896b/cffi-2.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2de9a304e27f7596cd03d16f1b7c72219bd944e99cc52b84d0145aefb07cbd3c", size = 180560, upload-time = "2025-09-08T23:22:28.197Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/b7/1200d354378ef52ec227395d95c2576330fd22a869f7a70e88e1447eb234/cffi-2.0.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:baf5215e0ab74c16e2dd324e8ec067ef59e41125d3eade2b863d294fd5035c92", size = 209613, upload-time = "2025-09-08T23:22:29.475Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/56/6033f5e86e8cc9bb629f0077ba71679508bdf54a9a5e112a3c0b91870332/cffi-2.0.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:730cacb21e1bdff3ce90babf007d0a0917cc3e6492f336c2f0134101e0944f93", size = 216476, upload-time = "2025-09-08T23:22:31.063Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/7f/55fecd70f7ece178db2f26128ec41430d8720f2d12ca97bf8f0a628207d5/cffi-2.0.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6824f87845e3396029f3820c206e459ccc91760e8fa24422f8b0c3d1731cbec5", size = 203374, upload-time = "2025-09-08T23:22:32.507Z" },
+    { url = "https://files.pythonhosted.org/packages/84/ef/a7b77c8bdc0f77adc3b46888f1ad54be8f3b7821697a7b89126e829e676a/cffi-2.0.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9de40a7b0323d889cf8d23d1ef214f565ab154443c42737dfe52ff82cf857664", size = 202597, upload-time = "2025-09-08T23:22:34.132Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/91/500d892b2bf36529a75b77958edfcd5ad8e2ce4064ce2ecfeab2125d72d1/cffi-2.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8941aaadaf67246224cee8c3803777eed332a19d909b47e29c9842ef1e79ac26", size = 215574, upload-time = "2025-09-08T23:22:35.443Z" },
+    { url = "https://files.pythonhosted.org/packages/44/64/58f6255b62b101093d5df22dcb752596066c7e89dd725e0afaed242a61be/cffi-2.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a05d0c237b3349096d3981b727493e22147f934b20f6f125a3eba8f994bec4a9", size = 218971, upload-time = "2025-09-08T23:22:36.805Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/49/fa72cebe2fd8a55fbe14956f9970fe8eb1ac59e5df042f603ef7c8ba0adc/cffi-2.0.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:94698a9c5f91f9d138526b48fe26a199609544591f859c870d477351dc7b2414", size = 211972, upload-time = "2025-09-08T23:22:38.436Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/28/dd0967a76aab36731b6ebfe64dec4e981aff7e0608f60c2d46b46982607d/cffi-2.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5fed36fccc0612a53f1d4d9a816b50a36702c28a2aa880cb8a122b3466638743", size = 217078, upload-time = "2025-09-08T23:22:39.776Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/c0/015b25184413d7ab0a410775fdb4a50fca20f5589b5dab1dbbfa3baad8ce/cffi-2.0.0-cp311-cp311-win32.whl", hash = "sha256:c649e3a33450ec82378822b3dad03cc228b8f5963c0c12fc3b1e0ab940f768a5", size = 172076, upload-time = "2025-09-08T23:22:40.95Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/8f/dc5531155e7070361eb1b7e4c1a9d896d0cb21c49f807a6c03fd63fc877e/cffi-2.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:66f011380d0e49ed280c789fbd08ff0d40968ee7b665575489afa95c98196ab5", size = 182820, upload-time = "2025-09-08T23:22:42.463Z" },
+    { url = "https://files.pythonhosted.org/packages/95/5c/1b493356429f9aecfd56bc171285a4c4ac8697f76e9bbbbb105e537853a1/cffi-2.0.0-cp311-cp311-win_arm64.whl", hash = "sha256:c6638687455baf640e37344fe26d37c404db8b80d037c3d29f58fe8d1c3b194d", size = 177635, upload-time = "2025-09-08T23:22:43.623Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d", size = 185271, upload-time = "2025-09-08T23:22:44.795Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c", size = 181048, upload-time = "2025-09-08T23:22:45.938Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529, upload-time = "2025-09-08T23:22:47.349Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097, upload-time = "2025-09-08T23:22:48.677Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e", size = 207983, upload-time = "2025-09-08T23:22:50.06Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/c8/15cb9ada8895957ea171c62dc78ff3e99159ee7adb13c0123c001a2546c1/cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037", size = 206519, upload-time = "2025-09-08T23:22:51.364Z" },
+    { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572, upload-time = "2025-09-08T23:22:52.902Z" },
+    { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963, upload-time = "2025-09-08T23:22:54.518Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361, upload-time = "2025-09-08T23:22:55.867Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/2b/2b6435f76bfeb6bbf055596976da087377ede68df465419d192acf00c437/cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18", size = 172932, upload-time = "2025-09-08T23:22:57.188Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5", size = 183557, upload-time = "2025-09-08T23:22:58.351Z" },
+    { url = "https://files.pythonhosted.org/packages/95/31/9f7f93ad2f8eff1dbc1c3656d7ca5bfd8fb52c9d786b4dcf19b2d02217fa/cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6", size = 177762, upload-time = "2025-09-08T23:22:59.668Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/cc/08ed5a43f2996a16b462f64a7055c6e962803534924b9b2f1371d8c00b7b/cffi-2.0.0-cp39-cp39-macosx_10_13_x86_64.whl", hash = "sha256:fe562eb1a64e67dd297ccc4f5addea2501664954f2692b69a76449ec7913ecbf", size = 184288, upload-time = "2025-09-08T23:23:48.404Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/de/38d9726324e127f727b4ecc376bc85e505bfe61ef130eaf3f290c6847dd4/cffi-2.0.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:de8dad4425a6ca6e4e5e297b27b5c824ecc7581910bf9aee86cb6835e6812aa7", size = 180509, upload-time = "2025-09-08T23:23:49.73Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/13/c92e36358fbcc39cf0962e83223c9522154ee8630e1df7c0b3a39a8124e2/cffi-2.0.0-cp39-cp39-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:4647afc2f90d1ddd33441e5b0e85b16b12ddec4fca55f0d9671fef036ecca27c", size = 208813, upload-time = "2025-09-08T23:23:51.263Z" },
+    { url = "https://files.pythonhosted.org/packages/15/12/a7a79bd0df4c3bff744b2d7e52cc1b68d5e7e427b384252c42366dc1ecbc/cffi-2.0.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3f4d46d8b35698056ec29bca21546e1551a205058ae1a181d871e278b0b28165", size = 216498, upload-time = "2025-09-08T23:23:52.494Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/ad/5c51c1c7600bdd7ed9a24a203ec255dccdd0ebf4527f7b922a0bde2fb6ed/cffi-2.0.0-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:e6e73b9e02893c764e7e8d5bb5ce277f1a009cd5243f8228f75f842bf937c534", size = 203243, upload-time = "2025-09-08T23:23:53.836Z" },
+    { url = "https://files.pythonhosted.org/packages/32/f2/81b63e288295928739d715d00952c8c6034cb6c6a516b17d37e0c8be5600/cffi-2.0.0-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:cb527a79772e5ef98fb1d700678fe031e353e765d1ca2d409c92263c6d43e09f", size = 203158, upload-time = "2025-09-08T23:23:55.169Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/74/cc4096ce66f5939042ae094e2e96f53426a979864aa1f96a621ad128be27/cffi-2.0.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:61d028e90346df14fedc3d1e5441df818d095f3b87d286825dfcbd6459b7ef63", size = 216548, upload-time = "2025-09-08T23:23:56.506Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/be/f6424d1dc46b1091ffcc8964fa7c0ab0cd36839dd2761b49c90481a6ba1b/cffi-2.0.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:0f6084a0ea23d05d20c3edcda20c3d006f9b6f3fefeac38f59262e10cef47ee2", size = 218897, upload-time = "2025-09-08T23:23:57.825Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/e0/dda537c2309817edf60109e39265f24f24aa7f050767e22c98c53fe7f48b/cffi-2.0.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:1cd13c99ce269b3ed80b417dcd591415d3372bcac067009b6e0f59c7d4015e65", size = 211249, upload-time = "2025-09-08T23:23:59.139Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/e7/7c769804eb75e4c4b35e658dba01de1640a351a9653c3d49ca89d16ccc91/cffi-2.0.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:89472c9762729b5ae1ad974b777416bfda4ac5642423fa93bd57a09204712322", size = 218041, upload-time = "2025-09-08T23:24:00.496Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/d9/6218d78f920dcd7507fc16a766b5ef8f3b913cc7aa938e7fc80b9978d089/cffi-2.0.0-cp39-cp39-win32.whl", hash = "sha256:2081580ebb843f759b9f617314a24ed5738c51d2aee65d31e02f6f7a2b97707a", size = 172138, upload-time = "2025-09-08T23:24:01.7Z" },
+    { url = "https://files.pythonhosted.org/packages/54/8f/a1e836f82d8e32a97e6b29cc8f641779181ac7363734f12df27db803ebda/cffi-2.0.0-cp39-cp39-win_amd64.whl", hash = "sha256:b882b3df248017dba09d6b16defe9b5c407fe32fc7c65a9c69798e6175601be9", size = 182794, upload-time = "2025-09-08T23:24:02.943Z" },
 ]
 
 [[package]]
@@ -87,7 +232,8 @@ name = "click"
 version = "8.4.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.10'",
+    "python_full_version >= '3.14'",
+    "python_full_version >= '3.10' and python_full_version < '3.14'",
 ]
 dependencies = [
     { name = "colorama", marker = "python_full_version >= '3.10' and sys_platform == 'win32'" },
@@ -142,7 +288,8 @@ name = "fastapi"
 version = "0.136.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.10'",
+    "python_full_version >= '3.14'",
+    "python_full_version >= '3.10' and python_full_version < '3.14'",
 ]
 dependencies = [
     { name = "annotated-doc", marker = "python_full_version >= '3.10'" },
@@ -289,7 +436,8 @@ name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.10'",
+    "python_full_version >= '3.14'",
+    "python_full_version >= '3.10' and python_full_version < '3.14'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
@@ -399,6 +547,31 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "2.23"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fe/cf/d2d3b9f5699fb1e4615c8e32ff220203e43b248e1dfcc6736ad9057731ca/pycparser-2.23.tar.gz", hash = "sha256:78816d4f24add8f10a06d6f05b4d424ad9e96cfebf68a4ddc99c65c0720d00c2", size = 173734, upload-time = "2025-09-09T13:23:47.91Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/e3/59cd50310fc9b59512193629e1984c1f95e5c8ae6e5d8c69532ccc65a7fe/pycparser-2.23-py3-none-any.whl", hash = "sha256:e5c6e8d3fbad53479cab09ac03729e0a9faf2bee3db8208a550daf5af81a5934", size = 118140, upload-time = "2025-09-09T13:23:46.651Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version >= '3.10' and python_full_version < '3.14'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
 ]
 
 [[package]]
@@ -581,7 +754,8 @@ name = "pytest"
 version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.10'",
+    "python_full_version >= '3.14'",
+    "python_full_version >= '3.10' and python_full_version < '3.14'",
 ]
 dependencies = [
     { name = "colorama", marker = "python_full_version >= '3.10' and sys_platform == 'win32'" },
@@ -614,7 +788,8 @@ name = "python-dotenv"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.10'",
+    "python_full_version >= '3.14'",
+    "python_full_version >= '3.10' and python_full_version < '3.14'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
@@ -840,7 +1015,8 @@ name = "regex"
 version = "2026.5.9"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.10'",
+    "python_full_version >= '3.14'",
+    "python_full_version >= '3.10' and python_full_version < '3.14'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/dc/0e/49aee608ad09480e7fd276898c99ec6192985fa331abe4eb3a986094490b/regex-2026.5.9.tar.gz", hash = "sha256:a8234aa23ec39894bfe4a3f1b85616a7032481964a13ac6fc9f10de4f6fca270", size = 416074, upload-time = "2026-05-09T23:15:19.37Z" }
 wheels = [
@@ -1005,7 +1181,8 @@ name = "starlette"
 version = "1.2.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.10'",
+    "python_full_version >= '3.14'",
+    "python_full_version >= '3.10' and python_full_version < '3.14'",
 ]
 dependencies = [
     { name = "anyio", version = "4.13.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
@@ -1021,6 +1198,7 @@ name = "tiny-ipa-backend"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "argon2-cffi" },
     { name = "fastapi", version = "0.128.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "fastapi", version = "0.136.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "uvicorn", version = "0.39.0", source = { registry = "https://pypi.org/simple" }, extra = ["standard"], marker = "python_full_version < '3.10'" },
@@ -1040,6 +1218,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "argon2-cffi", specifier = ">=23.1.0" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
@@ -1157,7 +1336,8 @@ name = "uvicorn"
 version = "0.49.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.10'",
+    "python_full_version >= '3.14'",
+    "python_full_version >= '3.10' and python_full_version < '3.14'",
 ]
 dependencies = [
     { name = "click", version = "8.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
@@ -1357,7 +1537,8 @@ name = "watchfiles"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.10'",
+    "python_full_version >= '3.14'",
+    "python_full_version >= '3.10' and python_full_version < '3.14'",
 ]
 dependencies = [
     { name = "anyio", version = "4.13.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
@@ -1565,7 +1746,8 @@ name = "websockets"
 version = "16.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.10'",
+    "python_full_version >= '3.14'",
+    "python_full_version >= '3.10' and python_full_version < '3.14'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/04/24/4b2031d72e840ce4c1ccb255f693b15c334757fc50023e4db9537080b8c4/websockets-16.0.tar.gz", hash = "sha256:5f6261a5e56e8d5c42a4497b364ea24d94d9563e8fbd44e78ac40879c60179b5", size = 179346, upload-time = "2026-01-10T09:23:47.181Z" }
 wheels = [

--- a/docs/05-data-api-contracts.md
+++ b/docs/05-data-api-contracts.md
@@ -112,6 +112,27 @@ phonemes(
   description_zh TEXT
 )
 
+users(
+  id TEXT PRIMARY KEY,
+  username TEXT NOT NULL UNIQUE,
+  password_hash TEXT NOT NULL,
+  is_owner INTEGER NOT NULL DEFAULT 0,
+  is_active INTEGER NOT NULL DEFAULT 1,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+)
+
+auth_sessions(
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  token_hash TEXT NOT NULL UNIQUE,
+  created_at TEXT NOT NULL,
+  last_seen_at TEXT NOT NULL,
+  expires_at TEXT NOT NULL,
+  revoked_at TEXT,
+  FOREIGN KEY(user_id) REFERENCES users(id)
+)
+
 settings(
   user_id TEXT PRIMARY KEY,
   primary_accent TEXT NOT NULL,
@@ -245,6 +266,25 @@ login rotates or replaces any existing session id
 deployed session secret is required and must not have an insecure built-in default
 local-dev secret/bootstrap behavior is documented and visibly non-production
 ```
+
+The #239 bootstrap foundation provides a CLI setup path without enabling route
+behavior:
+
+```bash
+cd backend
+python scripts/bootstrap_auth.py --db-url /path/to/tiny_ipa.sqlite owner \
+  --username owner --password 'change-me-long-password'
+
+python scripts/bootstrap_auth.py --db-url /tmp/tiny_ipa_dev.sqlite dev-user \
+  --enable-local-dev --environment development \
+  --username local-dev --password 'local-dev-password'
+```
+
+Owner bootstrap creates the first owner and fails closed if an owner already
+exists. Local dev bootstrap is explicit, creates a normal user instead of an
+auth bypass, and refuses `production`, `prod`, `deployed`, or `deploy`
+environments. Password hashes use Argon2 via `argon2-cffi`; auth session rows
+store a hash of the opaque session token, not the raw token.
 
 Same-origin SPA/API deployment is the default. If a split origin is introduced,
 the CORS allowlist must be exact and credentials-aware; wildcard origins are not

--- a/docs/development.md
+++ b/docs/development.md
@@ -62,6 +62,29 @@ write permission.
 
 Do not put `needs:implementer` on an Epic. Implementers pick up child issues, not Epic containers. If an Epic-level concern requires execution, create a child task such as integration QA, cross-issue gap fixing, or final manual QA evidence.
 
+## Local auth bootstrap
+
+M12 adds auth storage before login/logout routes. For personal deployment setup,
+create the first owner explicitly:
+
+```bash
+cd backend
+python scripts/bootstrap_auth.py --db-url ./tiny_ipa.sqlite owner \
+  --username owner --password 'change-me-long-password'
+```
+
+For local development, use the guarded dev-user path:
+
+```bash
+cd backend
+python scripts/bootstrap_auth.py --db-url /tmp/tiny_ipa_dev.sqlite dev-user \
+  --enable-local-dev --environment development \
+  --username local-dev --password 'local-dev-password'
+```
+
+The local-dev command refuses production/deployed environments and does not
+enable an auth bypass. It only creates a normal user record for local testing.
+
 `Ready + needs:implementer` may represent an Implementer queue, not only work that can start immediately. Implementers should read all ready issues in the queue, sort them by the `Depends on` line in each `Execution Contract`, and execute only the issues whose dependencies are satisfied.
 
 Do not make every child issue review a queue-wide stop. A previous issue's review blocks later implementation only when the later issue's `Execution Contract` says so with a hard `Depends on` gate, or when the Architect posts an explicit hold on the Epic. Otherwise the Implementer may continue through the ready queue and let review feedback converge through the normal PR cycle.


### PR DESCRIPTION
## Summary

Implements #239 backend auth persistence foundation only:
- adds `users` and `auth_sessions` SQLite runtime tables plus repository models/helpers
- adds Argon2 password hashing via `argon2-cffi`
- adds owner bootstrap and explicit guarded local-dev bootstrap paths
- adds opaque server-side auth session token hashing, resolution, revocation, and expiry helpers
- documents the #239 bootstrap commands and schema contract
- adds temp-DB tests for schema, bootstrap, password hashing, session storage, CLI smoke, and deployed secret fail-closed behavior

## Scope Boundaries

Out of scope preserved:
- no login/logout/me routes
- no current-user FastAPI dependency wiring
- no endpoint-wide user isolation refactor
- no frontend auth UI
- no real/private DB migration or default-data owner-claim apply mode
- no runtime/deploy/security config mutation

## Verification

- `uv run --extra dev pytest tests/test_auth_foundation.py tests/test_import_words.py::TestSchemaInitialisation` -> 17 passed
- `uv run --extra dev pytest` -> 280 passed, 1 existing Starlette/httpx deprecation warning
- `uv run --extra dev ruff check app/services/auth.py scripts/bootstrap_auth.py tests/test_auth_foundation.py app/services/db_schema.py app/services/db_store.py app/models.py tests/test_import_words.py` -> passed
- `uv run --extra dev python scripts/bootstrap_auth.py --db-url "$tmpdir/local-dev.sqlite" dev-user --enable-local-dev --environment development --username local-dev --password 'local dev password'` -> created local-dev user
- `uv lock --check` -> resolved successfully
- `git diff --check` -> passed
- `tools/agents/agent-audit` -> passed after built-in retry recovered a GitHub TLS timeout

## Residual Risks

- Full-repo `ruff check .` still fails on pre-existing unrelated lint in legacy files; touched files pass targeted ruff.
- `uv lock` updated resolver markers while adding `argon2-cffi`; package resolution and backend tests pass.
- Auth endpoints/current-user dependency and runtime data isolation remain for #240/#241.

Closes no issue directly; route #239 to Reviewer after review handoff.
