### PR TITLE
[#261] Add backend choose-word question support

### DIFF
--- a/backend/app/routes/attempts.py
+++ b/backend/app/routes/attempts.py
@@ -104,7 +104,13 @@ async def attempt(
             )
 
         # Server-side grading.
-        correct_answer = determine_correct_answer(item, word, session.primary_accent)
+        try:
+            correct_answer = determine_correct_answer(item, word, session.primary_accent)
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=400,
+                detail={"error": "INVALID_ATTEMPT", "detail": str(exc)},
+            ) from exc
         is_correct = grade_attempt(selected_answer, correct_answer)
 
         # Persist attempt.

--- a/backend/app/routes/settings.py
+++ b/backend/app/routes/settings.py
@@ -14,7 +14,7 @@ from app.services.db_store import get_settings, upsert_settings
 router = APIRouter()
 
 _VALID_ACCENTS = {"US", "UK"}
-_VALID_MODES = {"ipa_first", "reveal_first"}
+_VALID_MODES = {"ipa_first", "reveal_first", "choose_word"}
 _VALID_STRENGTHS = {"normal", "extra_review", "quick"}
 _VALID_LEARNER_LEVELS = {"entry", "mid"}
 _VALID_UI_LANGUAGES = {"zh-CN", "en-US"}

--- a/backend/app/services/grading.py
+++ b/backend/app/services/grading.py
@@ -1,29 +1,16 @@
-"""Server-side grading for practice attempts.
-
-Compares the user's selected answer against the correct IPA for the
-session item's word and accent. The correct answer is determined from
-the database, not trusted from the client request.
-"""
+"""Server-side grading for practice attempts."""
 
 from __future__ import annotations
-
-import sqlite3
-from typing import Optional
 
 from app.models import SessionItem, Word
 
 
 def determine_correct_answer(item: SessionItem, word: Word, accent: str = "US") -> str:
-    """Return the correct IPA string for a session item.
-
-    Args:
-        item: The session item being answered.
-        word: The corresponding word row.
-        accent: "US" or "UK".
-
-    Returns:
-        The IPA string the user should match, e.g. "/ʃɪp/".
-    """
+    """Return the server-side canonical answer for a session item."""
+    if item.question_type == "choose_word":
+        return word.word
+    if item.question_type != "choose_ipa":
+        raise ValueError(f"Unsupported question_type: {item.question_type}")
     if accent.upper() == "UK" and word.ipa_uk:
         return word.ipa_uk
     return word.ipa_us

--- a/backend/app/services/questions.py
+++ b/backend/app/services/questions.py
@@ -1,11 +1,7 @@
-"""Question generation for practice items.
-
-For each session item, generates a ``choose_ipa`` question with the correct
-IPA and plausible distractors drawn from other words.
-"""
+"""Question generation for practice items."""
 
 import random
-from typing import Dict, List, Optional
+from typing import List, Optional
 
 from app.models import Word
 
@@ -15,36 +11,73 @@ def generate_question(
     accent: str = "US",
     *,
     distractor_pool: Optional[List[str]] = None,
+    question_type: str = "choose_ipa",
     seed: Optional[int] = None,
 ) -> dict:
-    """Build a ``choose_ipa`` question dict for a word.
+    """Build a question dict for a word using the persisted question type."""
+    if question_type == "choose_word":
+        return _generate_choose_word_question(
+            word,
+            accent=accent,
+            distractor_pool=distractor_pool,
+            seed=seed,
+        )
+    if question_type == "choose_ipa":
+        return _generate_choose_ipa_question(
+            word,
+            accent=accent,
+            distractor_pool=distractor_pool,
+            seed=seed,
+        )
+    raise ValueError(f"Unsupported question_type: {question_type}")
 
-    Args:
-        word: The target word (must have ipa_us for accent="US").
-        accent: "US" or "UK" — which IPA to use as the correct answer.
-        distractor_pool: Pre-built pool of IPA strings to draw distractors
-                         from. If omitted, no distractors are generated and
-                         a placeholder is used (caller should supply a pool
-                         for real use).
-        seed: Shuffle seed so the same word gets the same choices on repeat
-              calls.
 
-    Returns:
-        A question dict matching the API contract:
-        ``{"type": "choose_ipa", "prompt": "...", "choices": [...]}``
-    """
-    correct = word.ipa_us if accent.upper() == "US" else (word.ipa_uk or word.ipa_us)
+def _active_ipa(word: Word, accent: str) -> str:
+    return word.ipa_us if accent.upper() == "US" else (word.ipa_uk or word.ipa_us)
 
+
+def _shuffled_choices(
+    correct: str,
+    distractor_pool: Optional[List[str]],
+    seed: Optional[int],
+) -> list[str]:
     choices = [correct]
-    if distractor_pool:
-        rng = random.Random(seed)
-        candidates = [ipa for ipa in distractor_pool if ipa != correct]
-        rng.shuffle(candidates)
-        choices.extend(candidates[:3])
-        rng.shuffle(choices)
+    if not distractor_pool:
+        return choices
 
+    rng = random.Random(seed)
+    candidates = [value for value in distractor_pool if value and value != correct]
+    rng.shuffle(candidates)
+    choices.extend(candidates[:3])
+    rng.shuffle(choices)
+    return choices
+
+
+def _generate_choose_ipa_question(
+    word: Word,
+    accent: str,
+    *,
+    distractor_pool: Optional[List[str]],
+    seed: Optional[int],
+) -> dict:
+    correct = _active_ipa(word, accent)
     return {
         "type": "choose_ipa",
         "prompt": "Which IPA matches this word?",
-        "choices": choices,
+        "choices": _shuffled_choices(correct, distractor_pool, seed),
+    }
+
+
+def _generate_choose_word_question(
+    word: Word,
+    accent: str,
+    *,
+    distractor_pool: Optional[List[str]],
+    seed: Optional[int],
+) -> dict:
+    return {
+        "type": "choose_word",
+        "prompt": "Which word matches this IPA?",
+        "display_ipa": _active_ipa(word, accent),
+        "choices": _shuffled_choices(word.word, distractor_pool, seed),
     }

--- a/backend/app/services/sessions.py
+++ b/backend/app/services/sessions.py
@@ -230,6 +230,7 @@ def _create_normal_group_response(
         group_type="normal",
         learner_level=settings.learner_level,
         focus_phonemes=settings.focus_phonemes,
+        question_type=_normal_question_type(settings.practice_mode),
     )
 
     return _build_response(
@@ -1040,6 +1041,7 @@ def _create_group_from_words(
     source_scope: Optional[str] = None,
     source_group_id: Optional[str] = None,
     focus_phonemes: Optional[List[str]] = None,
+    question_type: str = "choose_ipa",
 ) -> tuple[DailySession, List[SessionItem]]:
     session_id = f"{session_date}-{user_id}-g{group_index:03d}-{group_type}"
     session = DailySession(
@@ -1071,7 +1073,7 @@ def _create_group_from_words(
             target_phonemes=(
                 word.phoneme_tags_us if accent == "US" else (word.phoneme_tags_uk or [])
             ),
-            question_type="choose_ipa",
+            question_type=question_type,
             status="pending",
         )
         create_session_item(conn, item)
@@ -1090,6 +1092,22 @@ def _build_distractor_pool(conn, accent: str) -> List[str]:
         """
     ).fetchall()
     return [r[0] for r in rows if r[0]]
+
+
+def _build_word_distractor_pool(conn) -> List[str]:
+    """Collect word strings from the words table for choose_word choices."""
+    rows = conn.execute(
+        """
+        SELECT DISTINCT word FROM words
+        WHERE word IS NOT NULL AND word != '' AND content_status != 'disabled'
+        LIMIT 200
+        """
+    ).fetchall()
+    return [r[0] for r in rows if r[0]]
+
+
+def _normal_question_type(practice_mode: str) -> str:
+    return "choose_word" if practice_mode == "choose_word" else "choose_ipa"
 
 
 def _completed_normal_groups_today(conn, user_id: str, session_date: str) -> dict:
@@ -1234,7 +1252,8 @@ def _build_response(
     settings = get_settings(conn, session.user_id)
     show_accent_compare = bool(settings and settings.show_accent_compare)
     show_translation = bool(settings.show_translation) if settings is not None else True
-    distractor_pool = _build_distractor_pool(conn, accent)
+    ipa_distractor_pool = _build_distractor_pool(conn, accent)
+    word_distractor_pool = _build_word_distractor_pool(conn)
     latest_attempts = get_latest_attempts_for_session_items(
         conn,
         [item.id for item in items],
@@ -1253,7 +1272,12 @@ def _build_response(
         question = generate_question(
             word,
             accent=accent,
-            distractor_pool=distractor_pool,
+            distractor_pool=(
+                word_distractor_pool
+                if item.question_type == "choose_word"
+                else ipa_distractor_pool
+            ),
+            question_type=item.question_type,
             seed=_stable_hash(item.id),
         )
 

--- a/backend/tests/test_m13_choose_word_backend.py
+++ b/backend/tests/test_m13_choose_word_backend.py
@@ -1,0 +1,184 @@
+"""Backend foundation tests for M13 choose_word practice mode."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+_SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+from import_words import import_words  # noqa: E402
+
+from app.db import get_connection  # noqa: E402
+from app.main import app  # noqa: E402
+from tests.auth_helpers import authenticated_client, bootstrap_owner_user  # noqa: E402
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures"
+CONTENT_SAMPLE = FIXTURES / "content_sample.json"
+PHONEMES_PATH = Path(__file__).resolve().parent.parent.parent / "content" / "phonemes.json"
+
+
+def _seed_db(tmp_path: Path, monkeypatch) -> str:
+    db_path = str(tmp_path / "m13-choose-word.sqlite")
+    import_words(source_path=CONTENT_SAMPLE, phonemes_path=PHONEMES_PATH, db_path=db_path)
+    import app.db as db_mod
+
+    monkeypatch.setattr(db_mod, "DEFAULT_DB_PATH", db_path)
+    bootstrap_owner_user(db_path)
+    return db_path
+
+
+def _client() -> TestClient:
+    return authenticated_client(TestClient(app))
+
+
+def test_default_normal_group_remains_choose_ipa(tmp_path, monkeypatch):
+    _seed_db(tmp_path, monkeypatch)
+    client = _client()
+
+    data = client.post("/api/practice/next-normal").json()
+
+    assert data["items"]
+    assert {item["question"]["type"] for item in data["items"]} == {"choose_ipa"}
+    first = data["items"][0]
+    assert first["display_ipa"] in first["question"]["choices"]
+
+
+def test_choose_word_setting_creates_word_choice_normal_group(tmp_path, monkeypatch):
+    db_path = _seed_db(tmp_path, monkeypatch)
+    client = _client()
+    settings = client.put("/api/settings", json={"practice_mode": "choose_word"})
+    assert settings.status_code == 200
+    assert settings.json()["practice_mode"] == "choose_word"
+
+    data = client.post("/api/practice/next-normal").json()
+
+    assert data["items"]
+    item = data["items"][0]
+    assert item["question"]["type"] == "choose_word"
+    assert item["question"]["display_ipa"] == item["display_ipa"]
+    assert item["word"] in item["question"]["choices"]
+    assert item["display_ipa"] not in item["question"]["choices"]
+    conn = get_connection(db_path)
+    row = conn.execute(
+        "SELECT question_type FROM session_items WHERE id = ?",
+        (item["session_item_id"],),
+    ).fetchone()
+    conn.close()
+    assert row["question_type"] == "choose_word"
+
+
+def test_choose_word_attempt_uses_server_word_answer_and_updates_stats(
+    tmp_path,
+    monkeypatch,
+):
+    db_path = _seed_db(tmp_path, monkeypatch)
+    client = _client()
+    client.put("/api/settings", json={"practice_mode": "choose_word"})
+    item = client.post("/api/practice/next-normal").json()["items"][0]
+
+    response = client.post(
+        "/api/attempt",
+        json={
+            "session_item_id": item["session_item_id"],
+            "selected_answer": item["word"],
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["is_correct"] is True
+    assert data["correct_answer"] == item["word"]
+    assert data["updated_phonemes"]
+    conn = get_connection(db_path)
+    row = conn.execute(
+        """
+        SELECT question_type, selected_answer, correct_answer, is_correct
+        FROM attempts
+        WHERE session_item_id = ?
+        """,
+        (item["session_item_id"],),
+    ).fetchone()
+    conn.close()
+    assert dict(row) == {
+        "question_type": "choose_word",
+        "selected_answer": item["word"],
+        "correct_answer": item["word"],
+        "is_correct": 1,
+    }
+
+
+def test_choose_word_attempt_rejects_visible_ipa_as_word_answer(tmp_path, monkeypatch):
+    db_path = _seed_db(tmp_path, monkeypatch)
+    client = _client()
+    client.put("/api/settings", json={"practice_mode": "choose_word"})
+    item = client.post("/api/practice/next-normal").json()["items"][0]
+
+    response = client.post(
+        "/api/attempt",
+        json={
+            "session_item_id": item["session_item_id"],
+            "selected_answer": item["display_ipa"],
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["is_correct"] is False
+    assert data["correct_answer"] == item["word"]
+    assert data["updated_phonemes"]
+    conn = get_connection(db_path)
+    row = conn.execute(
+        """
+        SELECT question_type, selected_answer, correct_answer, is_correct
+        FROM attempts
+        WHERE session_item_id = ?
+        """,
+        (item["session_item_id"],),
+    ).fetchone()
+    conn.close()
+    assert dict(row) == {
+        "question_type": "choose_word",
+        "selected_answer": item["display_ipa"],
+        "correct_answer": item["word"],
+        "is_correct": 0,
+    }
+
+
+def test_unsupported_question_type_fails_closed(tmp_path, monkeypatch):
+    db_path = _seed_db(tmp_path, monkeypatch)
+    client = _client()
+    item = client.post("/api/practice/next-normal").json()["items"][0]
+    conn = get_connection(db_path)
+    conn.execute(
+        "UPDATE session_items SET question_type = 'type_word' WHERE id = ?",
+        (item["session_item_id"],),
+    )
+    conn.commit()
+    conn.close()
+
+    response = client.post(
+        "/api/attempt",
+        json={
+            "session_item_id": item["session_item_id"],
+            "selected_answer": item["word"],
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"]["error"] == "INVALID_ATTEMPT"
+    conn = get_connection(db_path)
+    attempt_count = conn.execute(
+        "SELECT COUNT(*) AS cnt FROM attempts WHERE session_item_id = ?",
+        (item["session_item_id"],),
+    ).fetchone()["cnt"]
+    stat_count = conn.execute(
+        "SELECT COUNT(*) AS cnt FROM phoneme_stats WHERE user_id = 'default'",
+    ).fetchone()["cnt"]
+    conn.close()
+    assert attempt_count == 0
+    assert stat_count == 0

--- a/backend/tests/test_settings_api.py
+++ b/backend/tests/test_settings_api.py
@@ -108,6 +108,11 @@ class TestSettingsApi:
         assert resp.status_code == 400
         assert resp.json()["detail"]["error"] == "SETTINGS_INVALID"
 
+    def test_put_accepts_choose_word_practice_mode(self, client):
+        resp = client.put("/api/settings", json={"practice_mode": "choose_word"})
+        assert resp.status_code == 200
+        assert resp.json()["practice_mode"] == "choose_word"
+
     def test_put_invalid_learner_level(self, client):
         resp = client.put("/api/settings", json={"learner_level": "advanced"})
         assert resp.status_code == 400


### PR DESCRIPTION
## Summary

- Add backend `choose_word` question payload generation for normal groups when `practice_mode` is `choose_word`.
- Extend server-side grading dispatch so `/api/attempt` grades `choose_word` by target word while preserving `choose_ipa`.
- Fail closed with `INVALID_ATTEMPT` for unsupported persisted `question_type`.
- Keep review/focus groups on the existing default `choose_ipa` path.
- Add focused backend tests for generation, grading, persisted attempts, stats updates, unsupported mode errors, and Settings acceptance of `choose_word`.

## Scope boundaries

- Backend foundation only.
- No frontend renderer work.
- No distractor quality optimization/report beyond minimal word-choice generation.
- No `type_word` production mode.
- No scheduler rewrite, source-content mutation, `meaning_zh`, `minimal_pair_group`, deployment/account/admin/runtime config, real DB mutation, or data migration changes.
- PR target is `epic/m13-practice-modes`, not `main`.

## Verification

- `uv run --project backend --extra dev pytest backend/tests/test_m13_choose_word_backend.py backend/tests/test_settings_api.py backend/tests/test_attempts.py` -> 39 passed, 1 existing warning.
- `uv run --project backend --extra dev pytest` -> 333 passed, 1 existing warning.
- `uv run --project backend --extra dev ruff check backend/app/routes/attempts.py backend/app/routes/settings.py backend/app/services/grading.py backend/app/services/questions.py backend/app/services/sessions.py backend/tests/test_m13_choose_word_backend.py backend/tests/test_settings_api.py` -> passed.
- `git diff --check` passed.
- `tools/agents/agent-audit` passed clean.

## Handoff

#261 should route to Reviewer for backend contract compliance review. No downstream M13 issue should be released until #261 is accepted.