### PR TITLE
[#264] Add type-word accepted-answer contract

### DIFF
--- a/backend/tests/test_m13_question_contract.py
+++ b/backend/tests/test_m13_question_contract.py
@@ -1,9 +1,11 @@
+import json
+from collections import defaultdict
 from pathlib import Path
 
 import pytest
 
-
 DOC = Path(__file__).resolve().parents[2] / "docs" / "05-data-api-contracts.md"
+CONTENT_ROOT = Path(__file__).resolve().parents[2] / "content"
 
 
 def _contract_text() -> str:
@@ -12,6 +14,33 @@ def _contract_text() -> str:
 
 def _normalized_contract_text() -> str:
     return " ".join(_contract_text().split())
+
+
+def _load_content_words() -> list[tuple[str, dict]]:
+    words: list[tuple[str, dict]] = []
+    for level, filename in [
+        ("entry", "core_300_words.json"),
+        ("mid", "core_1000_words.json"),
+    ]:
+        data = json.loads((CONTENT_ROOT / filename).read_text(encoding="utf-8"))
+        rows = data if isinstance(data, list) else data.get("words", [])
+        words.extend((level, row) for row in rows)
+    return words
+
+
+def _same_level_same_ipa_groups(accent: str) -> dict[tuple[str, str], set[str]]:
+    field = "ipa_us" if accent == "US" else "ipa_uk"
+    groups: dict[tuple[str, str], set[str]] = defaultdict(set)
+    for level, row in _load_content_words():
+        ipa = (row.get(field) or "").strip()
+        word = (row.get("word") or "").strip().lower()
+        if ipa and word:
+            groups[(level, ipa)].add(word)
+    return {
+        key: values
+        for key, values in groups.items()
+        if len(values) > 1
+    }
 
 
 @pytest.mark.parametrize(
@@ -56,6 +85,36 @@ def test_m13_question_taxonomy_lists_supported_and_deferred_modes(
 )
 def test_m13_type_word_homophone_policy_is_explicit(policy_phrase: str) -> None:
     assert policy_phrase in _normalized_contract_text()
+
+
+@pytest.mark.parametrize(
+    "contract_phrase",
+    [
+        "server-side accepted-answer snapshot",
+        "accepted_answers storage",
+        "Unicode NFKC normalization",
+        "no fuzzy typo matching in the MVP",
+        "exclude that row from type_word candidate generation",
+        "no production type_word exposure in the current M13 MVP",
+        "normal-only type_word behind an explicit challenge-mode selector",
+    ],
+)
+def test_m13_type_word_accepted_answer_contract_is_actionable(
+    contract_phrase: str,
+) -> None:
+    assert contract_phrase in _normalized_contract_text()
+
+
+def test_current_content_has_same_ipa_type_word_ambiguity_examples() -> None:
+    us_groups = _same_level_same_ipa_groups("US")
+    uk_groups = _same_level_same_ipa_groups("UK")
+
+    assert len(us_groups) >= 11
+    assert len(uk_groups) >= 7
+    assert {"new", "knew"} <= us_groups[("entry", "/ˈnju/")]
+    assert {"see", "sea"} <= us_groups[("mid", "/ˈsi/")]
+    assert {"buy", "bye"} <= us_groups[("mid", "/ˈbaɪ/")]
+    assert {"honor", "honour"} <= us_groups[("mid", "/ˈɑnɝ/")]
 
 
 @pytest.mark.parametrize(

--- a/docs/05-data-api-contracts.md
+++ b/docs/05-data-api-contracts.md
@@ -763,16 +763,80 @@ question explicitly supports multiple correct answers. This keeps a learner
 from seeing two visually different words that are both correct for the same
 displayed IPA.
 
-`type_word` is deferred because same-IPA and homophone answers require fairness
-rules before production release. Examples include `new` / `knew`, `sun` /
-`son`, and `see` / `sea`. A future `type_word` contract must define:
+`type_word` remains gated for production until accepted answers are generated
+and persisted by the backend. The first safe implementation path is not
+"compare the typed string with `word.word`"; it is "compare the normalized typed
+string with a server-side accepted-answer snapshot for the session item."
+
+Current content already has same-IPA and spelling-variant ambiguity. A
+2026-07-03 probe over `content/core_300_words.json` and
+`content/core_1000_words.json` found:
+
+| Scope | US exact same-IPA groups | UK exact same-IPA groups | Examples |
+| --- | ---: | ---: | --- |
+| Same learner level | 11 | 7 | `knew` / `new`, `buy` / `bye`, `see` / `sea`, `ads` / `adds`, `color` / `colour`, `favor` / `favour`, `honor` / `honour`, `labor` / `labour` |
+| Cross learner level | 3 | 2 | Entry `sun` / Mid `son`, Entry `new` / Mid `new`, Entry `feb` / `february` / Mid `february` |
+
+Legacy ambiguity examples include `new` / `knew`, `sun` / `son`, and `see` /
+`sea`. The spelling variant policy must be explicit before `type_word` can move
+from contract fixture to learner-facing runtime.
+
+Because learners may type a valid homophone or spelling variant that is not the
+target row, a future `type_word` implementation must add explicit accepted
+answers before exposure. The accepted-answer snapshot must be created
+server-side when the session item is created or first materialized, and it must
+be stable for grading and feedback even if content files change later.
+
+Minimal safe `type_word` contract for a follow-up implementation:
 
 ```text
-accepted_answers source
-normalization rules
-spelling variant policy
-same-IPA exclusion or multi-answer policy
-feedback copy for alternate accepted answers
+accepted_answers source:
+  - canonical target word
+  - all enabled runtime words sharing the active-accent IPA
+  - explicit spelling variants or aliases if a future curation file adds them
+  - no frontend-provided answers
+
+accepted_answers storage:
+  - persisted session-item answer metadata or persisted question payload
+  - response may expose display-safe accepted answer labels only after grading
+  - /api/attempt must grade against the persisted snapshot
+
+normalization rules:
+  - Unicode NFKC normalization
+  - trim leading/trailing whitespace
+  - collapse repeated internal whitespace
+  - case-insensitive comparison
+  - normalize curly apostrophes to ASCII apostrophe
+  - strip surrounding sentence punctuation such as ., ,, !, ?
+  - hyphen/space variants and omitted apostrophes are accepted only when an
+    explicit accepted-answer entry or generated alias exists
+  - no fuzzy typo matching in the MVP
+
+same-IPA behavior:
+  - if typed answer matches any accepted answer, mark correct
+  - if it matches an accepted alternate, feedback says the typed answer is also
+    accepted for this IPA and shows the target word separately
+  - if same-IPA accepted answers are unavailable, exclude that row from
+    type_word candidate generation rather than marking homophones wrong
+
+feedback copy:
+  - exact target: "Correct."
+  - accepted alternate: "Accepted: {typedAnswer} also matches this IPA. Target
+    word: {targetWord}."
+  - incorrect: "Not quite. You typed {typedAnswer}. Accepted answer:
+    {targetWord}."
+  - ambiguous unavailable: "This IPA has multiple valid spellings, so this item
+    is not used for typed-answer practice yet."
+  - partial mismatch: no "almost" or edit-distance hint until a later contract
+    defines typo tolerance
+
+launch recommendation:
+  - no production type_word exposure in the current M13 MVP
+  - safe follow-up may implement normal-only type_word behind an explicit
+    challenge-mode selector after accepted-answer metadata, row exclusion, and
+    feedback copy tests are accepted
+  - review, focus, and specialty groups stay non-typed until separate
+    walkthrough evidence accepts those flows
 ```
 
 Until then, `type_word` may appear only in docs/test fixtures that assert it is


### PR DESCRIPTION
## Scope completed
- Defined the gated `type_word` accepted-answer contract in `docs/05-data-api-contracts.md`.
- Captured same-IPA and spelling-variant ambiguity evidence from current Entry/Core300 and Mid/Core1000 content.
- Added normalization, accepted-answer storage/source, feedback copy, row-exclusion, and launch/no-launch recommendation.
- Added focused contract/data-probe tests in `backend/tests/test_m13_question_contract.py`.

## Verification
- `uv run --project backend pytest backend/tests/test_m13_question_contract.py -q` -> 36 passed
- `uv run --project backend ruff check backend/tests/test_m13_question_contract.py` -> passed
- `git diff --check` -> passed
- `tools/agents/agent-audit` -> passed, no workflow drift findings

## Evidence summary
- Same learner-level exact same-IPA groups found: US 11, UK 7.
- Cross learner-level exact same-IPA groups found: US 3, UK 2.
- Examples include `new`/`knew`, `sun`/`son`, `see`/`sea`, `buy`/`bye`, and US/UK spelling variants such as `honor`/`honour`.

## Recommendation
- Keep production `type_word` gated for M13 until a follow-up implements server-persisted accepted answers and row exclusion.
- Safe follow-up path: normal-only `type_word` behind an explicit challenge-mode selector after accepted-answer metadata and feedback tests are accepted.

## Residual risks
- The evidence uses exact active-accent IPA equality only; it does not solve fuzzy pronunciation similarity or typo tolerance.
- No runtime `type_word` behavior was implemented by this PR.

Closes neither #264 nor #256. Linked issue: #264