### PR TITLE
[#260] Add choose-word distractor quality scoring

### DIFF
--- a/backend/app/services/db_store.py
+++ b/backend/app/services/db_store.py
@@ -324,6 +324,34 @@ def get_word_by_id(conn: sqlite3.Connection, word_id: str) -> Optional[Word]:
     return _word_from_row(row)
 
 
+_LEARNER_LEVEL_TO_WORD_LEVEL = {
+    "entry": "beginner",
+    "mid": "intermediate",
+}
+
+
+def list_words_for_level(
+    conn: sqlite3.Connection,
+    learner_level: str,
+    *,
+    accent: str = "US",
+) -> List[Word]:
+    word_level = _LEARNER_LEVEL_TO_WORD_LEVEL.get(learner_level, learner_level)
+    ipa_field = "ipa_us" if accent.upper() == "US" else "ipa_uk"
+    rows = conn.execute(
+        f"""
+        SELECT * FROM words
+        WHERE level = ?
+          AND content_status != 'disabled'
+          AND word IS NOT NULL AND word != ''
+          AND {ipa_field} IS NOT NULL AND {ipa_field} != ''
+        ORDER BY word
+        """,
+        (word_level,),
+    ).fetchall()
+    return [_word_from_row(row) for row in rows]
+
+
 # ============================================================================
 # Phonemes
 # ============================================================================

--- a/backend/app/services/distractors.py
+++ b/backend/app/services/distractors.py
@@ -1,0 +1,289 @@
+"""Runtime distractor scoring for reverse word-choice questions."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass
+from difflib import SequenceMatcher
+from typing import Iterable
+
+from app.models import Word
+
+_VOWEL_NUCLEUS_RE = re.compile(
+    r"(?:iː|uː|eɪ|aɪ|oʊ|aʊ|ɔɪ|ɪ|ʊ|e|æ|ɑ|ɔ|ʌ|ə|ɝ|ɚ|ɒ|ɐ|ɜ|i|u)"
+)
+
+
+@dataclass(frozen=True)
+class DistractorCandidate:
+    word: Word
+    score: float
+    shared_phonemes: int
+    ipa_similarity: float
+    syllable_delta: int
+    word_length_delta: int
+    difficulty_overlap: int
+    fallback: bool
+
+
+def active_ipa(word: Word, accent: str = "US") -> str:
+    if accent.upper() == "UK" and word.ipa_uk:
+        return word.ipa_uk
+    return word.ipa_us
+
+
+def active_phonemes(word: Word, accent: str = "US") -> list[str]:
+    if accent.upper() == "UK" and word.phoneme_tags_uk:
+        return word.phoneme_tags_uk
+    return word.phoneme_tags_us
+
+
+def estimate_syllable_count(ipa: str) -> int:
+    if not ipa:
+        return 0
+    return len(_VOWEL_NUCLEUS_RE.findall(ipa.replace("/", "")))
+
+
+def _stable_jitter(seed: int | None, value: str) -> float:
+    digest = hashlib.md5(f"{seed or 0}:{value}".encode()).hexdigest()
+    return int(digest[:8], 16) / 0xFFFFFFFF
+
+
+def _same_level(target: Word, candidate: Word) -> bool:
+    return bool(target.level and candidate.level and target.level == candidate.level)
+
+
+def score_choose_word_candidate(
+    target: Word,
+    candidate: Word,
+    *,
+    accent: str = "US",
+) -> DistractorCandidate | None:
+    if candidate.id == target.id or candidate.word == target.word:
+        return None
+    if candidate.content_status == "disabled":
+        return None
+    if not _same_level(target, candidate):
+        return None
+
+    target_ipa = active_ipa(target, accent)
+    candidate_ipa = active_ipa(candidate, accent)
+    if not target_ipa or not candidate_ipa:
+        return None
+    if candidate_ipa == target_ipa:
+        return None
+
+    target_phonemes = set(active_phonemes(target, accent))
+    candidate_phonemes = set(active_phonemes(candidate, accent))
+    shared_phonemes = len(target_phonemes & candidate_phonemes)
+    similarity = SequenceMatcher(None, target_ipa, candidate_ipa).ratio()
+    syllable_delta = abs(
+        estimate_syllable_count(target_ipa) - estimate_syllable_count(candidate_ipa)
+    )
+    word_length_delta = abs(len(target.word) - len(candidate.word))
+    target_tags = set(target.difficulty_tags or [])
+    candidate_tags = set(candidate.difficulty_tags or [])
+    difficulty_overlap = len(target_tags & candidate_tags)
+
+    score = (
+        shared_phonemes * 4.0
+        + similarity * 3.0
+        + max(0, 3 - syllable_delta) * 1.25
+        + max(0, 6 - word_length_delta) * 0.35
+        + difficulty_overlap * 1.5
+    )
+    fallback = shared_phonemes == 0 and difficulty_overlap == 0 and similarity < 0.45
+    return DistractorCandidate(
+        word=candidate,
+        score=round(score, 4),
+        shared_phonemes=shared_phonemes,
+        ipa_similarity=round(similarity, 4),
+        syllable_delta=syllable_delta,
+        word_length_delta=word_length_delta,
+        difficulty_overlap=difficulty_overlap,
+        fallback=fallback,
+    )
+
+
+def choose_word_distractors(
+    target: Word,
+    candidates: Iterable[Word],
+    *,
+    accent: str = "US",
+    seed: int | None = None,
+    limit: int = 3,
+) -> list[DistractorCandidate]:
+    scored = [
+        score
+        for candidate in candidates
+        if (score := score_choose_word_candidate(target, candidate, accent=accent))
+        is not None
+    ]
+    return sorted(
+        scored,
+        key=lambda item: (
+            -item.score,
+            _stable_jitter(seed, item.word.id),
+            item.word.word,
+        ),
+    )[:limit]
+
+
+def build_choose_word_quality_report(
+    words: Iterable[Word],
+    *,
+    accent: str = "US",
+    choice_count: int = 4,
+    sample_limit: int = 10,
+) -> dict:
+    usable = [
+        word
+        for word in words
+        if word.content_status != "disabled" and word.word and active_ipa(word, accent)
+    ]
+    distractor_limit = max(choice_count - 1, 1)
+    by_level: dict[str, dict] = {}
+    exact_ipa_groups: dict[tuple[str, str], list[Word]] = {}
+    target_samples = []
+
+    for word in usable:
+        level = word.level or "unknown"
+        level_summary = by_level.setdefault(
+            level,
+            {
+                "targets": 0,
+                "full_choice_targets": 0,
+                "sparse_targets": 0,
+                "fallback_distractors": 0,
+                "same_ipa_excluded_pairs": 0,
+                "sparse_samples": [],
+            },
+        )
+        level_summary["targets"] += 1
+        key = (level, active_ipa(word, accent))
+        exact_ipa_groups.setdefault(key, []).append(word)
+
+        choices = choose_word_distractors(
+            word,
+            usable,
+            accent=accent,
+            seed=0,
+            limit=distractor_limit,
+        )
+        if len(choices) >= distractor_limit:
+            level_summary["full_choice_targets"] += 1
+        else:
+            level_summary["sparse_targets"] += 1
+            if len(level_summary["sparse_samples"]) < sample_limit:
+                level_summary["sparse_samples"].append(
+                    {
+                        "word_id": word.id,
+                        "word": word.word,
+                        "level": level,
+                        "ipa": active_ipa(word, accent),
+                        "distractor_count": len(choices),
+                    }
+                )
+        fallback_count = sum(1 for choice in choices if choice.fallback)
+        level_summary["fallback_distractors"] += fallback_count
+        if len(target_samples) < sample_limit:
+            target_samples.append(
+                {
+                    "word_id": word.id,
+                    "word": word.word,
+                    "level": level,
+                    "ipa": active_ipa(word, accent),
+                    "distractors": [
+                        {
+                            "word_id": choice.word.id,
+                            "word": choice.word.word,
+                            "score": choice.score,
+                            "shared_phonemes": choice.shared_phonemes,
+                            "ipa_similarity": choice.ipa_similarity,
+                            "fallback": choice.fallback,
+                        }
+                        for choice in choices
+                    ],
+                }
+            )
+
+    ambiguous_groups = [
+        {
+            "level": level,
+            "ipa": ipa,
+            "words": [word.word for word in group],
+            "word_ids": [word.id for word in group],
+        }
+        for (level, ipa), group in sorted(exact_ipa_groups.items())
+        if len(group) > 1
+    ]
+    for group in ambiguous_groups:
+        count = len(group["word_ids"])
+        by_level[group["level"]]["same_ipa_excluded_pairs"] += count * (count - 1)
+
+    for level_summary in by_level.values():
+        targets = level_summary["targets"]
+        level_summary["full_choice_rate"] = _rate(
+            level_summary["full_choice_targets"], targets
+        )
+        level_summary["sparse_target_rate"] = _rate(
+            level_summary["sparse_targets"], targets
+        )
+        expected_distractors = targets * distractor_limit
+        level_summary["fallback_distractor_rate"] = _rate(
+            level_summary["fallback_distractors"], expected_distractors
+        )
+
+    totals = {
+        "targets": sum(level["targets"] for level in by_level.values()),
+        "full_choice_targets": sum(
+            level["full_choice_targets"] for level in by_level.values()
+        ),
+        "sparse_targets": sum(level["sparse_targets"] for level in by_level.values()),
+        "fallback_distractors": sum(
+            level["fallback_distractors"] for level in by_level.values()
+        ),
+        "same_ipa_excluded_pairs": sum(
+            level["same_ipa_excluded_pairs"] for level in by_level.values()
+        ),
+    }
+    expected_total_distractors = totals["targets"] * distractor_limit
+    totals["full_choice_rate"] = _rate(totals["full_choice_targets"], totals["targets"])
+    totals["sparse_target_rate"] = _rate(totals["sparse_targets"], totals["targets"])
+    totals["fallback_distractor_rate"] = _rate(
+        totals["fallback_distractors"], expected_total_distractors
+    )
+    return {
+        "report_name": "M13 choose_word distractor quality report",
+        "accent": accent.upper(),
+        "choice_count": choice_count,
+        "scoring_signals": [
+            "shared_target_phonemes",
+            "ipa_similarity",
+            "syllable_count_delta",
+            "difficulty_tag_overlap",
+            "word_length_delta",
+            "learner_level_partition",
+        ],
+        "totals": totals,
+        "by_level": by_level,
+        "ambiguous_same_ipa_groups": ambiguous_groups[:sample_limit],
+        "samples": target_samples,
+        "residual_risks": [
+            (
+                "Runtime scoring is heuristic; curated confusable metadata remains "
+                "a possible follow-up."
+            ),
+            (
+                "Exact same active-accent IPA alternatives are excluded rather "
+                "than treated as multi-correct."
+            ),
+        ],
+    }
+
+
+def _rate(count: int, total: int) -> float:
+    if total <= 0:
+        return 0.0
+    return round(count / total, 4)

--- a/backend/app/services/sessions.py
+++ b/backend/app/services/sessions.py
@@ -23,10 +23,12 @@ from app.services.db_store import (
     get_session_items,
     get_settings,
     get_word_by_id,
+    list_words_for_level,
     mark_session_abandoned,
     mark_session_completed,
     upsert_settings,
 )
+from app.services.distractors import choose_word_distractors
 from app.services.questions import generate_question
 from app.services.scheduler import select_daily_words
 
@@ -1094,18 +1096,6 @@ def _build_distractor_pool(conn, accent: str) -> List[str]:
     return [r[0] for r in rows if r[0]]
 
 
-def _build_word_distractor_pool(conn) -> List[str]:
-    """Collect word strings from the words table for choose_word choices."""
-    rows = conn.execute(
-        """
-        SELECT DISTINCT word FROM words
-        WHERE word IS NOT NULL AND word != '' AND content_status != 'disabled'
-        LIMIT 200
-        """
-    ).fetchall()
-    return [r[0] for r in rows if r[0]]
-
-
 def _normal_question_type(practice_mode: str) -> str:
     return "choose_word" if practice_mode == "choose_word" else "choose_ipa"
 
@@ -1253,7 +1243,11 @@ def _build_response(
     show_accent_compare = bool(settings and settings.show_accent_compare)
     show_translation = bool(settings.show_translation) if settings is not None else True
     ipa_distractor_pool = _build_distractor_pool(conn, accent)
-    word_distractor_pool = _build_word_distractor_pool(conn)
+    word_distractor_candidates = list_words_for_level(
+        conn,
+        session.learner_level,
+        accent=accent,
+    )
     latest_attempts = get_latest_attempts_for_session_items(
         conn,
         [item.id for item in items],
@@ -1273,7 +1267,15 @@ def _build_response(
             word,
             accent=accent,
             distractor_pool=(
-                word_distractor_pool
+                [
+                    candidate.word.word
+                    for candidate in choose_word_distractors(
+                        word,
+                        word_distractor_candidates,
+                        accent=accent,
+                        seed=_stable_hash(item.id),
+                    )
+                ]
                 if item.question_type == "choose_word"
                 else ipa_distractor_pool
             ),

--- a/backend/scripts/report_choose_word_distractors.py
+++ b/backend/scripts/report_choose_word_distractors.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Build an M13 choose_word runtime distractor quality report."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+_BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(_BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_ROOT))
+
+from app.models import Word  # noqa: E402
+from app.services.distractors import build_choose_word_quality_report  # noqa: E402
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_words(path: Path) -> list[dict]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if isinstance(data, list):
+        return data
+    if isinstance(data, dict) and isinstance(data.get("words"), list):
+        return data["words"]
+    raise ValueError(f"{path} must be a JSON array or object with a words array")
+
+
+def _word_from_entry(entry: dict) -> Word:
+    return Word(
+        id=str(entry.get("word_id") or entry.get("id") or entry.get("word") or ""),
+        word=str(entry.get("word") or ""),
+        level=str(entry.get("level") or ""),
+        ipa_us=str(entry.get("ipa_us") or ""),
+        ipa_uk=entry.get("ipa_uk"),
+        phoneme_tags_us=list(entry.get("phoneme_tags_us") or []),
+        phoneme_tags_uk=entry.get("phoneme_tags_uk"),
+        meaning_zh=entry.get("meaning_zh"),
+        audio_us=entry.get("audio_us"),
+        audio_uk=entry.get("audio_uk"),
+        difficulty_tags=entry.get("difficulty_tags"),
+        minimal_pair_group=entry.get("minimal_pair_group"),
+        content_status=str(entry.get("content_status") or "candidate"),
+    )
+
+
+def load_word_models(paths: list[Path]) -> list[Word]:
+    words: list[Word] = []
+    for path in paths:
+        words.extend(_word_from_entry(entry) for entry in _load_words(path))
+    return words
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Report choose_word distractor scorer quality for content JSON files."
+    )
+    parser.add_argument(
+        "sources",
+        nargs="*",
+        type=Path,
+        default=[
+            _REPO_ROOT / "content" / "core_300_words.json",
+            _REPO_ROOT / "content" / "core_1000_words.json",
+        ],
+        help="Content JSON files to inspect.",
+    )
+    parser.add_argument("--accent", default="US", choices=["US", "UK"])
+    parser.add_argument("--choice-count", type=int, default=4)
+    parser.add_argument("--sample-limit", type=int, default=10)
+    parser.add_argument("--json-output", type=Path, default=None)
+    args = parser.parse_args(argv)
+
+    words = load_word_models(args.sources)
+    report = build_choose_word_quality_report(
+        words,
+        accent=args.accent,
+        choice_count=args.choice_count,
+        sample_limit=args.sample_limit,
+    )
+    payload = json.dumps(report, indent=2, ensure_ascii=False) + "\n"
+    if args.json_output:
+        args.json_output.parent.mkdir(parents=True, exist_ok=True)
+        args.json_output.write_text(payload, encoding="utf-8")
+    else:
+        print(payload, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/test_m13_choose_word_backend.py
+++ b/backend/tests/test_m13_choose_word_backend.py
@@ -63,6 +63,7 @@ def test_choose_word_setting_creates_word_choice_normal_group(tmp_path, monkeypa
     assert item["question"]["display_ipa"] == item["display_ipa"]
     assert item["word"] in item["question"]["choices"]
     assert item["display_ipa"] not in item["question"]["choices"]
+    assert set(item["question"]["choices"]) == {"ship", "sheep", "cat"}
     conn = get_connection(db_path)
     row = conn.execute(
         "SELECT question_type FROM session_items WHERE id = ?",

--- a/backend/tests/test_m13_choose_word_distractors.py
+++ b/backend/tests/test_m13_choose_word_distractors.py
@@ -1,0 +1,144 @@
+"""Tests for M13 choose_word distractor scoring and reporting."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from report_choose_word_distractors import load_word_models  # noqa: E402
+
+from app.models import Word  # noqa: E402
+from app.services.distractors import (  # noqa: E402
+    build_choose_word_quality_report,
+    choose_word_distractors,
+    score_choose_word_candidate,
+)
+
+
+def word(
+    word_id: str,
+    ipa: str,
+    *,
+    text: str | None = None,
+    level: str = "beginner",
+    phonemes: list[str] | None = None,
+    tags: list[str] | None = None,
+    status: str = "core_selected",
+) -> Word:
+    return Word(
+        id=word_id,
+        word=text or word_id,
+        level=level,
+        ipa_us=ipa,
+        phoneme_tags_us=phonemes or [],
+        content_status=status,
+        difficulty_tags=tags,
+    )
+
+
+def test_choose_word_scorer_is_deterministic_and_prefers_shared_phonemes():
+    target = word(
+        "ship",
+        "/ʃɪp/",
+        phonemes=["/ʃ/", "/ɪ/", "/p/"],
+        tags=["sh", "short_i"],
+    )
+    candidates = [
+        word(
+            "cat",
+            "/kæt/",
+            phonemes=["/k/", "/æ/", "/t/"],
+            tags=["short_a"],
+        ),
+        word(
+            "sheep",
+            "/ʃiːp/",
+            phonemes=["/ʃ/", "/iː/", "/p/"],
+            tags=["sh", "long_i"],
+        ),
+        word(
+            "shop",
+            "/ʃɑp/",
+            phonemes=["/ʃ/", "/ɑ/", "/p/"],
+            tags=["sh"],
+        ),
+    ]
+
+    first = choose_word_distractors(target, candidates, seed=42)
+    second = choose_word_distractors(target, candidates, seed=42)
+
+    assert [item.word.id for item in first] == [item.word.id for item in second]
+    assert first[0].word.id in {"sheep", "shop"}
+    assert first[0].shared_phonemes == 2
+
+
+def test_choose_word_scorer_excludes_same_ipa_and_other_levels():
+    target = word("new", "/nu/", phonemes=["/n/", "/u/"])
+    same_ipa = word("knew", "/nu/", phonemes=["/n/", "/u/"])
+    other_level = word(
+        "noon",
+        "/nun/",
+        level="intermediate",
+        phonemes=["/n/", "/u/"],
+    )
+
+    assert score_choose_word_candidate(target, same_ipa) is None
+    assert score_choose_word_candidate(target, other_level) is None
+    assert choose_word_distractors(target, [same_ipa, other_level]) == []
+
+
+def test_choose_word_report_surfaces_sparse_and_fallback_buckets():
+    words = [
+        word("ship", "/ʃɪp/", phonemes=["/ʃ/", "/ɪ/", "/p/"]),
+        word("knew", "/nu/", phonemes=["/n/", "/u/"]),
+        word("new", "/nu/", phonemes=["/n/", "/u/"]),
+        word("cat", "/kæt/", phonemes=["/k/", "/æ/", "/t/"]),
+        word("want", "/wɑnt/", level="intermediate", phonemes=["/w/", "/ɑ/", "/n/", "/t/"]),
+    ]
+
+    report = build_choose_word_quality_report(words, choice_count=4, sample_limit=5)
+
+    assert report["report_name"] == "M13 choose_word distractor quality report"
+    assert report["totals"]["targets"] == 5
+    assert report["totals"]["sparse_targets"] > 0
+    assert report["totals"]["fallback_distractors"] > 0
+    assert report["totals"]["sparse_target_rate"] > 0
+    assert report["totals"]["fallback_distractor_rate"] > 0
+    assert report["totals"]["same_ipa_excluded_pairs"] == 2
+    assert report["by_level"]["intermediate"]["sparse_targets"] == 1
+    assert report["by_level"]["beginner"]["full_choice_rate"] < 1
+    assert report["ambiguous_same_ipa_groups"] == [
+        {
+            "level": "beginner",
+            "ipa": "/nu/",
+            "words": ["knew", "new"],
+            "word_ids": ["knew", "new"],
+        }
+    ]
+    assert "learner_level_partition" in report["scoring_signals"]
+
+
+def test_report_script_loads_content_json_as_word_models(tmp_path):
+    source = tmp_path / "words.json"
+    source.write_text(
+        """[
+          {
+            "word_id": "ship",
+            "word": "ship",
+            "level": "beginner",
+            "ipa_us": "/ʃɪp/",
+            "phoneme_tags_us": ["/ʃ/", "/ɪ/", "/p/"],
+            "content_status": "core_selected"
+          }
+        ]""",
+        encoding="utf-8",
+    )
+
+    words = load_word_models([source])
+
+    assert len(words) == 1
+    assert words[0].id == "ship"
+    assert words[0].phoneme_tags_us == ["/ʃ/", "/ɪ/", "/p/"]


### PR DESCRIPTION
## Summary

Implements #260 runtime distractor scoring and quality reporting for M13 `choose_word`.

## Scope

- Adds a backend `choose_word` distractor scorer using shared phonemes, IPA similarity, syllable delta, word length, difficulty-tag overlap, same-level partitioning, and deterministic seeded tie-breaking.
- Excludes exact same active-accent IPA alternatives from runtime choices.
- Replaces the prior global word-string pool with same learner-level structured `Word` candidates in Today session question generation.
- Adds `backend/scripts/report_choose_word_distractors.py` to report full-choice coverage, sparse targets, fallback distractors, same-IPA ambiguous groups, and samples.
- Adds focused scorer/report tests and extends the #261 backend choose-word assertion.

## Verification

- `uv run --project backend --extra dev pytest backend/tests/test_m13_choose_word_distractors.py backend/tests/test_m13_choose_word_backend.py` -> 9 passed, 1 existing warning.
- `uv run --project backend --extra dev pytest backend/tests/test_m13_choose_word_distractors.py backend/tests/test_m13_choose_word_backend.py backend/tests/test_m13_question_contract.py backend/tests/test_settings_api.py -q` -> 53 passed, 1 existing warning.
- `uv run --project backend --extra dev pytest -q` -> 338 passed, 1 existing warning.
- `uv run --project backend --extra dev ruff check backend/app/services/distractors.py backend/app/services/db_store.py backend/app/services/sessions.py backend/scripts/report_choose_word_distractors.py backend/tests/test_m13_choose_word_distractors.py backend/tests/test_m13_choose_word_backend.py` -> passed.
- `uv run --project backend --extra dev python backend/scripts/report_choose_word_distractors.py --sample-limit 2` -> produced report: 1299 US targets, 1299 full-choice targets, 0 sparse targets, 0 fallback distractors, 20 same-IPA excluded pairs.
- `git diff --check` -> passed.
- `tools/agents/agent-audit` -> passed clean after one GitHub TLS retry.

## Out of Scope

No source-content mutation, populated `minimal_pair_group` curation, `meaning_zh` changes, scheduler rewrite, frontend renderer/workflow, `type_word`, deployment/auth/account/admin/runtime config, real DB mutation, data migration, `main` merge, or #256 closure.

Completion handoff: to:reviewer
