### PR TITLE
[#241] Enforce backend user data isolation

### DIFF
--- a/backend/app/routes/attempts.py
+++ b/backend/app/routes/attempts.py
@@ -5,10 +5,11 @@ from __future__ import annotations
 import uuid
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Request
 
+from app.auth_dependencies import require_current_user
 from app.db import get_db
-from app.models import Attempt
+from app.models import Attempt, User
 from app.services.db_store import (
     all_session_items_attempted,
     create_attempt,
@@ -29,7 +30,10 @@ def _now_iso() -> str:
 
 
 @router.post("/attempt")
-async def attempt(request: Request):
+async def attempt(
+    request: Request,
+    current_user: User = Depends(require_current_user),
+):
     """Submit a practice attempt for grading.
 
     Expects JSON body::
@@ -80,6 +84,11 @@ async def attempt(request: Request):
                 status_code=404,
                 detail={"error": "SESSION_NOT_FOUND", "detail": session_id},
             )
+        if session.user_id != current_user.id:
+            raise HTTPException(
+                status_code=404,
+                detail={"error": "ITEM_NOT_FOUND", "detail": session_item_id},
+            )
         if session.status == "completed":
             raise HTTPException(
                 status_code=400,
@@ -102,7 +111,7 @@ async def attempt(request: Request):
         timestamp = _now_iso()
         attempt_row = Attempt(
             id=str(uuid.uuid4()),
-            user_id="default",
+            user_id=current_user.id,
             session_item_id=session_item_id,
             word_id=item.word_id,
             primary_accent=session.primary_accent,
@@ -119,7 +128,7 @@ async def attempt(request: Request):
         # Update phoneme stats.
         updated_phonemes = update_phoneme_stats(
             conn,
-            user_id="default",
+            user_id=current_user.id,
             primary_accent=session.primary_accent,
             target_phonemes=item.target_phonemes,
             is_correct=is_correct,

--- a/backend/app/routes/practice.py
+++ b/backend/app/routes/practice.py
@@ -1,8 +1,10 @@
 """Practice endpoints — daily session and action-specific group starts."""
 
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Request
 
+from app.auth_dependencies import require_current_user
 from app.db import get_db
+from app.models import User
 from app.services.sessions import (
     build_abandon_current_and_next_response,
     build_clear_focus_response,
@@ -19,46 +21,49 @@ router = APIRouter()
 
 
 @router.get("/today")
-def today():
+def today(current_user: User = Depends(require_current_user)):
     """Return today's practice hub state without creating a new group.
 
     Refresh-safe: repeated calls on the same date return the active normal group
     if one exists, otherwise a no-active hub response.
     """
     with get_db() as conn:
-        return build_today_response(conn)
+        return build_today_response(conn, user_id=current_user.id)
 
 
 @router.post("/practice/next-normal")
-def next_normal_group():
+def next_normal_group(current_user: User = Depends(require_current_user)):
     """Resume active normal group or explicitly create the first/next normal group."""
     with get_db() as conn:
-        return build_next_normal_group_response(conn)
+        return build_next_normal_group_response(conn, user_id=current_user.id)
 
 
 @router.post("/practice/abandon-current-and-next")
-def abandon_current_and_next_group():
+def abandon_current_and_next_group(current_user: User = Depends(require_current_user)):
     """Abandon active normal group and create the next selected-level group."""
     with get_db() as conn:
-        return build_abandon_current_and_next_response(conn)
+        return build_abandon_current_and_next_response(conn, user_id=current_user.id)
 
 
 @router.post("/review/recent-mistakes")
-def recent_mistake_review():
+def recent_mistake_review(current_user: User = Depends(require_current_user)):
     """Create or resume a review group from recent wrong answers."""
     with get_db() as conn:
-        return build_recent_mistake_review_response(conn)
+        return build_recent_mistake_review_response(conn, user_id=current_user.id)
 
 
 @router.post("/practice/minimal-pairs")
-def minimal_pair_group():
+def minimal_pair_group(current_user: User = Depends(require_current_user)):
     """Create or resume a confusing-sound comparison specialty group."""
     with get_db() as conn:
-        return build_minimal_pair_group_response(conn)
+        return build_minimal_pair_group_response(conn, user_id=current_user.id)
 
 
 @router.post("/practice/target-phoneme")
-async def target_phoneme_group(request: Request):
+async def target_phoneme_group(
+    request: Request,
+    current_user: User = Depends(require_current_user),
+):
     """Create or resume an intentional chosen-sound specialty group."""
     body = await request.json()
     phoneme = body.get("phoneme")
@@ -71,11 +76,18 @@ async def target_phoneme_group(request: Request):
             },
         )
     with get_db() as conn:
-        return build_target_phoneme_group_response(conn, phoneme=phoneme.strip())
+        return build_target_phoneme_group_response(
+            conn,
+            user_id=current_user.id,
+            phoneme=phoneme.strip(),
+        )
 
 
 @router.post("/review/current-group")
-async def current_group_review(request: Request):
+async def current_group_review(
+    request: Request,
+    current_user: User = Depends(require_current_user),
+):
     """Create a review group from wrong answers in one completed/current group."""
     body = await request.json()
     group_id = body.get("group_id") or body.get("source_group_id")
@@ -89,7 +101,9 @@ async def current_group_review(request: Request):
         )
     with get_db() as conn:
         response = build_current_group_review_response(
-            conn, source_group_id=group_id.strip()
+            conn,
+            user_id=current_user.id,
+            source_group_id=group_id.strip(),
         )
     if response.get("error") == "GROUP_NOT_FOUND":
         raise HTTPException(status_code=404, detail=response)
@@ -97,7 +111,10 @@ async def current_group_review(request: Request):
 
 
 @router.post("/practice/focus")
-async def focused_group(request: Request):
+async def focused_group(
+    request: Request,
+    current_user: User = Depends(require_current_user),
+):
     """Select focus phonemes and start or resume focused practice."""
     body = await request.json()
     focus_phonemes = body.get("focus_phonemes")
@@ -119,12 +136,13 @@ async def focused_group(request: Request):
     with get_db() as conn:
         return build_focused_group_response(
             conn,
+            user_id=current_user.id,
             focus_phonemes=[item.strip() for item in focus_phonemes],
         )
 
 
 @router.post("/practice/clear-focus")
-def clear_focus():
+def clear_focus(current_user: User = Depends(require_current_user)):
     """Clear focus phonemes and return normal practice state."""
     with get_db() as conn:
-        return build_clear_focus_response(conn)
+        return build_clear_focus_response(conn, user_id=current_user.id)

--- a/backend/app/routes/progress.py
+++ b/backend/app/routes/progress.py
@@ -1,19 +1,21 @@
 """Progress endpoint — GET /api/progress."""
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 
+from app.auth_dependencies import require_current_user
 from app.db import get_db
+from app.models import User
 from app.services.progress import build_progress_response
 
 router = APIRouter()
 
 
 @router.get("/progress")
-def progress():
+def progress(current_user: User = Depends(require_current_user)):
     """Return a domain summary of learner progress.
 
     Includes today's status, streak, total attempts/sessions, and
     weak/strong phoneme lists derived from phoneme_stats.
     """
     with get_db() as conn:
-        return build_progress_response(conn)
+        return build_progress_response(conn, user_id=current_user.id)

--- a/backend/app/routes/settings.py
+++ b/backend/app/routes/settings.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Request
 
+from app.auth_dependencies import require_current_user
 from app.db import get_db
-from app.models import Settings
+from app.models import Settings, User
 from app.services.db_store import get_settings, upsert_settings
 
 router = APIRouter()
@@ -20,10 +21,10 @@ _VALID_UI_LANGUAGES = {"zh-CN", "en-US"}
 
 
 @router.get("/settings")
-def settings_get():
+def settings_get(current_user: User = Depends(require_current_user)):
     """Return current settings for the default user."""
     with get_db() as conn:
-        s = get_settings(conn, "default")
+        s = get_settings(conn, current_user.id)
         if s is None:
             # Return defaults if never initialised
             return {
@@ -51,7 +52,10 @@ def settings_get():
 
 
 @router.put("/settings")
-async def settings_put(request: Request):
+async def settings_put(
+    request: Request,
+    current_user: User = Depends(require_current_user),
+):
     """Update settings for the default user.
 
     Accepts a partial update — only provided fields are changed.
@@ -59,9 +63,9 @@ async def settings_put(request: Request):
     body = await request.json()
 
     with get_db() as conn:
-        existing = get_settings(conn, "default")
+        existing = get_settings(conn, current_user.id)
         if existing is None:
-            existing = Settings(user_id="default")
+            existing = Settings(user_id=current_user.id)
 
         # Validate and apply each field
         errors = []

--- a/backend/app/services/sessions.py
+++ b/backend/app/services/sessions.py
@@ -411,7 +411,7 @@ def build_current_group_review_response(
         }
 
     source_session = get_session_by_id(conn, source_group_id)
-    if source_session is None:
+    if source_session is None or source_session.user_id != user_id:
         return {
             "error": "GROUP_NOT_FOUND",
             "detail": f"No practice group found for {source_group_id}.",

--- a/backend/tests/auth_helpers.py
+++ b/backend/tests/auth_helpers.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app.db import get_connection
+from app.models import User
+from app.services.auth import hash_password
+from app.services.db_store import create_user, get_user_by_id
+
+OWNER_USERNAME = "owner"
+OWNER_PASSWORD = "correct horse battery staple"
+
+
+def bootstrap_owner_user(db_path: str) -> None:
+    conn = get_connection(db_path)
+    try:
+        if get_user_by_id(conn, "default") is None:
+            create_user(
+                conn,
+                User(
+                    id="default",
+                    username=OWNER_USERNAME,
+                    password_hash=hash_password(OWNER_PASSWORD),
+                    is_owner=True,
+                    is_active=True,
+                    created_at="2026-07-02T00:00:00+00:00",
+                    updated_at="2026-07-02T00:00:00+00:00",
+                ),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def authenticated_client(client: TestClient) -> TestClient:
+    resp = client.post(
+        "/api/auth/login",
+        json={"username": OWNER_USERNAME, "password": OWNER_PASSWORD},
+    )
+    assert resp.status_code == 200, resp.json()
+    return client

--- a/backend/tests/test_attempts.py
+++ b/backend/tests/test_attempts.py
@@ -18,6 +18,7 @@ from import_words import import_words  # noqa: E402
 from app.db import get_connection  # noqa: E402
 from app.main import app  # noqa: E402
 from app.services.progress import _compute_mastery, update_phoneme_stats  # noqa: E402
+from tests.auth_helpers import authenticated_client, bootstrap_owner_user  # noqa: E402
 
 FIXTURES = Path(__file__).resolve().parent / "fixtures"
 CONTENT_SAMPLE = FIXTURES / "content_sample.json"
@@ -37,13 +38,14 @@ def seeded_db_fixture(tmp_path: Path) -> str:
 
     orig = db_mod.DEFAULT_DB_PATH
     db_mod.DEFAULT_DB_PATH = db_path
+    bootstrap_owner_user(db_path)
     yield db_path
     db_mod.DEFAULT_DB_PATH = orig
 
 
 @pytest.fixture(name="client")
 def client_fixture(seeded_db: str) -> TestClient:
-    return TestClient(app)
+    return authenticated_client(TestClient(app))
 
 
 def _get_first_item(client: TestClient) -> dict:

--- a/backend/tests/test_audio_validation.py
+++ b/backend/tests/test_audio_validation.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import sys
 from pathlib import Path
 
@@ -13,8 +12,9 @@ _SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
 if str(_SCRIPTS) not in sys.path:
     sys.path.insert(0, str(_SCRIPTS))
 
-from validate_content import _check_audio_files, load_words  # noqa: E402
-from app.main import app  # noqa: E402
+from validate_content import _check_audio_files  # noqa: E402
+
+from tests.auth_helpers import authenticated_client, bootstrap_owner_user  # noqa: E402
 
 FIXTURES = Path(__file__).resolve().parent / "fixtures"
 CONTENT_SAMPLE = FIXTURES / "content_sample.json"
@@ -37,6 +37,7 @@ class TestAudioStaticServing:
         monkeypatch.setenv("TINY_IPA_AUDIO_DIR", str(tmp_path / "audio"))
         # Rebuild app with the new audio dir
         import importlib
+
         import app.main as main_mod
         importlib.reload(main_mod)
 
@@ -52,6 +53,7 @@ class TestAudioStaticServing:
         monkeypatch.setenv("TINY_IPA_AUDIO_DIR", str(audio_dir))
 
         import importlib
+
         import app.main as main_mod
         importlib.reload(main_mod)
 
@@ -171,9 +173,14 @@ class TestTodayAudioUrl:
         from import_words import import_words  # noqa: E402
         import_words(
             source_path=CONTENT_SAMPLE,
-            phonemes_path=Path(__file__).resolve().parent.parent.parent / "content" / "phonemes.json",
+            phonemes_path=(
+                Path(__file__).resolve().parent.parent.parent
+                / "content"
+                / "phonemes.json"
+            ),
             db_path=db_path,
         )
+        bootstrap_owner_user(db_path)
         import app.db as db_mod
         self._orig_db = db_mod.DEFAULT_DB_PATH
         db_mod.DEFAULT_DB_PATH = db_path
@@ -183,9 +190,10 @@ class TestTodayAudioUrl:
         audio_dir.mkdir()
         monkeypatch.setenv("TINY_IPA_AUDIO_DIR", str(audio_dir))
         import importlib
+
         import app.main as main_mod
         importlib.reload(main_mod)
-        self.client = TestClient(main_mod.app)
+        self.client = authenticated_client(TestClient(main_mod.app))
 
         yield
         db_mod.DEFAULT_DB_PATH = self._orig_db

--- a/backend/tests/test_progress_api.py
+++ b/backend/tests/test_progress_api.py
@@ -20,6 +20,7 @@ from app.db import get_connection  # noqa: E402
 from app.main import app  # noqa: E402
 from app.services.db_schema import init_db  # noqa: E402
 from app.services.progress import build_progress_response  # noqa: E402
+from tests.auth_helpers import authenticated_client, bootstrap_owner_user  # noqa: E402
 
 FIXTURES = Path(__file__).resolve().parent / "fixtures"
 CONTENT_SAMPLE = FIXTURES / "content_sample.json"
@@ -39,13 +40,14 @@ def seeded_db_fixture(tmp_path: Path) -> str:
     import app.db as db_mod
     orig = db_mod.DEFAULT_DB_PATH
     db_mod.DEFAULT_DB_PATH = db_path
+    bootstrap_owner_user(db_path)
     yield db_path
     db_mod.DEFAULT_DB_PATH = orig
 
 
 @pytest.fixture(name="client")
 def client_fixture(seeded_db: str) -> TestClient:
-    return TestClient(app)
+    return authenticated_client(TestClient(app))
 
 
 # ---------------------------------------------------------------------------
@@ -190,6 +192,8 @@ class TestProgressApi:
         db_mod.DEFAULT_DB_PATH = db_path
         try:
             c = TestClient(app)
+            bootstrap_owner_user(db_path)
+            authenticated_client(c)
             resp = c.get("/api/progress")
             assert resp.status_code == 200
             data = resp.json()

--- a/backend/tests/test_settings_api.py
+++ b/backend/tests/test_settings_api.py
@@ -18,6 +18,7 @@ from app.db import get_connection  # noqa: E402
 from app.main import app  # noqa: E402
 from app.services.db_schema import init_db  # noqa: E402
 from app.services.db_store import get_settings  # noqa: E402
+from tests.auth_helpers import authenticated_client, bootstrap_owner_user  # noqa: E402
 
 FIXTURES = Path(__file__).resolve().parent / "fixtures"
 CONTENT_SAMPLE = FIXTURES / "content_sample.json"
@@ -32,13 +33,14 @@ def seeded_db_fixture(tmp_path: Path) -> str:
     import app.db as db_mod
     orig = db_mod.DEFAULT_DB_PATH
     db_mod.DEFAULT_DB_PATH = db_path
+    bootstrap_owner_user(db_path)
     yield db_path
     db_mod.DEFAULT_DB_PATH = orig
 
 
 @pytest.fixture(name="client")
 def client_fixture(seeded_db: str) -> TestClient:
-    return TestClient(app)
+    return authenticated_client(TestClient(app))
 
 
 class TestSettingsApi:
@@ -148,6 +150,8 @@ class TestSettingsApi:
         db_mod.DEFAULT_DB_PATH = db_path
         try:
             c = TestClient(app)
+            bootstrap_owner_user(db_path)
+            authenticated_client(c)
             resp = c.get("/api/settings")
             assert resp.status_code == 200
             assert resp.json()["daily_word_count"] == 10

--- a/backend/tests/test_today_persistence.py
+++ b/backend/tests/test_today_persistence.py
@@ -28,6 +28,7 @@ from app.services.db_store import (  # noqa: E402
     get_session_items,
     get_word_by_id,
 )
+from tests.auth_helpers import authenticated_client, bootstrap_owner_user  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Paths
@@ -59,13 +60,14 @@ def seeded_db_fixture(tmp_path: Path) -> str:
 
     orig = db_mod.DEFAULT_DB_PATH
     db_mod.DEFAULT_DB_PATH = db_path
+    bootstrap_owner_user(db_path)
     yield db_path
     db_mod.DEFAULT_DB_PATH = orig
 
 
 @pytest.fixture(name="client")
 def client_fixture(seeded_db: str) -> TestClient:
-    return TestClient(app)
+    return authenticated_client(TestClient(app))
 
 
 @pytest.fixture(name="seeded_db_core_300")
@@ -83,13 +85,14 @@ def seeded_db_core_300_fixture(tmp_path: Path) -> str:
 
     orig = db_mod.DEFAULT_DB_PATH
     db_mod.DEFAULT_DB_PATH = db_path
+    bootstrap_owner_user(db_path)
     yield db_path
     db_mod.DEFAULT_DB_PATH = orig
 
 
 @pytest.fixture(name="core_300_client")
 def core_300_client_fixture(seeded_db_core_300: str) -> TestClient:
-    return TestClient(app)
+    return authenticated_client(TestClient(app))
 
 
 @pytest.fixture(name="seeded_db_entry_mid")
@@ -113,13 +116,14 @@ def seeded_db_entry_mid_fixture(tmp_path: Path) -> str:
 
     orig = db_mod.DEFAULT_DB_PATH
     db_mod.DEFAULT_DB_PATH = db_path
+    bootstrap_owner_user(db_path)
     yield db_path
     db_mod.DEFAULT_DB_PATH = orig
 
 
 @pytest.fixture(name="entry_mid_client")
 def entry_mid_client_fixture(seeded_db_entry_mid: str) -> TestClient:
-    return TestClient(app)
+    return authenticated_client(TestClient(app))
 
 
 # ---------------------------------------------------------------------------
@@ -1122,6 +1126,8 @@ class TestTodayPersistence:
         db_mod.DEFAULT_DB_PATH = db_path
         try:
             c = TestClient(app)
+            bootstrap_owner_user(db_path)
+            authenticated_client(c)
             resp = c.get("/api/today")
             assert resp.status_code == 200
             data = resp.json()

--- a/backend/tests/test_user_data_isolation.py
+++ b/backend/tests/test_user_data_isolation.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+_SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+from import_words import import_words  # noqa: E402
+
+from app.db import get_connection  # noqa: E402
+from app.main import app  # noqa: E402
+from app.models import Settings, User  # noqa: E402
+from app.services.auth import hash_password  # noqa: E402
+from app.services.db_store import create_user, get_settings, upsert_settings  # noqa: E402
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures"
+CONTENT_SAMPLE = FIXTURES / "content_sample.json"
+PHONEMES_PATH = Path(__file__).resolve().parent.parent.parent / "content" / "phonemes.json"
+
+ALICE_PASSWORD = "correct horse battery staple"
+BOB_PASSWORD = "another correct horse battery staple"
+
+
+@pytest.fixture(name="isolated_db")
+def isolated_db_fixture(tmp_path: Path) -> str:
+    db_path = str(tmp_path / "isolation.sqlite")
+    import_words(source_path=CONTENT_SAMPLE, phonemes_path=PHONEMES_PATH, db_path=db_path)
+    conn = get_connection(db_path)
+    _create_user(conn, "alice", "alice", ALICE_PASSWORD)
+    _create_user(conn, "bob", "bob", BOB_PASSWORD)
+    conn.commit()
+    conn.close()
+
+    import app.db as db_mod
+
+    orig = db_mod.DEFAULT_DB_PATH
+    db_mod.DEFAULT_DB_PATH = db_path
+    yield db_path
+    db_mod.DEFAULT_DB_PATH = orig
+
+
+def _create_user(conn, user_id: str, username: str, password: str) -> None:
+    create_user(
+        conn,
+        User(
+            id=user_id,
+            username=username,
+            password_hash=hash_password(password),
+            is_owner=False,
+            is_active=True,
+            created_at="2026-07-02T00:00:00+00:00",
+            updated_at="2026-07-02T00:00:00+00:00",
+        ),
+    )
+    upsert_settings(conn, Settings(user_id=user_id, daily_word_count=1))
+
+
+def _login(username: str, password: str) -> TestClient:
+    client = TestClient(app)
+    resp = client.post(
+        "/api/auth/login",
+        json={"username": username, "password": password},
+    )
+    assert resp.status_code == 200, resp.json()
+    return client
+
+
+def test_settings_are_scoped_to_current_user(isolated_db: str):
+    alice = _login("alice", ALICE_PASSWORD)
+    bob = _login("bob", BOB_PASSWORD)
+
+    alice.put("/api/settings", json={"daily_word_count": 2, "learner_level": "mid"})
+    bob_settings = bob.get("/api/settings").json()
+
+    assert bob_settings["daily_word_count"] == 1
+    assert bob_settings["learner_level"] == "entry"
+
+    conn = get_connection(isolated_db)
+    try:
+        assert get_settings(conn, "alice").daily_word_count == 2
+        assert get_settings(conn, "bob").daily_word_count == 1
+    finally:
+        conn.close()
+
+
+def test_today_and_progress_are_scoped_to_current_user(isolated_db: str):
+    alice = _login("alice", ALICE_PASSWORD)
+    bob = _login("bob", BOB_PASSWORD)
+
+    alice_group = alice.post("/api/practice/next-normal").json()
+    bob_progress = bob.get("/api/progress").json()
+    bob_today = bob.get("/api/today").json()
+
+    assert alice_group["status"] == "in_progress"
+    assert bob_progress["total_sessions"] == 0
+    assert bob_progress["resumable_normal_groups"] == 0
+    assert bob_today["status"] == "idle"
+
+
+def test_attempt_rejects_other_users_session_item(isolated_db: str):
+    alice = _login("alice", ALICE_PASSWORD)
+    bob = _login("bob", BOB_PASSWORD)
+
+    alice_group = alice.post("/api/practice/next-normal").json()
+    item = alice_group["items"][0]
+    resp = bob.post(
+        "/api/attempt",
+        json={
+            "session_item_id": item["session_item_id"],
+            "selected_answer": item["display_ipa"],
+        },
+    )
+
+    assert resp.status_code == 404
+    assert resp.json()["detail"]["error"] == "ITEM_NOT_FOUND"
+
+
+def test_current_group_review_rejects_other_users_source_group(isolated_db: str):
+    alice = _login("alice", ALICE_PASSWORD)
+    bob = _login("bob", BOB_PASSWORD)
+
+    alice_group = alice.post("/api/practice/next-normal").json()
+    resp = bob.post(
+        "/api/review/current-group",
+        json={"group_id": alice_group["group_id"]},
+    )
+
+    assert resp.status_code == 404
+    assert resp.json()["detail"]["error"] == "GROUP_NOT_FOUND"


### PR DESCRIPTION
## Scope

Implements #241 only: backend endpoint-wide authenticated user data isolation for learner runtime paths.

Completed:
- Protected settings, today, normal practice, review, focus, specialty, attempt, and progress endpoints with the #240 `require_current_user` dependency.
- Passed `current_user.id` into existing service-level user-scoped paths instead of falling back to anonymous/default route behavior.
- Added attempt ownership guard so one user cannot submit attempts for another user's session item.
- Added current-group review ownership guard so one user cannot review another user's source group.
- Kept words, phonemes, and audio as shared global content.
- Updated existing route tests to authenticate through test-only helper users.
- Added two-user regression tests for settings isolation, Today/Progress isolation, cross-user attempt denial, and cross-user current-group review denial.

Out of scope preserved:
- No #242 default-user owner-claim dry-run or migration/apply mode.
- No #243 frontend login/logout/current-user UX.
- No #244 readiness review.
- No final `main` merge, #210 closure, deployment/runtime config mutation, data migration, or real/private DB mutation.

## Verification

- `uv run --project backend --extra dev pytest backend/tests/test_settings_api.py backend/tests/test_attempts.py backend/tests/test_progress_api.py backend/tests/test_today_persistence.py backend/tests/test_user_data_isolation.py` -> 107 passed, 1 existing Starlette/httpx deprecation warning.
- `uv run --project backend --extra dev pytest` -> 293 passed, 1 existing Starlette/httpx deprecation warning.
- `uv run --project backend --extra dev ruff check backend/app/routes/settings.py backend/app/routes/progress.py backend/app/routes/practice.py backend/app/routes/attempts.py backend/app/services/sessions.py backend/tests/auth_helpers.py backend/tests/test_audio_validation.py backend/tests/test_settings_api.py backend/tests/test_attempts.py backend/tests/test_progress_api.py backend/tests/test_today_persistence.py backend/tests/test_user_data_isolation.py` -> passed.
- `git diff --check` -> passed.
- `tools/agents/agent-audit` -> clean.

## Residual Risks

- Test helper creates an authenticated `default` test user so existing fixture rows remain current-user-owned without performing a real owner-claim migration; #242 still owns real/private default-data dry-run guidance.
- Frontend auth UX remains #243.
- Full deployed Origin/CSRF/CORS readiness remains #244/#27 evidence work.