### PR TITLE
[#240] Add M12 auth endpoints and current-user dependency

### DIFF
--- a/backend/app/auth_dependencies.py
+++ b/backend/app/auth_dependencies.py
@@ -1,0 +1,72 @@
+"""FastAPI auth dependency helpers for M12."""
+
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+from fastapi import Cookie, HTTPException
+
+from app.db import get_db
+from app.models import User
+from app.services.auth import (
+    DEPLOYED_ENVIRONMENTS,
+    AuthSecretRequiredError,
+    ResolvedSession,
+    require_session_secret,
+    resolve_auth_session,
+)
+
+AUTH_COOKIE_NAME = "tiny_ipa_session"
+AUTH_COOKIE_PATH = "/"
+AUTH_COOKIE_SAMESITE = "lax"
+
+
+def is_deployed_environment() -> bool:
+    return os.getenv("TINY_IPA_ENV", "local").strip().lower() in DEPLOYED_ENVIRONMENTS
+
+
+def auth_cookie_secure() -> bool:
+    return is_deployed_environment()
+
+
+def auth_error(error: str, detail: str, *, status_code: int = 401) -> HTTPException:
+    return HTTPException(
+        status_code=status_code,
+        detail={"error": error, "detail": detail},
+    )
+
+
+def ensure_auth_configured() -> None:
+    try:
+        require_session_secret()
+    except AuthSecretRequiredError as exc:
+        raise auth_error(
+            "AUTH_CONFIG_INVALID",
+            str(exc),
+            status_code=500,
+        ) from exc
+
+
+def resolve_current_session(token: Optional[str]) -> Optional[ResolvedSession]:
+    ensure_auth_configured()
+    if not token:
+        return None
+    with get_db() as conn:
+        return resolve_auth_session(conn, token=token)
+
+
+def get_optional_current_user(
+    tiny_ipa_session: Optional[str] = Cookie(default=None, alias=AUTH_COOKIE_NAME),
+) -> Optional[User]:
+    resolved = resolve_current_session(tiny_ipa_session)
+    return resolved.user if resolved is not None else None
+
+
+def require_current_user(
+    tiny_ipa_session: Optional[str] = Cookie(default=None, alias=AUTH_COOKIE_NAME),
+) -> User:
+    resolved = resolve_current_session(tiny_ipa_session)
+    if resolved is None:
+        raise auth_error("AUTH_REQUIRED", "Sign in required.")
+    return resolved.user

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,9 +7,10 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 
+from app.routes.attempts import router as attempts_router
+from app.routes.auth import router as auth_router
 from app.routes.health import router as health_router
 from app.routes.practice import router as practice_router
-from app.routes.attempts import router as attempts_router
 from app.routes.progress import router as progress_router
 from app.routes.settings import router as settings_router
 
@@ -23,12 +24,16 @@ app.add_middleware(
 )
 
 app.include_router(health_router, prefix="/api")
+app.include_router(auth_router, prefix="/api")
 app.include_router(practice_router, prefix="/api")
 app.include_router(attempts_router, prefix="/api")
 app.include_router(progress_router, prefix="/api")
 app.include_router(settings_router, prefix="/api")
 
 # Mount static audio directory for local dev. In production Nginx serves /audio/.
-_AUDIO_DIR = os.getenv("TINY_IPA_AUDIO_DIR", str(Path(__file__).resolve().parent.parent.parent / "audio"))
+_AUDIO_DIR = os.getenv(
+    "TINY_IPA_AUDIO_DIR",
+    str(Path(__file__).resolve().parent.parent.parent / "audio"),
+)
 if os.path.isdir(_AUDIO_DIR):
     app.mount("/audio", StaticFiles(directory=_AUDIO_DIR), name="audio")

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -1,0 +1,81 @@
+"""Auth endpoints for M12 minimal personal-VPS sessions."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Request, Response
+
+from app.auth_dependencies import (
+    AUTH_COOKIE_NAME,
+    AUTH_COOKIE_PATH,
+    AUTH_COOKIE_SAMESITE,
+    auth_cookie_secure,
+    auth_error,
+    ensure_auth_configured,
+    get_optional_current_user,
+)
+from app.db import get_db
+from app.models import User
+from app.services.auth import authenticate_user, issue_auth_session, revoke_session
+
+router = APIRouter(prefix="/auth")
+
+
+def _public_user(user: User) -> dict:
+    return {
+        "id": user.id,
+        "username": user.username,
+        "is_owner": user.is_owner,
+    }
+
+
+@router.post("/login")
+async def login(request: Request, response: Response):
+    ensure_auth_configured()
+    body = await request.json()
+    username = body.get("username")
+    password = body.get("password")
+    if not isinstance(username, str) or not isinstance(password, str):
+        raise auth_error("INVALID_CREDENTIALS", "Invalid username or password.")
+
+    with get_db() as conn:
+        authenticated = authenticate_user(conn, username=username, password=password)
+        if authenticated is None:
+            raise auth_error("INVALID_CREDENTIALS", "Invalid username or password.")
+        issued = issue_auth_session(conn, user_id=authenticated.user.id)
+
+    response.set_cookie(
+        AUTH_COOKIE_NAME,
+        issued.token,
+        httponly=True,
+        secure=auth_cookie_secure(),
+        samesite=AUTH_COOKIE_SAMESITE,
+        path=AUTH_COOKIE_PATH,
+    )
+    return {
+        "authenticated": True,
+        "user": _public_user(authenticated.user),
+    }
+
+
+@router.post("/logout")
+def logout(request: Request, response: Response):
+    ensure_auth_configured()
+    token = request.cookies.get(AUTH_COOKIE_NAME)
+    if token:
+        with get_db() as conn:
+            revoke_session(conn, token=token)
+    response.delete_cookie(
+        AUTH_COOKIE_NAME,
+        path=AUTH_COOKIE_PATH,
+        secure=auth_cookie_secure(),
+        httponly=True,
+        samesite=AUTH_COOKIE_SAMESITE,
+    )
+    return {"ok": True}
+
+
+@router.get("/me")
+def me(current_user: User | None = Depends(get_optional_current_user)):
+    if current_user is None:
+        return {"authenticated": False, "user": None}
+    return {"authenticated": True, "user": _public_user(current_user)}

--- a/backend/app/services/auth.py
+++ b/backend/app/services/auth.py
@@ -75,6 +75,12 @@ class ResolvedSession:
     user: User
 
 
+@dataclass(frozen=True)
+class AuthenticatedUser:
+    user: User
+    password_needs_rehash: bool
+
+
 def _now() -> datetime:
     return datetime.now(timezone.utc)
 
@@ -104,6 +110,24 @@ def verify_password(password: str, password_hash: str) -> bool:
 
 def password_hash_needs_rehash(password_hash: str) -> bool:
     return _PASSWORD_HASHER.check_needs_rehash(password_hash)
+
+
+def authenticate_user(
+    conn: sqlite3.Connection,
+    *,
+    username: str,
+    password: str,
+) -> Optional[AuthenticatedUser]:
+    username = _normalize_username(username)
+    user = get_user_by_username(conn, username)
+    if user is None or not user.is_active:
+        return None
+    if not verify_password(password, user.password_hash):
+        return None
+    return AuthenticatedUser(
+        user=user,
+        password_needs_rehash=password_hash_needs_rehash(user.password_hash),
+    )
 
 
 def bootstrap_owner(

--- a/backend/tests/test_auth_api.py
+++ b/backend/tests/test_auth_api.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+from fastapi import Depends, FastAPI
+from fastapi.testclient import TestClient
+
+from app.auth_dependencies import AUTH_COOKIE_NAME, require_current_user
+from app.db import get_connection
+from app.main import app
+from app.services.auth import bootstrap_owner, issue_auth_session
+from app.services.db_schema import init_db
+
+
+@pytest.fixture(name="auth_db")
+def auth_db_fixture(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> str:
+    db_path = str(tmp_path / "auth_api.sqlite")
+    conn = get_connection(db_path)
+    init_db(conn)
+    bootstrap_owner(conn, username="owner", password="correct horse battery staple")
+    conn.commit()
+    conn.close()
+
+    import app.db as db_mod
+
+    monkeypatch.setattr(db_mod, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setenv("TINY_IPA_ENV", "local")
+    monkeypatch.delenv("TINY_IPA_SESSION_SECRET", raising=False)
+    return db_path
+
+
+@pytest.fixture(name="client")
+def client_fixture(auth_db: str) -> TestClient:
+    return TestClient(app)
+
+
+def test_login_sets_http_only_lax_session_cookie(client: TestClient):
+    resp = client.post(
+        "/api/auth/login",
+        json={"username": "owner", "password": "correct horse battery staple"},
+    )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["authenticated"] is True
+    assert data["user"]["username"] == "owner"
+    assert data["user"]["is_owner"] is True
+    assert "password" not in data["user"]
+
+    cookie = resp.headers["set-cookie"]
+    assert f"{AUTH_COOKIE_NAME}=" in cookie
+    assert "HttpOnly" in cookie
+    assert "SameSite=lax" in cookie
+    assert "Path=/" in cookie
+    assert "Secure" not in cookie
+
+
+def test_login_rejects_invalid_credentials(client: TestClient):
+    resp = client.post(
+        "/api/auth/login",
+        json={"username": "owner", "password": "wrong password"},
+    )
+
+    assert resp.status_code == 401
+    assert resp.json()["detail"]["error"] == "INVALID_CREDENTIALS"
+    assert AUTH_COOKIE_NAME not in resp.cookies
+
+
+def test_me_reports_anonymous_then_authenticated_user(client: TestClient):
+    anon = client.get("/api/auth/me")
+    assert anon.status_code == 200
+    assert anon.json() == {"authenticated": False, "user": None}
+
+    client.post(
+        "/api/auth/login",
+        json={"username": "owner", "password": "correct horse battery staple"},
+    )
+
+    me = client.get("/api/auth/me")
+    assert me.status_code == 200
+    assert me.json()["authenticated"] is True
+    assert me.json()["user"]["username"] == "owner"
+
+
+def test_logout_invalidates_session_and_clears_cookie(client: TestClient):
+    client.post(
+        "/api/auth/login",
+        json={"username": "owner", "password": "correct horse battery staple"},
+    )
+
+    logout = client.post("/api/auth/logout")
+    assert logout.status_code == 200
+    assert logout.json() == {"ok": True}
+    assert f"{AUTH_COOKIE_NAME}=" in logout.headers["set-cookie"]
+    assert "Max-Age=0" in logout.headers["set-cookie"]
+
+    me = client.get("/api/auth/me")
+    assert me.status_code == 200
+    assert me.json() == {"authenticated": False, "user": None}
+
+
+def test_me_treats_expired_session_as_anonymous(
+    auth_db: str,
+    client: TestClient,
+):
+    conn = get_connection(auth_db)
+    user_id = conn.execute("SELECT id FROM users WHERE username = 'owner'").fetchone()["id"]
+    issued = issue_auth_session(
+        conn,
+        user_id=user_id,
+        now=datetime.now(timezone.utc) - timedelta(hours=2),
+        ttl=timedelta(minutes=1),
+    )
+    conn.commit()
+    conn.close()
+
+    client.cookies.set(AUTH_COOKIE_NAME, issued.token)
+    resp = client.get("/api/auth/me")
+
+    assert resp.status_code == 200
+    assert resp.json() == {"authenticated": False, "user": None}
+
+
+def test_current_user_dependency_returns_auth_required_when_anonymous(
+    auth_db: str,
+):
+    protected = FastAPI()
+
+    @protected.get("/protected")
+    def protected_route(_user=Depends(require_current_user)):
+        return {"ok": True}
+
+    client = TestClient(protected)
+    resp = client.get("/protected")
+
+    assert resp.status_code == 401
+    assert resp.json()["detail"]["error"] == "AUTH_REQUIRED"
+
+
+def test_current_user_dependency_resolves_authenticated_cookie(
+    auth_db: str,
+):
+    protected = FastAPI()
+
+    @protected.get("/protected")
+    def protected_route(user=Depends(require_current_user)):
+        return {"user_id": user.id, "username": user.username}
+
+    conn = get_connection(auth_db)
+    user_id = conn.execute("SELECT id FROM users WHERE username = 'owner'").fetchone()["id"]
+    issued = issue_auth_session(conn, user_id=user_id)
+    conn.commit()
+    conn.close()
+
+    client = TestClient(protected)
+    client.cookies.set(AUTH_COOKIE_NAME, issued.token)
+    resp = client.get("/protected")
+
+    assert resp.status_code == 200
+    assert resp.json() == {"user_id": user_id, "username": "owner"}
+
+
+def test_production_auth_fails_closed_without_session_secret(
+    auth_db: str,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("TINY_IPA_ENV", "production")
+    monkeypatch.delenv("TINY_IPA_SESSION_SECRET", raising=False)
+
+    client = TestClient(app)
+    resp = client.post(
+        "/api/auth/login",
+        json={"username": "owner", "password": "correct horse battery staple"},
+    )
+
+    assert resp.status_code == 500
+    assert resp.json()["detail"]["error"] == "AUTH_CONFIG_INVALID"
+
+
+def test_production_cookie_is_secure_when_secret_is_configured(
+    auth_db: str,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("TINY_IPA_ENV", "production")
+    monkeypatch.setenv("TINY_IPA_SESSION_SECRET", "test-only-secret")
+
+    client = TestClient(app)
+    resp = client.post(
+        "/api/auth/login",
+        json={"username": "owner", "password": "correct horse battery staple"},
+    )
+
+    assert resp.status_code == 200
+    assert "Secure" in resp.headers["set-cookie"]


### PR DESCRIPTION
## Scope

Implements #240 only: minimal backend auth endpoints and reusable current-user dependency for the M12 auth boundary.

Completed:
- Added `POST /api/auth/login`, `POST /api/auth/logout`, and `GET /api/auth/me`.
- Added centralized cookie/current-user helpers with stable `AUTH_REQUIRED`, `INVALID_CREDENTIALS`, and `AUTH_CONFIG_INVALID` error shapes.
- Login issues server-side opaque sessions using #239 storage; logout revokes sessions and clears the cookie.
- Cookie behavior is HttpOnly, SameSite=Lax, Path=/, and Secure in deployed environments.
- Deployed auth fails closed when `TINY_IPA_SESSION_SECRET` is missing.
- Added focused backend tests for login failure/success, cookie flags, logout invalidation, `/auth/me`, expired sessions, production missing-secret behavior, and dependency auth-required/authenticated paths.

Out of scope preserved:
- No #241 endpoint-wide user isolation rollout.
- No #242 default-user owner-claim dry-run or migration/apply mode.
- No #243 frontend login/logout/current-user UX.
- No #244 final readiness review.
- No `main` merge, #210 closure, deployment/runtime config mutation, data migration, or real/private DB mutation.

## Verification

- `uv run --project backend --extra dev pytest backend/tests/test_auth_api.py backend/tests/test_auth_foundation.py backend/tests/test_settings_api.py` -> 38 passed, 1 existing Starlette/httpx deprecation warning.
- `uv run --project backend --extra dev ruff check backend/app/auth_dependencies.py backend/app/routes/auth.py backend/app/services/auth.py backend/tests/test_auth_api.py backend/app/main.py` -> passed.
- `uv run --project backend --extra dev pytest` -> 289 passed, 1 existing Starlette/httpx deprecation warning.
- `git diff --check` -> passed.
- `tools/agents/agent-audit` -> clean.

## Residual Risks

- Current-user helpers are introduced but existing learner-data routes are not yet converted to current-user scoped data access; #241 owns the endpoint-wide isolation rollout.
- Frontend still has no login/logout UX; #243 owns that.
- Origin/CSRF/deployed CORS readiness remains later M12/M13 evidence work, not this backend endpoint foundation PR.