### PR TITLE
[#284] Add Tester role routing support

### DIFF
--- a/docs/08-multi-agent-epic-workflow.md
+++ b/docs/08-multi-agent-epic-workflow.md
@@ -26,6 +26,21 @@ The Implementer owns:
 - responding to review feedback
 - posting completion comments
 
+### Tester
+
+The Tester owns objective evidence when testing depth is the bottleneck:
+
+- test plans and test matrices
+- route-mocked versus real-backend evidence boundaries
+- temp-DB, browser, runtime, deployment-readiness, and regression evidence
+- residual-risk and coverage-gap reporting
+
+Tester does not approve, reject, merge, close, or replace Reviewer, Architect,
+or Human acceptance. Use Tester selectively for risky user-visible or stateful
+work; low-risk docs, helpers, or narrow implementation changes can still go
+directly from Implementer to Reviewer or Architect when ordinary evidence is
+enough.
+
 These are roles, not identities. The same agent can play different roles in different turns, but role expectations should be explicit.
 
 ## Work Hierarchy
@@ -222,6 +237,7 @@ Use exactly one primary next-action label on an active issue or PR unless the wo
 ```text
 needs:architect   Architect should plan, review, merge, or make a readiness decision
 needs:implementer Implementer should code, fix, verify, or update a PR
+needs:tester      Tester should plan or gather objective test evidence
 needs:user        User decision or clarification is required
 needs:ci          Waiting for CI or automated checks
 needs:merge       Reviewed and ready to merge
@@ -232,11 +248,11 @@ Allowed use by issue type:
 
 ```text
 type:task:
-  may use needs:implementer, needs:architect, needs:user, needs:ci, needs:merge, blocked
+  may use needs:implementer, needs:tester, needs:architect, needs:user, needs:ci, needs:merge, blocked
 
 type:epic:
   may use needs:architect, needs:user, blocked
-  should not use needs:implementer, needs:ci, or needs:merge
+  should not use needs:implementer, needs:tester, needs:ci, or needs:merge
 ```
 
 Epic handoff labels mean the next action is coordination-level work:
@@ -261,6 +277,13 @@ Implementer starts task:
 Implementer opens PR:
   add needs:architect
   move issue/PR to In Review
+
+Implementer finishes evidence-sensitive work:
+  add needs:tester when the contract says Tester evidence is required
+
+Tester completes evidence pass:
+  remove needs:tester
+  add needs:reviewer, needs:architect, or needs:implementer per contract
 
 Architect requests changes:
   remove needs:architect
@@ -290,6 +313,10 @@ tools/agents/agent-inbox implementer
 
 # Implementer queue with dependency gates
 tools/agents/agent-ready-queue
+
+# Tester evidence queue
+tools/agents/agent-inbox tester
+tools/agents/agent-ready-queue --role tester
 
 # User-decision queue
 tools/agents/agent-inbox user

--- a/docs/09-role-generic-agent-helpers.md
+++ b/docs/09-role-generic-agent-helpers.md
@@ -91,6 +91,10 @@ The same model must support at least these flows:
 ```text
 Architect -> Implementer
 Implementer -> Reviewer
+Implementer -> Tester
+Tester -> Reviewer
+Tester -> Implementer
+Tester -> Architect
 Reviewer -> Implementer
 Reviewer -> Architect
 Architect -> Reviewer
@@ -104,6 +108,13 @@ the Architect, and it may review code, QA evidence, docs, or integration risk.
 Final acceptance can still belong to the Architect when the issue contract says
 so.
 
+`Tester` is also first-class when evidence quality is the bottleneck. Tester
+plans or gathers objective evidence, but does not approve, reject, merge, close,
+or replace Reviewer, Architect, or Human acceptance. Do not require every old
+project or every low-risk issue to adopt Tester; use it when the repo already
+has role helpers or when user-visible state, browser flows, real-backend
+uncertainty, runtime readiness, or regression risk justify the extra handoff.
+
 ## Core Concepts
 
 ### Role
@@ -115,6 +126,7 @@ Examples:
 ```text
 architect
 implementer
+tester
 reviewer
 user
 ci
@@ -184,6 +196,42 @@ checkpoint` keeps child issues from becoming per-issue review stops.
 
 The helper must fail closed when required contract fields are missing or when a
 handoff value is unknown.
+
+### Testing Contract
+
+Use a Testing Contract when evidence risk is high enough to route through
+Tester or to require explicit evidence planning. It is optional, not a required
+field for every issue.
+
+Recommended shape:
+
+```markdown
+## Testing Contract
+
+Tester trigger: yes / no
+Evidence layers:
+- static/contract:
+- backend integration:
+- route-mocked browser:
+- real-backend/temp-DB browser:
+- dogfood/adopter trial:
+- human trial:
+Route-mock sufficiency: sufficient / insufficient / not applicable
+Real-backend requirement: required / not required, because ...
+Negative assertions:
+- ...
+Known gaps:
+- ...
+Residual risks:
+- ...
+Tester handoff: to:reviewer | to:architect | to:implementer | none
+```
+
+Trigger Tester for user-visible state chains, Settings/control effects,
+auth/data isolation, content import/scheduler behavior, deployment readiness,
+or cases where route mocks, convenient fixtures, or unit tests can miss the
+real behavior. Skip Tester for small low-risk docs/scripts changes when
+Implementer and Reviewer evidence is enough.
 
 ## Helper Surface
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -33,6 +33,10 @@ tools/agents/agent-inbox architect
 # Implementer: coding, fixes, verification
 tools/agents/agent-inbox implementer
 
+# Tester: test planning, evidence execution, gaps, residual risks
+tools/agents/agent-inbox tester
+tools/agents/agent-ready-queue --role tester
+
 # Implementer queue with dependency gates
 tools/agents/agent-ready-queue
 
@@ -44,8 +48,10 @@ tools/agents/agent-inbox merge
 ```
 
 The examples above are the roles currently used most often in Tiny IPA. The
-helper model is intentionally role-generic: future projects or later phases may
-add roles such as `reviewer` without changing the core inbox pattern.
+helper model is intentionally role-generic: this repo now includes `tester` for
+objective evidence planning and execution, but Tester is optional per issue.
+Use it when evidence quality is the bottleneck; do not force a Tester gate for
+small low-risk work where Implementer and Reviewer evidence is enough.
 
 When handing work to another role, update the label and add a short issue or PR comment explaining the next action.
 
@@ -227,6 +233,7 @@ Handoff labels must match the current owner of the next action:
 
 ```text
 needs:implementer -> implementer should pick up or fix a child issue or PR
+needs:tester      -> tester should plan or gather objective test evidence
 needs:architect   -> architect should review, merge, or decide readiness
 needs:user        -> user decision is needed
 needs:ci          -> checks are still running

--- a/tools/agents/README.md
+++ b/tools/agents/README.md
@@ -16,13 +16,16 @@ jq
 ```bash
 tools/agents/agent-inbox architect
 tools/agents/agent-inbox implementer
+tools/agents/agent-inbox tester
 tools/agents/agent-inbox reviewer
 tools/agents/agent-role-config
 tools/agents/agent-permission-smoke
 tools/agents/agent-ready-queue
+tools/agents/agent-ready-queue --role tester
 tools/agents/agent-ready-queue --role reviewer
 tools/agents/agent-pickup 63 --role implementer
 tools/agents/agent-handoff 64 --from implementer
+tools/agents/agent-handoff 64 --from tester --to reviewer
 tools/agents/agent-handoff 64 --from reviewer --to implementer
 tools/agents/agent-comment issue 86 --body-file /tmp/comment.md
 tools/agents/agent-batch-accept --epic 83 --issue 86 --issue 87
@@ -54,7 +57,8 @@ open issues once and groups the configured primary labels locally, instead of
 making one network call per label.
 
 `agent-ready-queue` defaults to the configured `implementer` role and also
-accepts `--role <role>` for other configured role inboxes, such as `reviewer`.
+accepts `--role <role>` for other configured role inboxes, such as `tester` or
+`reviewer`.
 It extracts `Execution Contract` lines so an agent can see which ready issues
 are immediately startable and which are waiting on `Depends on`. It reads both
 issue bodies and issue comments because many
@@ -85,6 +89,14 @@ label changes plus a compact completion/handoff comment template. Use
 `--to <role|none|batch>` to override the contract route for explicit handoffs.
 The dry-run path does not mutate labels, post comments, close issues, or read
 Project v2. `--apply` is not implemented in the current prototype.
+
+`tester` is a configured evidence role. Use `needs:tester` only when evidence
+quality is the bottleneck, such as user-visible state chains, browser flows,
+route-mocked versus real-backend uncertainty, temp-DB/runtime/deployment
+readiness, or regression risk. Tester plans or gathers evidence and then hands
+off to Reviewer, Architect, Implementer, or Human according to the issue
+contract. Tester does not approve, reject, merge, close, or replace Reviewer,
+Architect, or Human acceptance.
 
 `agent-comment` is a REST-first durable comment helper. It supports explicit
 `issue` and `pr` targets by number, requires `--body-file` input, previews by

--- a/tools/agents/_lib.sh
+++ b/tools/agents/_lib.sh
@@ -17,9 +17,10 @@ agent_role_config_path() {
 }
 
 agent_set_default_role_config() {
-  AGENT_ROLES=(architect implementer reviewer user ci merge)
+  AGENT_ROLES=(architect implementer tester reviewer user ci merge)
   AGENT_ROLE_LABEL_architect="needs:architect"
   AGENT_ROLE_LABEL_implementer="needs:implementer"
+  AGENT_ROLE_LABEL_tester="needs:tester"
   AGENT_ROLE_LABEL_reviewer="needs:reviewer"
   AGENT_ROLE_LABEL_user="needs:user"
   AGENT_ROLE_LABEL_ci="needs:ci"
@@ -27,6 +28,7 @@ agent_set_default_role_config() {
   AGENT_PRIMARY_NEXT_LABELS=(
     needs:architect
     needs:implementer
+    needs:tester
     needs:reviewer
     needs:user
     needs:ci

--- a/tools/agents/role-routing.conf
+++ b/tools/agents/role-routing.conf
@@ -3,10 +3,11 @@
 # This file is sourced by Bash. Keep values simple: arrays of role names and
 # labels, plus AGENT_ROLE_LABEL_<role> entries for each role.
 
-AGENT_ROLES=(architect implementer reviewer user ci merge)
+AGENT_ROLES=(architect implementer tester reviewer user ci merge)
 
 AGENT_ROLE_LABEL_architect="needs:architect"
 AGENT_ROLE_LABEL_implementer="needs:implementer"
+AGENT_ROLE_LABEL_tester="needs:tester"
 AGENT_ROLE_LABEL_reviewer="needs:reviewer"
 AGENT_ROLE_LABEL_user="needs:user"
 AGENT_ROLE_LABEL_ci="needs:ci"
@@ -15,6 +16,7 @@ AGENT_ROLE_LABEL_merge="needs:merge"
 AGENT_PRIMARY_NEXT_LABELS=(
   needs:architect
   needs:implementer
+  needs:tester
   needs:reviewer
   needs:user
   needs:ci

--- a/tools/agents/test-agent-audit
+++ b/tools/agents/test-agent-audit
@@ -106,6 +106,13 @@ if [[ "$*" == *"/issues"* && "$*" == *"state=open"* ]]; then
     "labels": [{"name": "type:task"}, {"name": "needs:implementer"}]
   },
   {
+    "number": 9,
+    "title": "Tester valid route",
+    "html_url": "https://example.test/issues/9",
+    "body": "## Final Execution Contract\n\nCompletion handoff: to:reviewer\n",
+    "labels": [{"name": "type:task"}, {"name": "needs:tester"}]
+  },
+  {
     "number": 8,
     "title": "Handoff completed route",
     "html_url": "https://example.test/issues/8",
@@ -138,5 +145,6 @@ grep -Fq "handoff: MISSING (missing)" <<< "$output"
 ! grep -Fq "#3 Batch checkpoint" <<< "$output"
 ! grep -Fq "#4 Picked up without route" <<< "$output"
 ! grep -Fq "#8 Handoff completed route" <<< "$output"
+! grep -Fq "#9 Tester valid route" <<< "$output"
 
 printf 'agent-audit fixture checks passed\n'

--- a/tools/agents/test-handoff
+++ b/tools/agents/test-handoff
@@ -52,6 +52,8 @@ contract() {
 case "$*" in
   *"/issues/10"*) issue_json 10 "Bare role contract" "$(contract implementer architect architect architect)" "type:task" ;;
   *"/issues/11"*) issue_json 11 "Same route" "$(contract reviewer none architect to:reviewer)" "type:task,needs:reviewer" ;;
+  *"/issues/12"*) issue_json 12 "Implementer to tester" "$(contract implementer tester architect to:tester)" "type:task,needs:implementer" ;;
+  *"/issues/13"*) issue_json 13 "Tester to reviewer" "$(contract tester reviewer architect to:reviewer)" "type:task,needs:tester" ;;
   *"/issues/1"*) issue_json 1 "Implementer to architect" "$(contract implementer architect architect to:architect)" "type:task" ;;
   *"/issues/2"*) issue_json 2 "Implementer to reviewer" "$(contract implementer reviewer architect to:architect)" "type:task,needs:implementer" ;;
   *"/issues/3"*) issue_json 3 "Reviewer to implementer" "$(contract reviewer none architect to:architect)" "type:task,needs:reviewer" ;;
@@ -80,6 +82,18 @@ grep -Fq "From: implementer (needs:implementer)" <<< "$impl_review"
 grep -Fq "Target: to:reviewer (needs:reviewer)" <<< "$impl_review"
 grep -Fq "remove needs:implementer" <<< "$impl_review"
 grep -Fq "add needs:reviewer" <<< "$impl_review"
+
+impl_tester="$("$fixture_root/tools/agents/agent-handoff" 12 --from implementer)"
+grep -Fq "From: implementer (needs:implementer)" <<< "$impl_tester"
+grep -Fq "Target: to:tester (needs:tester)" <<< "$impl_tester"
+grep -Fq "remove needs:implementer" <<< "$impl_tester"
+grep -Fq "add needs:tester" <<< "$impl_tester"
+
+tester_review="$("$fixture_root/tools/agents/agent-handoff" 13 --from tester)"
+grep -Fq "From: tester (needs:tester)" <<< "$tester_review"
+grep -Fq "Target: to:reviewer (needs:reviewer)" <<< "$tester_review"
+grep -Fq "remove needs:tester" <<< "$tester_review"
+grep -Fq "add needs:reviewer" <<< "$tester_review"
 
 review_impl="$("$fixture_root/tools/agents/agent-handoff" 3 --from reviewer --to implementer)"
 grep -Fq "Target: to:implementer (needs:implementer)" <<< "$review_impl"

--- a/tools/agents/test-pickup
+++ b/tools/agents/test-pickup
@@ -58,6 +58,7 @@ fi
 contract_ok=$'## Final Execution Contract\n\nBranch strategy: epic integration branch\nBase branch: `epic/x`\nTarget PR base: `epic/x`\nOwner role: implementer\nReview role: architect\nAcceptance role: architect\nDepends on: none\nCompletion handoff: to:architect\n'
 contract_reviewer=$'## Final Execution Contract\n\nBranch strategy: epic integration branch\nBase branch: `epic/x`\nTarget PR base: `epic/x`\nOwner role: reviewer\nReview role: none\nAcceptance role: architect\nDepends on: #9\nCompletion handoff: batch checkpoint\n'
 contract_blocked=$'## Final Execution Contract\n\nBranch strategy: epic integration branch\nBase branch: `epic/x`\nTarget PR base: `epic/x`\nOwner role: implementer\nReview role: architect\nAcceptance role: architect\nDepends on: #10\nCompletion handoff: to:architect\n'
+contract_tester=$'## Final Execution Contract\n\nBranch strategy: issue branch to main\nBase branch: `main`\nTarget PR base: `main`\nOwner role: tester\nReview role: reviewer\nAcceptance role: architect\nDepends on: none\nCompletion handoff: to:reviewer\n'
 
 case "$*" in
   *"/issues/1"*) issue_json 1 "Implementer pickup" "$contract_ok" "type:task,needs:implementer" ;;
@@ -66,6 +67,7 @@ case "$*" in
   *"/issues/4"*) issue_json 4 "Missing route" "$contract_ok" "type:task,needs:architect" ;;
   *"/issues/5"*) issue_json 5 "Blocked dependency" "$contract_blocked" "type:task,needs:implementer" ;;
   *"/issues/6"*) issue_json 6 "Released dependency" "$contract_blocked" "type:task,needs:architect" ;;
+  *"/issues/7"*) issue_json 7 "Tester pickup" "$contract_tester" "type:task,needs:tester" ;;
   *) printf 'unexpected fake gh call: %s\n' "$*" >&2; exit 21 ;;
 esac
 SH
@@ -81,6 +83,11 @@ reviewer_output="$("$fixture_root/tools/agents/agent-pickup" 2 --role reviewer)"
 grep -Fq "Role: reviewer (needs:reviewer)" <<< "$reviewer_output"
 grep -Fq "Work mode: review/decision; no coding branch implied" <<< "$reviewer_output"
 grep -Fq "Completion handoff: batch checkpoint" <<< "$reviewer_output"
+
+tester_output="$("$fixture_root/tools/agents/agent-pickup" 7 --role tester)"
+grep -Fq "Role: tester (needs:tester)" <<< "$tester_output"
+grep -Fq "Work mode: review/decision; no coding branch implied" <<< "$tester_output"
+grep -Fq "Completion handoff: to:reviewer" <<< "$tester_output"
 
 if "$fixture_root/tools/agents/agent-pickup" 1 --role ghost >/dev/null 2>&1; then
   printf 'unknown role unexpectedly succeeded\n' >&2

--- a/tools/agents/test-ready-queue
+++ b/tools/agents/test-ready-queue
@@ -49,6 +49,13 @@ if [[ "$*" == *"-X GET"* && "$*" == *"/issues"* && "$*" == *"state=open"* ]]; th
     "labels": [{"name": "type:task"}, {"name": "needs:reviewer"}]
   },
   {
+    "number": 4,
+    "title": "Tester evidence task",
+    "html_url": "https://example.test/issues/4",
+    "body": "## Final Execution Contract\n\nBranch strategy: issue branch to main\nBase branch: `main`\nTarget PR base: `main`\nOwner role: tester\nReview role: reviewer\nAcceptance role: architect\nDepends on: none\nCompletion handoff: to:reviewer\n",
+    "labels": [{"name": "type:task"}, {"name": "needs:tester"}]
+  },
+  {
     "number": 3,
     "title": "Architect task",
     "html_url": "https://example.test/issues/3",
@@ -84,6 +91,16 @@ grep -Fq "Review role: none" <<< "$reviewer_output"
 grep -Fq "Gate: startable" <<< "$reviewer_output"
 grep -Fq "Completion handoff: batch checkpoint" <<< "$reviewer_output"
 ! grep -Fq "labels=" "$tmp_dir/reviewer-gh.log"
+
+FAKE_GH_LOG="$tmp_dir/tester-gh.log" tester_output="$(
+  FAKE_GH_LOG="$tmp_dir/tester-gh.log" "$fixture_root/tools/agents/agent-ready-queue" --role tester
+)"
+grep -Fq "#4 Tester evidence task" <<< "$tester_output"
+! grep -Fq "#1 Implementer task" <<< "$tester_output"
+grep -Fq "Owner role: tester" <<< "$tester_output"
+grep -Fq "Completion handoff: to:reviewer" <<< "$tester_output"
+grep -Fq "Gate: startable" <<< "$tester_output"
+! grep -Fq "labels=" "$tmp_dir/tester-gh.log"
 
 if "$fixture_root/tools/agents/agent-ready-queue" --role ghost >/dev/null 2>&1; then
   printf 'unknown role unexpectedly succeeded\n' >&2

--- a/tools/agents/test-role-routing-config
+++ b/tools/agents/test-role-routing-config
@@ -13,13 +13,15 @@ check() {
   "$@"
 }
 
-check "built-in fallback includes reviewer" \
+check "built-in fallback includes tester and reviewer" \
   env AGENT_ROLE_ROUTING_CONFIG="$tmp_dir/missing.conf" ROOT="$root" bash -c '
     set -euo pipefail
     source "$ROOT/tools/agents/_lib.sh"
+    [[ "$(agent_role_label_for_role tester)" == "needs:tester" ]]
     [[ "$(agent_role_label_for_role reviewer)" == "needs:reviewer" ]]
     agent_require_primary_next_label needs:architect
     agent_require_primary_next_label needs:implementer
+    agent_require_primary_next_label needs:tester
     agent_require_primary_next_label needs:reviewer
   '
 
@@ -101,6 +103,13 @@ if [[ "$*" == *"-X GET"* && "$*" == *"/issues"* && "$*" == *"state=open"* ]]; th
     "html_url": "https://example.test/issues/2",
     "updated_at": "2026-06-10T00:00:00Z",
     "labels": [{"name": "needs:reviewer"}]
+  },
+  {
+    "number": 3,
+    "title": "Tester task",
+    "html_url": "https://example.test/issues/3",
+    "updated_at": "2026-06-10T00:00:00Z",
+    "labels": [{"name": "needs:tester"}]
   }
 ]
 JSON
@@ -108,7 +117,7 @@ JSON
 fi
 
 if [[ "$*" == *"repos/farmerhunter/tiny-ipa/issues/60"* && "$*" == *"--jq [.labels[].name]"* ]]; then
-  printf '["needs:architect","needs:implementer","needs:reviewer","blocked","area:tooling"]\n'
+  printf '["needs:architect","needs:implementer","needs:tester","needs:reviewer","blocked","area:tooling"]\n'
   exit 0
 fi
 
@@ -131,9 +140,11 @@ check "agent-inbox all groups configured labels with one issue fetch" \
     set -euo pipefail
     output="$("$1/tools/agents/agent-inbox" all)"
     grep -Fq "== needs:architect ==" <<< "$output"
+    grep -Fq "== needs:tester ==" <<< "$output"
     grep -Fq "== needs:reviewer ==" <<< "$output"
     grep -Fq "#1 Architect task" <<< "$output"
     grep -Fq "#2 Reviewer task" <<< "$output"
+    grep -Fq "#3 Tester task" <<< "$output"
     [[ "$(wc -l < "$FAKE_GH_LOG" | tr -d " ")" == "1" ]]
   ' bash "$fixture_root"
 
@@ -143,6 +154,7 @@ check "agent-label set-next removes other configured primary labels" \
     "$1/tools/agents/agent-label" 60 set-next needs:reviewer >/dev/null
     grep -Fq "/issues/60/labels/needs:architect" "$FAKE_GH_LOG"
     grep -Fq "/issues/60/labels/needs:implementer" "$FAKE_GH_LOG"
+    grep -Fq "/issues/60/labels/needs:tester" "$FAKE_GH_LOG"
     grep -Fq "/issues/60/labels/blocked" "$FAKE_GH_LOG"
     ! grep -Fq "/issues/60/labels/needs:reviewer" "$FAKE_GH_LOG"
     ! grep -Fq "labels[]=needs:reviewer" "$FAKE_GH_LOG"


### PR DESCRIPTION
## Summary

Implements #284 by adding repo-local Tester role routing support while keeping Tester optional and evidence-only.

Changes:
- Adds `tester=needs:tester` to role routing config and built-in fallback.
- Extends helper fixture tests for inbox, ready queue, pickup, handoff, and audit behavior.
- Documents Tester routing, optional Testing Contract usage, and handoff expectations in existing workflow/helper docs.

Scope boundaries:
- No runtime app code changes.
- No default Tester routing imposed on ordinary issues.
- No Reviewer, Architect, or Human gate replacement.

Verification:
- `tools/agents/test-role-routing-config && tools/agents/test-ready-queue && tools/agents/test-pickup && tools/agents/test-handoff && tools/agents/test-agent-audit`
- `tools/agents/agent-role-config`
- `tools/agents/agent-ready-queue --role tester`
- `tools/agents/agent-audit`
- `tools/agents/agent-inbox all`
- `git diff --check`