### PR TITLE
[#258] Add M13 practice question contract

### DIFF
--- a/backend/tests/test_m13_question_contract.py
+++ b/backend/tests/test_m13_question_contract.py
@@ -1,0 +1,80 @@
+from pathlib import Path
+
+import pytest
+
+
+DOC = Path(__file__).resolve().parents[2] / "docs" / "05-data-api-contracts.md"
+
+
+def _contract_text() -> str:
+    return DOC.read_text(encoding="utf-8")
+
+
+def _normalized_contract_text() -> str:
+    return " ".join(_contract_text().split())
+
+
+@pytest.mark.parametrize(
+    "phrase",
+    [
+        "M13 practice question contract",
+        "`choose_ipa` remains the compatibility baseline",
+        "`choose_word` is the first reverse-recognition expansion",
+        "`type_word` is deferred",
+        "`phoneme_stats` continuity is preserved",
+        "not from the frontend-visible answer string",
+        "server-side canonical answer for feedback",
+        "Unsupported `question_type` values fail closed",
+    ],
+)
+def test_m13_question_contract_covers_core_boundaries(phrase: str) -> None:
+    assert phrase in _normalized_contract_text()
+
+
+@pytest.mark.parametrize(
+    "question_type",
+    ["choose_ipa", "choose_word", "type_word"],
+)
+def test_m13_question_taxonomy_lists_supported_and_deferred_modes(
+    question_type: str,
+) -> None:
+    assert question_type in _normalized_contract_text()
+
+
+@pytest.mark.parametrize(
+    "policy_phrase",
+    [
+        "exact same active-accent IPA",
+        "`new` / `knew`",
+        "`sun` / `son`",
+        "`see` / `sea`",
+        "accepted_answers source",
+        "normalization rules",
+        "spelling variant policy",
+        "must not be exposed as a learner-selectable runtime mode",
+    ],
+)
+def test_m13_type_word_homophone_policy_is_explicit(policy_phrase: str) -> None:
+    assert policy_phrase in _normalized_contract_text()
+
+
+@pytest.mark.parametrize(
+    "behavior",
+    [
+        "mistake_review -> stays choose_ipa",
+        "weak_focus -> stays choose_ipa",
+        "minimal/sound compare -> unchanged specialty behavior",
+    ],
+)
+def test_m13_review_focus_first_slice_behavior_is_conservative(
+    behavior: str,
+) -> None:
+    assert behavior in _normalized_contract_text()
+
+
+@pytest.mark.parametrize(
+    "issue",
+    ["#261", "#260", "#259", "#262", "#264", "#263"],
+)
+def test_m13_child_issue_test_matrix_is_present(issue: str) -> None:
+    assert issue in _normalized_contract_text()

--- a/docs/05-data-api-contracts.md
+++ b/docs/05-data-api-contracts.md
@@ -669,6 +669,188 @@ Active group response 返回领域摘要，不返回原始调度内部状态：
 
 推荐服务端判题，不在生产响应中返回 `answer`。
 
+## M13 practice question contract
+
+M13 expands practice question modes without changing the authoritative
+session/attempt/statistics path. `choose_ipa` remains the compatibility
+baseline. `choose_word` is the first reverse-recognition expansion. `type_word`
+is deferred until accepted-answer and same-IPA ambiguity semantics are accepted.
+
+The backend is authoritative for question generation and grading. The frontend
+renders the discriminated `question` payload, submits `selected_answer` to
+`POST /api/attempt`, and never decides correctness from local prompt text.
+`phoneme_stats` continuity is preserved across supported modes: attempts update
+stats from the session item's persisted `target_phonemes`, not from the
+frontend-visible answer string.
+
+### Question mode taxonomy
+
+| `question.type` | Prompt surface | Choice/input surface | Correct-answer representation | Launch status |
+| --- | --- | --- | --- | --- |
+| `choose_ipa` | Show `word`, optional `meaning_zh`, audio, and target copy. | Multiple IPA choices. | IPA string for the active accent, e.g. `word.ipa_us` for US sessions. | Existing compatibility baseline. |
+| `choose_word` | Show IPA for the active accent plus question-specific prompt copy. | Multiple word choices. | Canonical `word.word` string for the target row. | First M13 implementation slice after this contract is accepted. |
+| `type_word` | Show IPA for the active accent plus typed-answer instructions. | Text input. | Accepted-answer set, not a single frontend string. | Deferred; not production-visible until same-IPA/homophone policy is implemented. |
+
+`choose_ipa` payload remains backward-compatible:
+
+```json
+{
+  "type": "choose_ipa",
+  "prompt": "Which IPA matches this word?",
+  "choices": ["/ʃɪp/", "/ʃiːp/", "/sɪp/"]
+}
+```
+
+`choose_word` uses the same multiple-choice renderer boundary but reverses the
+prompt and answers:
+
+```json
+{
+  "type": "choose_word",
+  "prompt": "Which word matches this IPA?",
+  "display_ipa": "/ʃɪp/",
+  "choices": ["ship", "sheep", "sip", "chip"]
+}
+```
+
+For `choose_word`, choices are learner-facing word strings, but grading still
+looks up the persisted `session_item_id`, `question_type`, word row, and active
+accent server-side. The client-submitted `selected_answer` is an answer token,
+not proof of correctness.
+
+`type_word` must not share the `choose_word` grading path until it has an
+accepted-answer contract:
+
+```json
+{
+  "type": "type_word",
+  "prompt": "Type the word that matches this IPA.",
+  "display_ipa": "/ˈnju/",
+  "input": {"kind": "text", "autocapitalize": "none"}
+}
+```
+
+### `/api/attempt` grading boundary
+
+`POST /api/attempt` remains the only production grading endpoint for practice
+answers. The request shape stays stable:
+
+```json
+{
+  "session_item_id": "item_001",
+  "selected_answer": "ship"
+}
+```
+
+Server grading dispatches by persisted `session_items.question_type`:
+
+```text
+choose_ipa   -> compare selected IPA token with active-accent IPA
+choose_word  -> compare selected word token with target word row
+type_word    -> deferred; compare normalized input against accepted answers
+```
+
+The response continues to return `is_correct`, `correct_answer`, and
+`updated_phonemes`. `correct_answer` is the server-side canonical answer for
+feedback, not a value trusted from the client. Unsupported `question_type`
+values fail closed with `INVALID_ATTEMPT` or an equivalent stable structured
+attempt error; they must not silently grade as `choose_ipa`.
+
+### Same-IPA and homophone policy
+
+`choose_word` distractors should avoid exact same active-accent IPA unless the
+question explicitly supports multiple correct answers. This keeps a learner
+from seeing two visually different words that are both correct for the same
+displayed IPA.
+
+`type_word` is deferred because same-IPA and homophone answers require fairness
+rules before production release. Examples include `new` / `knew`, `sun` /
+`son`, and `see` / `sea`. A future `type_word` contract must define:
+
+```text
+accepted_answers source
+normalization rules
+spelling variant policy
+same-IPA exclusion or multi-answer policy
+feedback copy for alternate accepted answers
+```
+
+Until then, `type_word` may appear only in docs/test fixtures that assert it is
+deferred or fail-closed; it must not be exposed as a learner-selectable runtime
+mode.
+
+### Review and focus behavior for the first M13 slice
+
+The first implementation slice should keep review/focus behavior conservative:
+
+```text
+normal groups      -> may use selected supported question mode once implemented
+mistake_review     -> stays choose_ipa until choose_word review semantics are accepted
+weak_focus         -> stays choose_ipa until choose_word focus semantics are accepted
+minimal/sound compare -> unchanged specialty behavior
+```
+
+This avoids mixing reverse-recognition distractor quality questions into
+current-group review, recent-mistake review, and weak-focus recovery before
+normal `choose_word` has backend/frontend evidence. If a later child issue wants
+review/focus to inherit the selected question mode, it must update this contract
+and provide route-mocked plus real-backend walkthrough evidence.
+
+### API and frontend renderer boundary
+
+The API shape is a discriminated question payload keyed by `question.type`.
+Shared item fields remain outside the question object:
+
+```text
+TodayItem.word
+TodayItem.display_ipa
+TodayItem.meaning_zh
+TodayItem.audio_url
+TodayItem.target_phonemes
+TodayItem.question
+```
+
+Frontend rendering should branch on `question.type`, not infer mode from prompt
+strings. `choose_ipa` and `choose_word` may share a generic multiple-choice
+renderer only if labels, accessible names, feedback copy, and selected-answer
+tokens stay mode-aware. `type_word` requires a separate text-input renderer and
+must stay hidden until accepted-answer semantics are complete.
+
+Question-specific localization must use dedicated prompt/feedback keys, for
+example:
+
+```text
+practice.question.prompt.choose_ipa
+practice.question.prompt.choose_word
+practice.question.prompt.type_word
+practice.feedback.correct_answer.ipa
+practice.feedback.correct_answer.word
+```
+
+Mobile text-fit expectations:
+
+- prompt copy must fit within the practice card without relying on raw enum
+  values;
+- choice buttons may contain IPA or word strings, but labels must not overflow
+  the mobile viewport;
+- feedback must name what the learner selected and what the server accepted in
+  mode-specific terms;
+- unresolved localization placeholders are blocker failures for M13 UI work.
+
+### M13 test matrix
+
+Later M13 child issues should reuse this matrix instead of redefining question
+semantics:
+
+| Issue | Required evidence |
+| --- | --- |
+| #261 backend choose-word generation/grading | Unit/integration tests for `choose_ipa` compatibility, `choose_word` payload generation, `/api/attempt` grading dispatch, fail-closed unknown `question_type`, and `phoneme_stats` updates from `target_phonemes`. |
+| #260 distractor scorer/report | Deterministic scorer tests and quality report evidence that `choose_word` distractors avoid exact same active-accent IPA unless a future multi-answer policy exists. |
+| #259 frontend generic renderer | Component/E2E tests for discriminated rendering, accessible choice labels, localized prompt/feedback copy, mobile text fit, and no `type_word` production exposure. |
+| #262 mode selection workflow | Route-mocked and real-backend walkthroughs for normal `choose_word` entry, active group resume, Settings/Today/Progress copy, review/focus remaining `choose_ipa`, and stats continuity. |
+| #264 type-word accepted-answer contract | Contract-only evidence for accepted answers, normalization, homophones, spelling variants, fail-closed unsupported runtime exposure, and future walkthrough criteria. |
+| #263 readiness review | User-facing summary, residual distractor/type-word risks, route-mocked and real-backend evidence, and final human-gated main integration decision. |
+
 ### Next normal group
 
 ```http


### PR DESCRIPTION
## Summary

- Add the M13 practice question contract to `docs/05-data-api-contracts.md`.
- Define `choose_ipa`, `choose_word`, and deferred `type_word` taxonomy.
- Document `/api/attempt` grading dispatch, `phoneme_stats` continuity, same-IPA/homophone policy, review/focus first-slice behavior, frontend renderer/localization boundaries, and downstream M13 test matrix.
- Add focused contract tests for the M13 question-mode contract.

## Scope boundaries

- Contract/docs/tests only.
- No runtime `choose_word` or `type_word` implementation.
- No scheduler/grading-model rewrite.
- No source content, `meaning_zh`, `minimal_pair_group`, deployment, account/admin, runtime config, DB mutation, or data migration changes.
- PR target is `epic/m13-practice-modes`, not `main`.

## Verification

- `uv run --project backend pytest backend/tests/test_m13_question_contract.py backend/tests/test_m12_auth_contract.py` -> 68 passed.
- `git diff --check` passed.
- `tools/agents/agent-audit` passed clean.

## Handoff

#258 should route to Reviewer for contract compliance review. Architect acceptance is required before merge into `epic/m13-practice-modes`.