### PR TITLE
[#242] Add default owner-claim dry-run report

### DIFF
--- a/backend/scripts/default_owner_claim.py
+++ b/backend/scripts/default_owner_claim.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""Dry-run report for future default-user owner claim."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+from pathlib import Path
+from typing import Any, Optional
+from urllib.parse import quote
+
+_HERE = Path(__file__).resolve().parent
+_BACKEND = _HERE.parent
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+from app.db import DEFAULT_DB_PATH  # noqa: E402
+
+DEFAULT_USER_ID = "default"
+
+
+def _db_path(raw: str) -> str:
+    if raw.startswith("sqlite:///"):
+        return raw[len("sqlite:///"):]
+    return raw
+
+
+def _read_only_connection(db_path: str) -> sqlite3.Connection:
+    path = Path(db_path).expanduser().resolve()
+    uri = f"file:{quote(str(path), safe='/:')}?mode=ro"
+    conn = sqlite3.connect(uri, uri=True)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA query_only=ON")
+    return conn
+
+
+def _has_table(conn: sqlite3.Connection, table: str) -> bool:
+    row = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+        (table,),
+    ).fetchone()
+    return row is not None
+
+
+def _count(
+    conn: sqlite3.Connection,
+    table: str,
+    where: str = "",
+    params: tuple[Any, ...] = (),
+) -> int:
+    if not _has_table(conn, table):
+        return 0
+    sql = f"SELECT COUNT(*) AS cnt FROM {table}"
+    if where:
+        sql += f" WHERE {where}"
+    row = conn.execute(sql, params).fetchone()
+    return int(row["cnt"]) if row else 0
+
+
+def _group_count(
+    conn: sqlite3.Connection,
+    sql: str,
+    params: tuple[Any, ...] = (),
+) -> dict[str, int]:
+    return {
+        str(row["key"]): int(row["cnt"])
+        for row in conn.execute(sql, params).fetchall()
+    }
+
+
+def build_default_owner_claim_report(
+    conn: sqlite3.Connection,
+    *,
+    db_path: str,
+    default_user_id: str = DEFAULT_USER_ID,
+) -> dict[str, Any]:
+    daily_sessions_by_status: dict[str, int] = {}
+    daily_sessions_by_group_type: dict[str, int] = {}
+    session_items_by_session_status: dict[str, int] = {}
+    session_items_by_group_type: dict[str, int] = {}
+
+    if _has_table(conn, "daily_sessions"):
+        daily_sessions_by_status = _group_count(
+            conn,
+            """
+            SELECT status AS key, COUNT(*) AS cnt
+            FROM daily_sessions
+            WHERE user_id = ?
+            GROUP BY status
+            ORDER BY status
+            """,
+            (default_user_id,),
+        )
+        daily_sessions_by_group_type = _group_count(
+            conn,
+            """
+            SELECT group_type AS key, COUNT(*) AS cnt
+            FROM daily_sessions
+            WHERE user_id = ?
+            GROUP BY group_type
+            ORDER BY group_type
+            """,
+            (default_user_id,),
+        )
+
+    if _has_table(conn, "session_items") and _has_table(conn, "daily_sessions"):
+        session_items_by_session_status = _group_count(
+            conn,
+            """
+            SELECT daily_sessions.status AS key, COUNT(session_items.id) AS cnt
+            FROM session_items
+            JOIN daily_sessions ON daily_sessions.id = session_items.session_id
+            WHERE daily_sessions.user_id = ?
+            GROUP BY daily_sessions.status
+            ORDER BY daily_sessions.status
+            """,
+            (default_user_id,),
+        )
+        session_items_by_group_type = _group_count(
+            conn,
+            """
+            SELECT daily_sessions.group_type AS key, COUNT(session_items.id) AS cnt
+            FROM session_items
+            JOIN daily_sessions ON daily_sessions.id = session_items.session_id
+            WHERE daily_sessions.user_id = ?
+            GROUP BY daily_sessions.group_type
+            ORDER BY daily_sessions.group_type
+            """,
+            (default_user_id,),
+        )
+
+    attempts_on_default_session_items = (
+        _count(
+            conn,
+            "attempts",
+            """
+            session_item_id IN (
+                SELECT session_items.id
+                FROM session_items
+                JOIN daily_sessions ON daily_sessions.id = session_items.session_id
+                WHERE daily_sessions.user_id = ?
+            )
+            """,
+            (default_user_id,),
+        )
+        if _has_table(conn, "attempts")
+        and _has_table(conn, "session_items")
+        and _has_table(conn, "daily_sessions")
+        else 0
+    )
+
+    return {
+        "dry_run": True,
+        "mutation_authorized": False,
+        "apply_mode_available": False,
+        "db_path": db_path,
+        "default_user_id": default_user_id,
+        "row_counts": {
+            "users_default": _count(conn, "users", "id = ?", (default_user_id,)),
+            "settings_default": _count(conn, "settings", "user_id = ?", (default_user_id,)),
+            "daily_sessions_default": _count(
+                conn,
+                "daily_sessions",
+                "user_id = ?",
+                (default_user_id,),
+            ),
+            "session_items_owned_by_default_sessions": sum(
+                session_items_by_session_status.values(),
+            ),
+            "attempts_default_user": _count(conn, "attempts", "user_id = ?", (default_user_id,)),
+            "attempts_on_default_session_items": attempts_on_default_session_items,
+            "phoneme_stats_default": _count(
+                conn,
+                "phoneme_stats",
+                "user_id = ?",
+                (default_user_id,),
+            ),
+            "auth_sessions_default": _count(
+                conn,
+                "auth_sessions",
+                "user_id = ?",
+                (default_user_id,),
+            ),
+        },
+        "breakdown": {
+            "daily_sessions_by_status": daily_sessions_by_status,
+            "daily_sessions_by_group_type": daily_sessions_by_group_type,
+            "session_items_by_session_status": session_items_by_session_status,
+            "session_items_by_group_type": session_items_by_group_type,
+        },
+        "backup_guidance": [
+            "Stop the Tiny IPA backend before any future real owner-claim apply operation.",
+            (
+                "Copy the SQLite database file and any sibling -wal and -shm files "
+                "to a timestamped backup path."
+            ),
+            (
+                "Run this dry-run report against the backup and the source database; "
+                "compare row counts before applying any future migration."
+            ),
+            (
+                "Keep the backup until login, settings, Today, Progress, attempts, "
+                "and review/focus flows are verified for the claimed owner."
+            ),
+        ],
+        "owner_claim_strategy": {
+            "temp_db_safe_sequence": [
+                "Create or choose the target owner user in a temp database.",
+                "Verify the dry-run row counts for default-owned runtime data.",
+                (
+                    "In a future Human-gated apply mode only, update default runtime "
+                    "owner fields to the target user id in one transaction."
+                ),
+                "Re-run auth/isolation and real-backend walkthroughs against the temp database.",
+            ],
+            "future_real_apply_requires_human_decision_contract": True,
+            "no_real_db_mutation_in_this_tool": True,
+        },
+    }
+
+
+def default_owner_claim(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Report default-user runtime rows for future owner-claim planning.",
+    )
+    parser.add_argument(
+        "--db-url",
+        default=DEFAULT_DB_PATH,
+        help="SQLite database path or sqlite:/// URI.",
+    )
+    parser.add_argument(
+        "--default-user-id",
+        default=DEFAULT_USER_ID,
+        help="Legacy user id to inspect; defaults to 'default'.",
+    )
+    args = parser.parse_args(argv)
+
+    db_path = _db_path(args.db_url)
+    with _read_only_connection(db_path) as conn:
+        report = build_default_owner_claim_report(
+            conn,
+            db_path=db_path,
+            default_user_id=args.default_user_id,
+        )
+    print(json.dumps(report, indent=2, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(default_owner_claim())

--- a/backend/tests/test_default_owner_claim.py
+++ b/backend/tests/test_default_owner_claim.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from app.db import get_connection
+from app.services.db_schema import init_db
+from scripts.default_owner_claim import build_default_owner_claim_report
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "default_owner_claim.py"
+
+
+def _seed_default_runtime_db(db_path: Path) -> None:
+    conn = get_connection(str(db_path))
+    try:
+        init_db(conn)
+        conn.execute(
+            """
+            INSERT INTO words (
+                id, word, level, ipa_us, phoneme_tags_us, content_status
+            ) VALUES ('ship', 'ship', 'entry', '/ʃɪp/', '["/ʃ/"]', 'safe')
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO users (
+                id, username, password_hash, is_owner, is_active, created_at, updated_at
+            ) VALUES (
+                'default', 'owner', 'hash', 1, 1,
+                '2026-07-02T00:00:00Z', '2026-07-02T00:00:00Z'
+            )
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO settings (
+                user_id, primary_accent, daily_word_count, show_translation,
+                show_accent_compare, practice_mode, review_strength, learner_level,
+                ui_language, focus_phonemes, updated_at
+            ) VALUES (
+                'default', 'US', 2, 1, 0, 'ipa_first', 'normal', 'entry',
+                'zh-CN', '[]', '2026-07-02T00:00:00Z'
+            )
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO daily_sessions (
+                id, user_id, session_date, primary_accent, status, created_at,
+                completed_at, group_index, group_type, learner_level,
+                source_session_item_ids, focus_phonemes
+            ) VALUES (
+                'session-default-1', 'default', '2026-07-02', 'US', 'in_progress',
+                '2026-07-02T00:00:00Z', NULL, 1, 'normal', 'entry', '[]', '[]'
+            )
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO daily_sessions (
+                id, user_id, session_date, primary_accent, status, created_at,
+                completed_at, group_index, group_type, learner_level,
+                source_session_item_ids, focus_phonemes
+            ) VALUES (
+                'session-default-2', 'default', '2026-07-01', 'US', 'completed',
+                '2026-07-01T00:00:00Z', '2026-07-01T00:10:00Z', 2,
+                'mistake_review', 'entry', '[]', '[]'
+            )
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO session_items (
+                id, session_id, word_id, order_index, target_phonemes,
+                question_type, status
+            ) VALUES (
+                'item-default-1', 'session-default-1', 'ship', 0, '["/ʃ/"]',
+                'ipa_choice', 'pending'
+            )
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO session_items (
+                id, session_id, word_id, order_index, target_phonemes,
+                question_type, status
+            ) VALUES (
+                'item-default-2', 'session-default-2', 'ship', 0, '["/ʃ/"]',
+                'ipa_choice', 'completed'
+            )
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO attempts (
+                id, user_id, session_item_id, word_id, primary_accent,
+                question_type, target_phoneme, selected_answer, correct_answer,
+                is_correct, created_at
+            ) VALUES (
+                'attempt-default-1', 'default', 'item-default-2', 'ship', 'US',
+                'ipa_choice', '/ʃ/', '/sɪp/', '/ʃɪp/', 0,
+                '2026-07-01T00:05:00Z'
+            )
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO phoneme_stats (
+                user_id, primary_accent, phoneme_id, attempt_count, correct_count,
+                last_attempt_at, last_wrong_at, mastery_status
+            ) VALUES (
+                'default', 'US', '/ʃ/', 3, 1,
+                '2026-07-01T00:05:00Z', '2026-07-01T00:05:00Z', 'weak'
+            )
+            """
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _row_counts(db_path: Path) -> dict[str, int]:
+    conn = get_connection(str(db_path))
+    try:
+        return {
+            table: conn.execute(f"SELECT COUNT(*) AS cnt FROM {table}").fetchone()["cnt"]
+            for table in [
+                "users",
+                "settings",
+                "daily_sessions",
+                "session_items",
+                "attempts",
+                "phoneme_stats",
+            ]
+        }
+    finally:
+        conn.close()
+
+
+def test_default_owner_claim_report_counts_default_runtime_rows(tmp_path: Path):
+    db_path = tmp_path / "tiny_ipa.sqlite"
+    _seed_default_runtime_db(db_path)
+
+    conn = get_connection(str(db_path))
+    try:
+        report = build_default_owner_claim_report(conn, db_path=str(db_path))
+    finally:
+        conn.close()
+
+    assert report["dry_run"] is True
+    assert report["mutation_authorized"] is False
+    assert report["apply_mode_available"] is False
+    assert report["row_counts"] == {
+        "users_default": 1,
+        "settings_default": 1,
+        "daily_sessions_default": 2,
+        "session_items_owned_by_default_sessions": 2,
+        "attempts_default_user": 1,
+        "attempts_on_default_session_items": 1,
+        "phoneme_stats_default": 1,
+        "auth_sessions_default": 0,
+    }
+    assert report["breakdown"]["daily_sessions_by_status"] == {
+        "completed": 1,
+        "in_progress": 1,
+    }
+    assert report["breakdown"]["session_items_by_group_type"] == {
+        "mistake_review": 1,
+        "normal": 1,
+    }
+    assert (
+        report["owner_claim_strategy"]["future_real_apply_requires_human_decision_contract"]
+        is True
+    )
+    assert report["owner_claim_strategy"]["no_real_db_mutation_in_this_tool"] is True
+
+
+def test_default_owner_claim_cli_is_read_only_and_outputs_json(tmp_path: Path):
+    db_path = tmp_path / "tiny_ipa.sqlite"
+    _seed_default_runtime_db(db_path)
+    before = _row_counts(db_path)
+
+    completed = subprocess.run(
+        [sys.executable, str(SCRIPT), "--db-url", str(db_path)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    report = json.loads(completed.stdout)
+    assert report["row_counts"]["daily_sessions_default"] == 2
+    assert report["backup_guidance"]
+    assert _row_counts(db_path) == before
+
+
+def test_default_owner_claim_cli_does_not_create_missing_database(tmp_path: Path):
+    db_path = tmp_path / "missing.sqlite"
+
+    completed = subprocess.run(
+        [sys.executable, str(SCRIPT), "--db-url", str(db_path)],
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode != 0
+    assert not db_path.exists()

--- a/docs/05-data-api-contracts.md
+++ b/docs/05-data-api-contracts.md
@@ -1042,6 +1042,57 @@ cd frontend && pnpm test:e2e:m8
 ```
 ```
 
+## M12 default-owner claim dry-run
+
+Existing local data may still be owned by the legacy `default` user id. Before
+any real/private SQLite data is claimed by an authenticated owner, the project
+must produce a dry-run report and preserve a restorable backup.
+
+Dry-run command:
+
+```text
+cd backend
+python scripts/default_owner_claim.py --db-url path/to/tiny_ipa.sqlite
+```
+
+Report contract:
+
+```text
+dry_run = true
+mutation_authorized = false
+apply_mode_available = false
+
+row_counts includes:
+  users_default
+  settings_default
+  daily_sessions_default
+  session_items_owned_by_default_sessions
+  attempts_default_user
+  attempts_on_default_session_items
+  phoneme_stats_default
+  auth_sessions_default
+
+breakdown includes:
+  daily_sessions_by_status
+  daily_sessions_by_group_type
+  session_items_by_session_status
+  session_items_by_group_type
+```
+
+Backup guidance before any future real apply mode:
+
+```text
+Stop the backend.
+Copy the SQLite database file and sibling -wal / -shm files to a timestamped
+backup path.
+Run the dry-run report against both backup and source database.
+Do not mutate real/private data until a separate Human Decision Contract
+authorizes the exact apply operation and rollback evidence.
+```
+
+The #242 artifact intentionally has no apply mode. Temp DB tests may describe
+the owner-claim sequence, but real/private mutation remains Human-gated.
+
 ## 服务端领域规则
 
 后端负责：


### PR DESCRIPTION
## Summary

Implements #242 default-user owner-claim dry-run and backup guidance.

Scope:
- Adds read-only `backend/scripts/default_owner_claim.py` dry-run report for legacy `default` runtime rows.
- Reports row counts for users/settings, daily_sessions, session_items by default-owned sessions, attempts, phoneme_stats, auth_sessions, plus status/group-type breakdowns.
- Documents backup guidance and future owner-claim strategy in `docs/05-data-api-contracts.md`.
- Adds temp-DB tests proving report counts, CLI JSON output, read-only behavior, and missing DB non-creation.

Boundaries:
- No apply mode.
- No real/private DB mutation.
- No owner-claim migration against local user data.
- No account/admin UX, deployment backup implementation, `main` merge, or #210 closure.

## Verification

- `uv run --project backend --extra dev pytest backend/tests/test_default_owner_claim.py` -> 3 passed
- `uv run --project backend --extra dev ruff check backend/scripts/default_owner_claim.py backend/tests/test_default_owner_claim.py` -> passed
- `uv run --project backend --extra dev pytest` -> 296 passed, 1 existing Starlette/httpx warning
- `git diff --check origin/epic/m12-minimal-auth-data-isolation...HEAD` -> passed
- `tools/agents/agent-audit` -> clean
