### PR TITLE
[#273] Fix Mid imported content level alias

### DIFF
--- a/backend/app/services/sessions.py
+++ b/backend/app/services/sessions.py
@@ -855,9 +855,7 @@ def _select_minimal_pair_words(
 ) -> list:
     ipa_field = "ipa_us" if accent == "US" else "ipa_uk"
     tags_field = "phoneme_tags_us" if accent == "US" else "phoneme_tags_uk"
-    level_values = (
-        ["entry", "beginner"] if learner_level == "entry" else [learner_level]
-    )
+    level_values = _level_values(learner_level)
     level_placeholders = ", ".join("?" for _ in level_values)
     rows = conn.execute(
         f"""
@@ -894,7 +892,11 @@ def _select_minimal_pair_words(
 
 
 def _level_values(learner_level: str) -> list[str]:
-    return ["entry", "beginner"] if learner_level == "entry" else [learner_level]
+    if learner_level == "entry":
+        return ["entry", "beginner"]
+    if learner_level == "mid":
+        return ["mid", "intermediate"]
+    return [learner_level]
 
 
 def _target_phoneme_options(

--- a/backend/tests/test_today_persistence.py
+++ b/backend/tests/test_today_persistence.py
@@ -103,13 +103,11 @@ def seeded_db_entry_mid_fixture(tmp_path: Path) -> str:
         source_path=CORE_300_PATH,
         phonemes_path=PHONEMES_PATH,
         db_path=db_path,
-        content_level="entry",
     )
     import_words(
         source_path=CORE_1000_PATH,
         phonemes_path=PHONEMES_PATH,
         db_path=db_path,
-        content_level="mid",
     )
 
     import app.db as db_mod
@@ -1233,7 +1231,9 @@ class TestLevelAwareToday:
         assert data["items"]
         assert all(not item["word_id"].startswith("mid_") for item in data["items"])
 
-    def test_mid_setting_uses_core1000_pool_without_entry_mix(self, entry_mid_client):
+    def test_mid_setting_uses_core1000_pool_without_entry_mix(
+        self, entry_mid_client, seeded_db_entry_mid
+    ):
         settings_resp = entry_mid_client.put("/api/settings", json={
             "learner_level": "mid",
             "daily_word_count": 6,
@@ -1248,6 +1248,16 @@ class TestLevelAwareToday:
         assert data["learner_level_label"] == "Mid"
         assert data["items"]
         assert all(item["word_id"].startswith("mid_") for item in data["items"])
+        conn = get_connection(seeded_db_entry_mid)
+        levels = {
+            conn.execute(
+                "SELECT level FROM words WHERE id = ?",
+                (item["word_id"],),
+            ).fetchone()["level"]
+            for item in data["items"]
+        }
+        conn.close()
+        assert levels == {"intermediate"}
 
     def test_level_change_keeps_active_group_and_affects_next_group(
         self, entry_mid_client, seeded_db_entry_mid


### PR DESCRIPTION
## Summary
- Treat learner level `mid` as both `mid` and imported Core1000 `intermediate` where session-level content aliasing is used.
- Reuse the shared level alias helper for minimal-pair selection.
- Update level-aware Today tests to use default Core300/Core1000 imports and assert Mid groups are backed by `intermediate` content rows.

## Verification
- `uv run --project backend --extra dev pytest backend/tests/test_today_persistence.py::TestLevelAwareToday backend/tests/test_m13_choose_word_backend.py -q` -> 12 passed, 1 warning
- `uv run --project backend --extra dev pytest backend/tests/test_today_persistence.py backend/tests/test_m13_choose_word_backend.py backend/tests/test_m13_choose_word_distractors.py -q` -> 65 passed, 1 warning
- `uv run --project backend --extra dev pytest -q` -> 348 passed, 1 warning
- `git diff --check` -> passed
- `tools/agents/agent-audit` -> clean

## Scope
- No source content mutation.
- No content taxonomy redesign.
- No main merge, M13 readiness closure, deployment/account/admin work, runtime config change, DB migration, or private DB mutation.