### PR TITLE
[#280] Add temporary SQLite backup restore dry run

### DIFF
--- a/backend/scripts/backup_restore_dry_run.py
+++ b/backend/scripts/backup_restore_dry_run.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Create and verify a temporary-only SQLite backup/restore dry run.
+
+Every path must be below the operating system temporary directory. This tool is
+deliberately unsuitable for production databases and never restores in place.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sqlite3
+import tempfile
+from pathlib import Path
+from typing import Any, Iterable, Optional, Union
+
+REQUIRED_TABLES = (
+    "users",
+    "auth_sessions",
+    "words",
+    "phonemes",
+    "settings",
+    "daily_sessions",
+    "session_items",
+    "attempts",
+    "phoneme_stats",
+)
+
+
+class DryRunPathError(ValueError):
+    """Raised when a path could escape the temporary-only dry-run boundary."""
+
+
+class BackupVerificationError(RuntimeError):
+    """Raised when SQLite integrity or runtime-data verification fails."""
+
+
+def _temp_root() -> Path:
+    return Path(tempfile.gettempdir()).resolve()
+
+
+def _resolved_temp_path(path: Union[str, Path], *, label: str) -> Path:
+    resolved = Path(path).expanduser().resolve()
+    try:
+        resolved.relative_to(_temp_root())
+    except ValueError as exc:
+        raise DryRunPathError(f"{label} must be under the system temporary directory") from exc
+    return resolved
+
+
+def _require_source(path: Union[str, Path]) -> Path:
+    source = _resolved_temp_path(path, label="source database")
+    if not source.is_file():
+        raise DryRunPathError("source database must be an existing temporary SQLite file")
+    return source
+
+
+def _require_new_target(path: Union[str, Path], *, label: str) -> Path:
+    target = _resolved_temp_path(path, label=label)
+    if not target.parent.is_dir():
+        raise DryRunPathError(f"{label} parent directory must already exist")
+    if target.exists():
+        raise DryRunPathError(f"{label} must not already exist")
+    return target
+
+
+def _readonly_connection(path: Path) -> sqlite3.Connection:
+    return sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+
+
+def _table_names(conn: sqlite3.Connection) -> set[str]:
+    return {
+        row[0]
+        for row in conn.execute(
+            "SELECT name FROM sqlite_master "
+            "WHERE type = 'table' AND name NOT LIKE 'sqlite_%'"
+        )
+    }
+
+
+def _table_fingerprint(conn: sqlite3.Connection, table: str) -> str:
+    digest = hashlib.sha256()
+    for row in conn.execute(f'SELECT * FROM "{table}" ORDER BY rowid'):
+        digest.update(repr(tuple(row)).encode("utf-8"))
+        digest.update(b"\n")
+    return digest.hexdigest()
+
+
+def _schema_fingerprint(conn: sqlite3.Connection) -> str:
+    digest = hashlib.sha256()
+    for name, sql in conn.execute(
+        "SELECT name, sql FROM sqlite_master "
+        "WHERE type = 'table' AND name NOT LIKE 'sqlite_%' ORDER BY name"
+    ):
+        digest.update(name.encode("utf-8"))
+        digest.update(b"\n")
+        digest.update((sql or "").encode("utf-8"))
+        digest.update(b"\n")
+    return digest.hexdigest()
+
+
+def snapshot_database(path: Union[str, Path]) -> dict[str, Any]:
+    """Return integrity and non-secret comparison data for a temporary database."""
+    database = _resolved_temp_path(path, label="database")
+    conn = _readonly_connection(database)
+    try:
+        quick_check = [row[0] for row in conn.execute("PRAGMA quick_check")]
+        if quick_check != ["ok"]:
+            raise BackupVerificationError("SQLite quick_check failed")
+
+        missing_tables = set(REQUIRED_TABLES) - _table_names(conn)
+        if missing_tables:
+            missing = ", ".join(sorted(missing_tables))
+            raise BackupVerificationError(f"required tables are missing: {missing}")
+
+        tables = {
+            table: {
+                "count": conn.execute(f'SELECT COUNT(*) FROM "{table}"').fetchone()[0],
+                "fingerprint": _table_fingerprint(conn, table),
+            }
+            for table in REQUIRED_TABLES
+        }
+        schema_fingerprint = _schema_fingerprint(conn)
+    finally:
+        conn.close()
+
+    return {
+        "quick_check": quick_check,
+        "schema_fingerprint": schema_fingerprint,
+        "tables": tables,
+    }
+
+
+def _copy_database(source: Path, target: Path) -> None:
+    source_conn = _readonly_connection(source)
+    target_conn = sqlite3.connect(target)
+    try:
+        source_conn.backup(target_conn)
+    finally:
+        target_conn.close()
+        source_conn.close()
+
+
+def run_backup_restore_dry_run(
+    source_path: Union[str, Path],
+    backup_path: Union[str, Path],
+    restore_path: Union[str, Path],
+) -> dict[str, Any]:
+    """Copy a temporary SQLite fixture to backup and separate restore targets."""
+    source = _require_source(source_path)
+    backup = _require_new_target(backup_path, label="backup artifact")
+    restore = _require_new_target(restore_path, label="restore target")
+
+    if len({source, backup, restore}) != 3:
+        raise DryRunPathError("source, backup artifact, and restore target must differ")
+
+    source_snapshot = snapshot_database(source)
+    _copy_database(source, backup)
+    backup_snapshot = snapshot_database(backup)
+    _copy_database(backup, restore)
+    restore_snapshot = snapshot_database(restore)
+
+    if source_snapshot != backup_snapshot or source_snapshot != restore_snapshot:
+        raise BackupVerificationError("backup or restore snapshot differs from source")
+
+    return {
+        "temporary_only": True,
+        "source": str(source),
+        "backup": str(backup),
+        "restore": str(restore),
+        "verification": source_snapshot,
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source", required=True, help="Existing temporary SQLite fixture")
+    parser.add_argument("--backup", required=True, help="New temporary backup artifact")
+    parser.add_argument("--restore", required=True, help="New temporary restored SQLite file")
+    return parser
+
+
+def main(argv: Optional[Iterable[str]] = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        report = run_backup_restore_dry_run(args.source, args.backup, args.restore)
+    except (DryRunPathError, BackupVerificationError) as exc:
+        print(f"dry-run failed: {exc}")
+        return 2
+
+    print(json.dumps(report, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/backend/tests/test_backup_restore_dry_run.py
+++ b/backend/tests/test_backup_restore_dry_run.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from app.db import get_connection
+from app.services.db_schema import init_db
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from backup_restore_dry_run import (  # noqa: E402
+    DryRunPathError,
+    run_backup_restore_dry_run,
+)
+
+
+def _fixture_database(path: Path) -> None:
+    conn = get_connection(str(path))
+    try:
+        init_db(conn)
+        conn.execute(
+            "INSERT INTO users VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (
+                "fixture-user",
+                "fixture-owner",
+                "fixture-password-hash",
+                1,
+                1,
+                "created",
+                "updated",
+            ),
+        )
+        conn.execute(
+            "INSERT INTO auth_sessions VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (
+                "fixture-session",
+                "fixture-user",
+                "fixture-token-hash",
+                "created",
+                "seen",
+                "expires",
+                None,
+            ),
+        )
+        conn.execute(
+            "INSERT INTO words VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                "ship",
+                "ship",
+                "entry",
+                "/ʃɪp/",
+                None,
+                '["/ʃ/"]',
+                None,
+                "船",
+                "/audio/us/ship.mp3",
+                None,
+                "[]",
+                None,
+                "core_selected",
+            ),
+        )
+        conn.execute(
+            "INSERT INTO phonemes VALUES (?, ?, ?, ?, ?, ?, ?)",
+            ("/ʃ/", "/ʃ/", "both", "consonant", 1, "ship", "卷舌"),
+        )
+        conn.execute(
+            "INSERT INTO settings VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                "fixture-user",
+                "US",
+                1,
+                1,
+                0,
+                "ipa_first",
+                "normal",
+                "entry",
+                "zh-CN",
+                '["/ʃ/"]',
+                "updated",
+            ),
+        )
+        conn.execute(
+            "INSERT INTO daily_sessions VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                "fixture-group",
+                "fixture-user",
+                "2026-07-14",
+                "US",
+                "completed",
+                "created",
+                "completed",
+                1,
+                "normal",
+                "entry",
+                "[]",
+                "normal_next",
+                None,
+                "[]",
+            ),
+        )
+        conn.execute(
+            "INSERT INTO session_items VALUES (?, ?, ?, ?, ?, ?, ?)",
+            ("fixture-item", "fixture-group", "ship", 0, '["/ʃ/"]', "choose_ipa", "completed"),
+        )
+        conn.execute(
+            "INSERT INTO attempts VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                "fixture-attempt",
+                "fixture-user",
+                "fixture-item",
+                "ship",
+                "US",
+                "choose_ipa",
+                "/ʃ/",
+                "/ʃɪp/",
+                "/ʃɪp/",
+                1,
+                "created",
+            ),
+        )
+        conn.execute(
+            "INSERT INTO phoneme_stats VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            ("fixture-user", "US", "/ʃ/", 1, 1, "created", None, "learning"),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def test_temp_backup_restore_round_trip_preserves_runtime_and_shared_data(tmp_path: Path) -> None:
+    source = tmp_path / "source.sqlite"
+    _fixture_database(source)
+
+    report = run_backup_restore_dry_run(
+        source,
+        tmp_path / "backup.sqlite",
+        tmp_path / "restored.sqlite",
+    )
+
+    assert report["temporary_only"] is True
+    assert report["verification"]["quick_check"] == ["ok"]
+    assert report["verification"]["schema_fingerprint"]
+    assert report["verification"]["tables"]["users"]["count"] == 1
+    assert report["verification"]["tables"]["auth_sessions"]["count"] == 1
+    assert report["verification"]["tables"]["settings"]["count"] == 1
+    assert report["verification"]["tables"]["daily_sessions"]["count"] == 1
+    assert report["verification"]["tables"]["session_items"]["count"] == 1
+    assert report["verification"]["tables"]["attempts"]["count"] == 1
+    assert report["verification"]["tables"]["phoneme_stats"]["count"] == 1
+    assert report["verification"]["tables"]["words"]["count"] == 1
+    assert report["verification"]["tables"]["phonemes"]["count"] == 1
+
+
+def test_dry_run_rejects_repo_database_path_before_reading_it(tmp_path: Path) -> None:
+    repo_database = Path(__file__).resolve().parents[1] / "tiny_ipa.sqlite"
+
+    with pytest.raises(DryRunPathError, match="system temporary directory"):
+        run_backup_restore_dry_run(
+            repo_database,
+            tmp_path / "backup.sqlite",
+            tmp_path / "restored.sqlite",
+        )
+
+
+def test_dry_run_rejects_existing_restore_target(tmp_path: Path) -> None:
+    source = tmp_path / "source.sqlite"
+    restore = tmp_path / "restored.sqlite"
+    _fixture_database(source)
+    restore.touch()
+
+    with pytest.raises(DryRunPathError, match="restore target must not already exist"):
+        run_backup_restore_dry_run(source, tmp_path / "backup.sqlite", restore)
+
+
+def test_cli_runs_a_temporary_only_round_trip(tmp_path: Path) -> None:
+    source = tmp_path / "source.sqlite"
+    _fixture_database(source)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPTS / "backup_restore_dry_run.py"),
+            "--source",
+            str(source),
+            "--backup",
+            str(tmp_path / "backup.sqlite"),
+            "--restore",
+            str(tmp_path / "restored.sqlite"),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout)["temporary_only"] is True

--- a/backend/tests/test_m14_backup_restore_contract.py
+++ b/backend/tests/test_m14_backup_restore_contract.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+
+DOC = Path(__file__).resolve().parents[2] / "docs" / "development.md"
+
+
+def _runbook_text() -> str:
+    document = DOC.read_text(encoding="utf-8")
+    start = document.index("## M14 SQLite backup and restore dry-run")
+    return " ".join(document[start:].split())
+
+
+def test_m14_backup_restore_runbook_fails_closed_on_data_boundaries() -> None:
+    runbook = _runbook_text()
+
+    for phrase in (
+        "not a production backup command",
+        "operating system temporary directory",
+        "rejects repository and production paths",
+        "separate new restore target",
+        "PRAGMA quick_check",
+        "It never prints user rows, password hashes, session token hashes, or secrets.",
+        "Do not add overwrite, owner-claim apply, cron, systemd, or remote-copy behavior",
+        "#281 owns the all-system smoke/rollback checklist",
+    ):
+        assert phrase in runbook

--- a/docs/development.md
+++ b/docs/development.md
@@ -555,3 +555,42 @@ Later Human-gated host commands may include `nginx -t`, a loopback
 the owner approves VPS access. Do not run Nginx writes/reloads, copy the build,
 write an environment file, or change DNS/TLS under #279. #280 owns
 backup/restore and #281 owns the final deployment smoke/rollback checklist.
+
+## M14 SQLite backup and restore dry-run
+
+This #280 tool proves a backup/restore round trip with disposable fixture data.
+It is not a production backup command and does not authorize reading, copying,
+or restoring a private database. All three paths must be under the operating
+system temporary directory: the existing source fixture, a new backup artifact,
+and a separate new restore target. The tool rejects repository and production
+paths, existing output files, missing required tables, and any in-place restore.
+
+The artifact is a SQLite database copy created with the SQLite backup API. The
+tool runs `PRAGMA quick_check` and compares schema plus non-secret per-table
+counts and fingerprints across source, backup artifact, and restore target. It verifies
+shared `words`/`phonemes` plus `users`, `auth_sessions`, `settings`,
+`daily_sessions`, `session_items`, `attempts`, and `phoneme_stats`. It never
+prints user rows, password hashes, session token hashes, or secrets.
+
+The automated dry-run creates its own temporary fixture and is the reproducible
+local proof:
+
+```bash
+uv run --project backend pytest backend/tests/test_backup_restore_dry_run.py -q
+```
+
+For an explicit disposable fixture created by a test or local experiment, run:
+
+```bash
+uv run --project backend python backend/scripts/backup_restore_dry_run.py \
+  --source <temp-dir>/source.sqlite \
+  --backup <temp-dir>/backup.sqlite \
+  --restore <temp-dir>/restored.sqlite
+```
+
+Keep the temporary artifact and restored database only until the result has
+been reviewed, then remove that temporary directory using the local operating
+system cleanup procedure. Do not add overwrite, owner-claim apply, cron,
+systemd, or remote-copy behavior to this dry-run tool. Production retention,
+off-host copies, restore authorization, and rollback execution remain
+Human-gated; #281 owns the all-system smoke/rollback checklist.


### PR DESCRIPTION
## Scope completed
- Add a temporary-only SQLite backup/restore dry-run CLI using SQLite backup API.
- Reject non-temporary source paths, existing outputs, missing required tables, and in-place restore.
- Verify SQLite quick_check, schema fingerprint, and table counts/fingerprints for shared content plus user/auth/session/settings/practice/attempt/progress runtime tables.
- Document reproducible local verification and Human-gated production boundaries.

## Verification
- Focused backup/restore, M14 contract, and CLI subprocess tests: passed.
- Full backend suite: 421 passed.
- Ruff for touched files: passed.
- git diff --check: passed.
- tools/agents/agent-audit: clean.

## Residual risks
- This is a temporary-fixture proof only. It does not authorize or exercise production artifact retention, off-host copies, real private DB reads, or a production restore.
- #281 retains the overall smoke/rollback workflow.