### PR TITLE
[#269] Hide choose-word answer audio before submit

### DIFF
--- a/frontend/src/components/ChoiceQuestion.tsx
+++ b/frontend/src/components/ChoiceQuestion.tsx
@@ -117,12 +117,6 @@ export function ChoiceQuestion({ item, t, onResult, onContinue }: Props) {
             <span className="question-cue-label">{t("practice.question.cue.ipa")}</span>
             <span className="word-text ipa-cue">
               {item.question.display_ipa ?? item.display_ipa}
-              <AudioButton
-                audioUrl={item.audio_url}
-                word={item.word}
-                t={t}
-                disabled={submitting}
-              />
             </span>
           </>
         ) : (

--- a/frontend/tests/e2e/m13-question-renderer.spec.ts
+++ b/frontend/tests/e2e/m13-question-renderer.spec.ts
@@ -173,7 +173,7 @@ test.describe("M13 generic practice question renderer", () => {
     await expect(page.locator(".ipa-cue")).toContainText("/ʃɪp/");
     await expect(page.locator(".word-display")).not.toContainText("ship");
     await expect(page.locator(".word-display")).not.toContainText("船；大船");
-    await expect(page.locator(".word-display .audio-btn")).toHaveCount(1);
+    await expect(page.locator(".word-display .audio-btn")).toHaveCount(0);
 
     await page.getByRole("button", { name: "选择 sheep" }).click();
     const feedback = page.getByRole("alert");


### PR DESCRIPTION
## Summary

Fixes #269, a blocker found after #259 / PR #268: `choose_word` exposed the answer through pre-answer audio.

## Scope

- Removes `AudioButton` from the pre-answer `choose_word` stimulus branch.
- Keeps `choose_ipa` word/audio/meaning behavior unchanged.
- Updates the M13 route-mocked walkthrough to assert no pre-answer `.audio-btn` exists for `choose_word`.

## Verification

- `cd frontend && pnpm test:e2e:m13` -> 3 passed.
- `cd frontend && pnpm exec tsc --noEmit && pnpm run lint && pnpm run build` -> passed.
- `git diff --check` -> passed.
- `tools/agents/agent-audit` -> passed clean after GitHub TLS/EOF retries.

## Out of Scope

No backend generation/grading changes, production `type_word`, settings/mode-selection workflow, scheduler/content/meaning_zh/deploy/auth/account/admin/runtime config/DB mutation/data migration changes, `main` merge, or #256 closure.

Completion handoff: to:reviewer
