### PR TITLE
[#27] docs: update roadmap for M14 deployment planning

### DIFF
--- a/docs/05-data-api-contracts.md
+++ b/docs/05-data-api-contracts.md
@@ -14,19 +14,27 @@ Runtime Data
 
 源内容是事实来源。SQLite 可以删除重建，但用户学习记录需要备份。
 
-## Localization and Current-user Roadmap Boundary
+## Deployment Prerequisite Roadmap Boundary
 
-M11 and M12 insert two prerequisites before deployment:
+M11, M12, and M13 are deployment prerequisites before M14 VPS work:
 
 ```text
 M11 Localization and Configurable UI Language (#209)
 M12 Minimal Auth and Multi-user Data Isolation (#210)
+M13 Expand Practice Modes: Choose Word and Type Word (#256)
 ```
 
 Localization is a UI/runtime contract. It should make learner-facing copy
 configurable without changing IPA/content/grading semantics. Auth is a runtime
 identity contract. It should make existing `user_id` fields meaningful before
-the app is exposed through VPS deployment.
+the app is exposed through VPS deployment. Practice modes are a practice-runtime
+contract. They should keep question mode, grading, distractor quality, and
+mode-specific UI behavior testable before deployment smoke and restore checks.
+
+M14 deployment and backup (#27) is now decomposed. #276 owns the deployment
+target/runtime config contract. Later M14 work must not mutate real VPS, DNS,
+TLS, secrets, deployment config, or private SQLite data without an explicit
+Human gate.
 
 These Epics must preserve the existing content boundary:
 
@@ -421,10 +429,12 @@ owner-claim mutation.
   - cookie flags, Origin/CSRF checks, and CORS allowlist behavior are evidenced
   - default-data dry-run evidence is linked for any existing private DB
 
-#27 VPS deployment prerequisite evidence
+#27 / M14 VPS deployment prerequisite evidence
   - M12 readiness comment links auth/session/cookie/origin evidence
   - user-isolation tests and real-backend walkthrough evidence are accepted
+  - M13 practice-mode readiness evidence is accepted
   - backup and owner-claim dry-run guidance exists before deployment release
+  - #276 deployment target/runtime config contract is accepted before #277-#281
   - local dev remains runnable without VPS-specific assumptions
 ```
 

--- a/docs/06-epic-roadmap.md
+++ b/docs/06-epic-roadmap.md
@@ -548,22 +548,39 @@ Goal: make the app reachable on a real phone and maintainable on a personal VPS.
 Roadmap status:
 
 ```text
-Blocked / planning. Epic #27 has moved after M11 Localization, M12 Minimal Auth,
-and M13 Practice Modes. It may now be decomposed by Architect, but no real VPS,
-DNS, secret, deployment config, or private SQLite mutation is authorized without
-an explicit Human gate.
+Blocked while child work proceeds. Epic #27 has moved after M11 Localization,
+M12 Minimal Auth, and M13 Practice Modes. It has been decomposed into M14 child
+issues. #276 is the only released child issue; #277-#282 remain blocked until
+the deployment target/runtime config contract is accepted.
+
+No real VPS, DNS, secret, deployment config, or private SQLite mutation is
+authorized without an explicit Human gate.
 ```
 
-Expected child issue areas:
+Child issues:
 
 ```text
-deployment target/runtime config contract
-production auth/origin/CORS/secret hardening
-VPS install and systemd service runbook
-frontend build and reverse-proxy routing
-SQLite backup and restore dry-run verification
-deployment smoke checks and rollback checklist
-M14 readiness review and human deployment gate
+#276 [P0] Deployment target and runtime config contract - released to Implementer
+#277 [P1] Production auth, origin, CORS, and secret hardening - blocked
+#278 [P1] VPS install and systemd runbook - blocked
+#279 [P2] Frontend build and reverse-proxy routing contract - blocked
+#280 [P2] SQLite backup and restore dry-run verification - blocked
+#281 [P3] Deployment smoke and rollback checklist - blocked
+#282 [P4] VPS deployment readiness review and human deployment gate - blocked
+```
+
+Dependency graph:
+
+```text
+#276 Deployment target/runtime config contract
+  -> #277 production auth/origin/CORS/secret hardening
+  -> #278 VPS install and systemd runbook
+  -> #279 frontend build and reverse-proxy routing
+  -> #280 SQLite backup/restore dry-run
+  -> #281 deployment smoke and rollback checklist
+
+#277 + #278 + #279 + #280 + #281
+  -> #282 readiness review and human deployment gate
 ```
 
 Acceptance:

--- a/docs/06-epic-roadmap.md
+++ b/docs/06-epic-roadmap.md
@@ -18,9 +18,10 @@ Tiny IPA uses Epic issues as the primary planning and multi-agent coordination u
 | M9 UK Accent Compare and Specialty Practice | #28 | Done |
 | M10 UX Research and Practice Experience Optimization | #102 | Done |
 | M11 Localization and Configurable UI Language | #209 | Done |
-| M12 Minimal Auth and Multi-user Data Isolation | #210 | Ready for decomposition |
-| M13 VPS Deployment and Backup | #27 | Blocked |
-| M14 Account Management and Admin UX | #212 | Backlog / Deferred |
+| M12 Minimal Auth and Multi-user Data Isolation | #210 | Done |
+| M13 Expand Practice Modes: Choose Word and Type Word | #256 | Done |
+| M14 VPS Deployment and Backup | #27 | Blocked / Planning |
+| M15 Account Management and Admin UX | #212 | Backlog / Deferred |
 
 ## M0：Feasibility and Architecture Skeleton
 
@@ -439,8 +440,10 @@ personal VPS deployment exposes Tiny IPA beyond a single local default user.
 Roadmap status:
 
 ```text
-Decomposed. #238 is the released P0 contract/test-matrix issue. #239 through
-#244 remain dependency-gated until #238 is reviewed and accepted.
+Done. M12 has been merged to main. Minimal personal-VPS auth, current-user
+resolution, per-user data isolation, localized auth UX, default-owner dry-run
+guidance, and M12 readiness evidence are complete for the M14 deployment
+prerequisite boundary.
 ```
 
 Expected child issue areas:
@@ -494,28 +497,73 @@ Depends on: #209 for localization/copy boundary before learner-facing auth UI wo
 Completion handoff: batch checkpoint
 ```
 
-## M13：VPS Deployment and Backup
+## M13：Expand Practice Modes: Choose Word and Type Word
+
+Goal: expand practice beyond the original Word-to-IPA loop while keeping answer
+grading, distractor quality, and mode-specific UX safe.
+
+Roadmap status:
+
+```text
+Done. M13 has been merged to main. Word-to-IPA remains the default safe mode.
+IPA-to-word is available for newly created regular groups. Type-word remains
+unlaunched behind its accepted-answer contract.
+```
+
+Accepted scope:
+
+```text
+question-mode API contract for choose_ipa, choose_word, and deferred type_word
+server-side choose_word generation and grading
+runtime choose_word distractor scorer and quality report
+generic frontend renderer for choose_ipa and choose_word
+Settings mode selector and Today current/pending mode state
+route-mocked and real-backend M13 walkthrough evidence
+```
+
+Acceptance:
+
+```text
+Word-to-IPA remains compatible and default
+IPA-to-word shows IPA first and word choices
+choose_word does not leak the target word, meaning, or audio before submit
+active normal groups keep their original mode when Settings changes mid-group
+next newly created normal group uses the selected mode
+review/focus/specialty practice remain Word-to-IPA for this slice
+Type-word is not visible or launched
+```
+
+Boundaries:
+
+```text
+do not launch Type-word until a future implementation contract is accepted
+do not mutate source content, meaning_zh, or content taxonomy under practice modes
+do not fold deployment, account/admin UX, or runtime config changes into this Epic
+```
+
+## M14：VPS Deployment and Backup
 
 Goal: make the app reachable on a real phone and maintainable on a personal VPS.
 
 Roadmap status:
 
 ```text
-Blocked. Epic #27 has moved after #209 Localization and #210 Minimal Auth /
-Multi-user Data Isolation. It should not be decomposed or released to
-Implementer until those prerequisites define the language, current-user,
-auth-secret, session-cookie, and user-data backup boundaries.
+Blocked / planning. Epic #27 has moved after M11 Localization, M12 Minimal Auth,
+and M13 Practice Modes. It may now be decomposed by Architect, but no real VPS,
+DNS, secret, deployment config, or private SQLite mutation is authorized without
+an explicit Human gate.
 ```
 
 Expected child issue areas:
 
 ```text
-Nginx
-HTTPS
-systemd backend service
-frontend build deployment
-SQLite backup and restore
-deployment.md
+deployment target/runtime config contract
+production auth/origin/CORS/secret hardening
+VPS install and systemd service runbook
+frontend build and reverse-proxy routing
+SQLite backup and restore dry-run verification
+deployment smoke checks and rollback checklist
+M14 readiness review and human deployment gate
 ```
 
 Acceptance:
@@ -539,7 +587,7 @@ do not mutate real SQLite data, secrets, DNS, VPS runtime, or deployment config
 without explicit Human approval
 ```
 
-## M14：Account Management and Admin UX
+## M15：Account Management and Admin UX
 
 Goal: preserve broader account and admin UX ideas as a deferred post-deploy
 roadmap placeholder, without mixing them into minimal auth or deployment.


### PR DESCRIPTION
## Summary
- Mark M12 and M13 as done in the roadmap.
- Add the accepted M13 practice modes roadmap section.
- Shift VPS Deployment and Backup to M14 and Account/Admin UX to M15.
- Update M14 child issue status to match current durable state: #276 released, #277-#282 blocked.
- Update `docs/05-data-api-contracts.md` so deployment prerequisites include M11/M12/M13 and the #276 runtime config gate.

## Verification
- `git diff --check` passed.
- `tools/agents/agent-audit` passed clean.
- `tools/agents/agent-inbox all` shows #276 under `needs:implementer`, #284 under `needs:reviewer`, and #277-#282/#27/#212 blocked.

## Scope
- Docs/planning only.
- No deployment/runtime config mutation, real VPS action, DB mutation, or M14 implementation.

Related: #27, #276