### PR TITLE
[#276] Add deployment runtime config contract

### DIFF
--- a/backend/tests/test_m14_deployment_contract.py
+++ b/backend/tests/test_m14_deployment_contract.py
@@ -1,0 +1,71 @@
+from pathlib import Path
+
+import pytest
+
+DOC = Path(__file__).resolve().parents[2] / "docs" / "06-epic-roadmap.md"
+
+
+def _contract_text() -> str:
+    return " ".join(DOC.read_text(encoding="utf-8").split())
+
+
+@pytest.mark.parametrize(
+    "phrase",
+    [
+        "Deployment Target and Runtime Config Contract",
+        "Human input checklist",
+        "Runtime config variables",
+        "Production config must fail closed",
+        "Optional VPS inventory plan",
+        "Forbidden in #276",
+        "Deployment verification matrix",
+    ],
+)
+def test_m14_deployment_contract_sections_exist(phrase: str) -> None:
+    assert phrase in _contract_text()
+
+
+@pytest.mark.parametrize(
+    "runtime_variable",
+    [
+        "TINY_IPA_ENV",
+        "TINY_IPA_DB_PATH",
+        "TINY_IPA_SESSION_SECRET",
+        "TINY_IPA_COOKIE_SECURE",
+        "TINY_IPA_ALLOWED_ORIGINS",
+        "VITE_API_BASE_URL",
+        "TINY_IPA_AUDIO_ROOT",
+        "TINY_IPA_STATIC_ROOT",
+        "TINY_IPA_BACKEND_PORT",
+        "TINY_IPA_LOG_DIR",
+        "TINY_IPA_HEALTH_PATH",
+    ],
+)
+def test_m14_runtime_config_inventory_covers_required_variables(
+    runtime_variable: str,
+) -> None:
+    assert runtime_variable in _contract_text()
+
+
+@pytest.mark.parametrize(
+    "boundary",
+    [
+        "production without TINY_IPA_SESSION_SECRET -> refuse startup",
+        "production with TINY_IPA_COOKIE_SECURE=false -> refuse startup",
+        "production with wildcard credentialed CORS -> refuse startup",
+        "production with relative or repo-local DB path -> refuse startup",
+        "ssh to the VPS without explicit Human authorization",
+        "private SQLite read, copy, migration, restore, or mutation",
+    ],
+)
+def test_m14_deployment_contract_fails_closed_for_production_boundaries(
+    boundary: str,
+) -> None:
+    assert boundary in _contract_text()
+
+
+@pytest.mark.parametrize("child_issue", ["#277", "#278", "#279", "#280", "#281", "#282"])
+def test_m14_deployment_contract_covers_follow_up_verification_matrix(
+    child_issue: str,
+) -> None:
+    assert child_issue in _contract_text()

--- a/docs/06-epic-roadmap.md
+++ b/docs/06-epic-roadmap.md
@@ -539,6 +539,129 @@ do not mutate real SQLite data, secrets, DNS, VPS runtime, or deployment config
 without explicit Human approval
 ```
 
+### Deployment Target and Runtime Config Contract
+
+#276 is a planning and evidence gate. It defines the deployment contract for a
+personal VPS, but it does not authorize SSH execution, production secret writes,
+DNS/TLS changes, service starts, systemd/Nginx mutation, private SQLite access,
+or deployment rollout.
+
+Deployment target assumptions:
+
+```text
+target type: personal VPS or equivalent single-host Linux server
+provider binding: none; business logic must not depend on a VPS provider
+runtime shape: Nginx/reverse proxy -> frontend static files + backend API
+backend persistence: SQLite file outside the source checkout
+audio/static assets: served as static files, preferably by the reverse proxy
+operator model: one trusted owner/operator; real host actions remain Human-gated
+```
+
+Human input checklist before later M14 implementation:
+
+| Topic | Required answer before action |
+| --- | --- |
+| Domain | production hostname and whether a staging hostname exists |
+| TLS | certificate source and renewal owner |
+| VPS access | SSH host/user, whether read-only inventory is allowed, and whether sudo is allowed |
+| Install preference | system package manager, Python/Node versions, checkout directory, service user |
+| Data policy | production DB path, backup destination, retention, and restore test expectations |
+| Secrets | who generates/stores `TINY_IPA_SESSION_SECRET`; repo must not generate/write it in #276 |
+| Rollback | acceptable downtime, release rollback method, and DB rollback boundary |
+| Logs | log directory, retention expectation, and whether logs may contain user identifiers |
+
+Runtime config variables for follow-up issues:
+
+| Variable | Local dev behavior | Production requirement |
+| --- | --- | --- |
+| `TINY_IPA_ENV` | defaults to `development` | must be explicitly `production` |
+| `TINY_IPA_DB_PATH` | may point to a local/temp SQLite file | required absolute path outside repo checkout |
+| `TINY_IPA_SESSION_SECRET` | may use documented local-only value | required high-entropy secret from Human/operator channel |
+| `TINY_IPA_COOKIE_SECURE` | may be `false` on `localhost` | must be `true` |
+| `TINY_IPA_COOKIE_SAMESITE` | `lax` unless tests require otherwise | `lax` or stricter, documented with auth tests |
+| `TINY_IPA_ALLOWED_ORIGINS` | may include localhost dev origins | required exact HTTPS origin list; no wildcard with cookies |
+| `VITE_API_BASE_URL` | dev server may point at local backend | must match deployed API origin/path |
+| `TINY_IPA_AUDIO_ROOT` | may use repo `audio/` | required readable static asset directory |
+| `TINY_IPA_STATIC_ROOT` | optional during Vite dev | required frontend build directory for static serving |
+| `TINY_IPA_BACKEND_HOST` | localhost is allowed | loopback or private interface behind reverse proxy |
+| `TINY_IPA_BACKEND_PORT` | any free local port | fixed documented service port |
+| `TINY_IPA_LOG_DIR` | may be stdout/temp logs | required writable app log directory or journald-only decision |
+| `TINY_IPA_HEALTH_PATH` | `/api/health` | `/api/health`, unauthenticated, no private data |
+
+Production config must fail closed:
+
+```text
+production without TINY_IPA_SESSION_SECRET -> refuse startup
+production with TINY_IPA_COOKIE_SECURE=false -> refuse startup
+production with wildcard credentialed CORS -> refuse startup
+production with relative or repo-local DB path -> refuse startup
+production with local-dev auth bootstrap/bypass enabled -> refuse startup
+production with missing explicit allowed origins -> refuse startup
+```
+
+Local development remains intentionally easier:
+
+```text
+localhost origins are allowed
+local SQLite paths are allowed
+secure cookies may be disabled on localhost
+dev-user bootstrap may create a normal local user only when explicitly requested
+local dev must not require Nginx, systemd, DNS, TLS, or VPS-only paths
+```
+
+Safe repo automation versus Human-gated host action:
+
+| Category | Allowed in repo automation | Human-gated on real VPS |
+| --- | --- | --- |
+| Config | schema/lint/dry-run checks for required env vars | writing production env files or secrets |
+| Backend | local temp-DB health/import/auth smoke tests | starting/stopping production service |
+| Frontend | local build and static path checks | editing deployed web root |
+| Reverse proxy | template/checklist docs | mutating Nginx/Caddy config or reloading proxy |
+| TLS/DNS | checklist and validation commands | changing DNS records or certificates |
+| Backup | temp-fixture backup/restore dry-run | reading/copying private production SQLite |
+| Host inventory | documented optional read-only probe plan | SSH execution without explicit approval |
+
+Optional VPS inventory plan, only after separate Human authorization:
+
+| Probe | Classification | Purpose |
+| --- | --- | --- |
+| `uname -a` | read-only | kernel/architecture note |
+| `cat /etc/os-release` | read-only | OS/version support note |
+| `nproc` / `free -h` / `df -h` | read-only | CPU/RAM/disk sizing |
+| `command -v python3 node pnpm nginx systemctl sqlite3` | read-only | runtime availability |
+| `python3 --version` / `node --version` / `pnpm --version` | read-only | version evidence |
+| `systemctl --version` | read-only | systemd availability |
+| `ss -tulpn` | read-only; may require elevated visibility | port occupancy evidence |
+| `id` / `groups` / `pwd` | read-only | permission and working-directory evidence |
+| `find /opt /srv -maxdepth 2 -type d -name '*tiny*'` | read-only if authorized | candidate app directory discovery |
+| `ls -la <approved-app-dir>` | read-only if path approved | checkout/static/data path inventory |
+
+Forbidden in #276 and still Human-gated later:
+
+```text
+ssh to the VPS without explicit Human authorization
+package installation or runtime upgrade
+sudo mutation commands
+systemctl start/stop/restart/enable/disable
+nginx/caddy config writes or reloads
+DNS or TLS certificate changes
+production secret generation or file writes
+private SQLite read, copy, migration, restore, or mutation
+long-running service start
+firewall mutation
+```
+
+Deployment verification matrix for child issues:
+
+| Issue | Verification evidence expected |
+| --- | --- |
+| #277 auth/origin/CORS/secret hardening | production env fail-closed tests, cookie flag tests, exact-origin CORS tests, local-dev non-regression |
+| #278 VPS install/systemd runbook | read-only inventory record, install plan, service unit template review, no live mutation without Human gate |
+| #279 frontend/reverse proxy routing | frontend build output check, API base path check, `/api/health` route, `/audio/` static route, fallback behavior |
+| #280 SQLite backup/restore dry-run | temp DB backup/restore round trip, owner/user data preserved, source content restorable, no private DB mutation |
+| #281 smoke/rollback checklist | local or authorized staging smoke: login, settings, Today, Progress, audio, health, restart, rollback note |
+| #282 readiness/human deployment gate | all child evidence linked, unresolved risks listed, explicit Human deployment decision contract |
+
 ## M14：Account Management and Admin UX
 
 Goal: preserve broader account and admin UX ideas as a deferred post-deploy


### PR DESCRIPTION
## Scope completed
- Added the #276 deployment target/runtime config contract to `docs/06-epic-roadmap.md`.
- Defined personal-VPS assumptions without binding business logic to a provider.
- Added Human input checklist, runtime config variable inventory, local-dev versus production behavior, fail-closed production requirements, safe repo automation versus Human-gated host actions, optional read-only VPS inventory plan, forbidden command/action list, and #277-#282 verification matrix.
- Added focused contract tests in `backend/tests/test_m14_deployment_contract.py`.

## Verification
- `uv run --project backend pytest backend/tests/test_m14_deployment_contract.py -q` -> 30 passed
- `uv run --project backend ruff check backend/tests/test_m14_deployment_contract.py` -> passed
- `git diff --check` -> passed
- `tools/agents/agent-audit` -> passed after GitHub TLS retries, no workflow drift findings

## Boundaries honored
- No real VPS access, SSH probing, DNS/TLS changes, production secret generation, systemd/Nginx mutation, private SQLite access, data migration, deployment rollout, account/admin UX expansion, final main merge, or #27/#276/#212 closure.
- Did not implement #277-#282.

## Residual risks
- Runtime variable names are a proposed contract for later implementation and still need Reviewer/Architect acceptance before #277-#282 hardening work.
- Optional VPS probe commands are documented only; actual SSH/VPS probing still requires separate Human authorization.

Linked issue: #276